### PR TITLE
fix: remove Git LFS dependency from CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
       - uses: astral-sh/setup-uv@v5
       - run: uv sync
         working-directory: server
@@ -35,8 +33,6 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,10 @@ RUN uv sync --no-dev --frozen --no-install-project
 # spaCyモデル（英語ベース）を事前ダウンロード
 RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 
-# 日本語NERモデル（CNN/tok2vec）をコピー＆インストール
-COPY packages/models/ja_ner_ja-0.2.0 packages/models/ja_ner_ja-0.2.0
-RUN uv pip install packages/models/ja_ner_ja-0.2.0
-
-# 英語NERモデル（CNN/tok2vec）をコピー＆インストール
-COPY packages/models/en_ner_en-0.1.0 packages/models/en_ner_en-0.1.0
-RUN uv pip install packages/models/en_ner_en-0.1.0
+# NERモデルをGitHub Releasesからインストール（LFS不要）
+RUN uv pip install \
+    https://github.com/plenoai/pleno-anonymize/releases/download/v0.1.0/ja_ner_ja-0.2.0-py3-none-any.whl \
+    https://github.com/plenoai/pleno-anonymize/releases/download/v0.1.0/en_ner_en-0.1.0.tar.gz
 
 # アプリケーションコードをコピー
 COPY server/src/ src/


### PR DESCRIPTION
## Summary
- CI/CD was failing because the repository exceeded its Git LFS bandwidth budget
- Removed `lfs: true` from `test` and `deploy` checkout steps in `.github/workflows/ci.yml`
- Modified `Dockerfile` to install NER models directly from GitHub Release assets (`v0.1.0`) instead of `COPY` from LFS-tracked local paths
- Test job works without LFS because adversarial NER tests already have `skipif` guards for missing models
- Model wheel/tarball assets uploaded to the `v0.1.0` release: `ja_ner_ja-0.2.0-py3-none-any.whl`, `en_ner_en-0.1.0.tar.gz`

## Root cause
`error: failed to fetch some objects from LFS` — "This repository exceeded its LFS budget."

## Test plan
- [ ] `check` job passes (ruff lint/format — no LFS dependency)
- [ ] `test` job passes (pytest with model-absent skip guards)
- [ ] `deploy` job passes on main merge (Dockerfile downloads models from GitHub Releases)