### PR TITLE
fix(deploy): allow packages/training/ in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,15 @@ docs
 flake.nix
 flake.lock
 .gitmodules
-packages/training
+# packages/training is needed (recognizers_ja.py + workspace pyproject), but
+# heavy data / outputs / artifacts are excluded to keep image small.
+packages/training/data
+packages/training/output
+packages/training/experiments
+packages/training/notebooks
+packages/training/configs
+packages/training/docs
+packages/training/CHANGELOG.md
+packages/training/__pycache__
+packages/training/**/__pycache__
 packages/models/ja_ner_ja-0.2.0/ja_ner_ja/__pycache__


### PR DESCRIPTION
Fixes PR #34's Dockerfile workspace-aware rewrite — `.dockerignore` still excluded `packages/training` causing post-merge deploy on main to fail.

Build error:
```
ERROR: failed to compute cache key: "/packages/training": not found
```

This change allows `packages/training/{src,pyproject.toml}` while keeping data/output/experiments/notebooks/configs/docs excluded to maintain image size. Recognizers_ja.py + workspace pyproject are the only runtime deps from training.

Detected after PR #36 merge when CI deploy fired for the first time post-U1.