### PR TITLE
fix(server): load NER models by package name (E050 regression)

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -8,7 +8,6 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 from functools import lru_cache, partial
-from pathlib import Path
 from typing import List, Optional, Dict, Any, Tuple
 import httpx
 from fastapi import FastAPI, Request, Response
@@ -61,17 +60,12 @@ def _init_presidio():
             super().__init__()
             self.nlp = models
 
-    app_dir = Path(__file__).parent
-    models_dir = app_dir.parent / "packages" / "models"
+    # Models are installed as Python packages from HF wheels (see Dockerfile);
+    # resolve via spaCy entry_point lookup, not filesystem path.
+    _nlp_ja = spacy.load("ja_ner_ja")
 
-    # Load Japanese NER model
-    ja_model_path = models_dir / "ja_ner_ja-0.2.0" / "ja_ner_ja" / "ja_ner_ja-0.2.0"
-    _nlp_ja = spacy.load(str(ja_model_path))
-
-    # Load English NER model (CNN/tok2vec version for low-resource deployment)
-    en_model_path = models_dir / "en_ner_en-0.1.0" / "en_ner_en" / "en_ner_en-0.1.0"
     try:
-        _nlp_en = spacy.load(str(en_model_path))
+        _nlp_en = spacy.load("en_ner_en")
     except OSError:
         _nlp_en = None
 

--- a/server/tests/test_model_loading.py
+++ b/server/tests/test_model_loading.py
@@ -1,0 +1,38 @@
+"""Regression guard: server must load NER models via spaCy package-name lookup.
+
+Production playground broke after PR #34 because `_init_presidio` resolved models
+through a filesystem path (`packages/models/...`) that no longer existed once the
+Dockerfile switched from `COPY packages/models/` to HF wheel install (PR #23,
+4 weeks earlier). The bug stayed latent until cache eviction.
+"""
+
+import pytest
+
+
+def test_init_presidio_loads_real_ja_model():
+    """`_init_presidio()` must succeed when ja_ner_ja wheel is installed."""
+    pytest.importorskip("ja_ner_ja")
+
+    import server.src.app as app
+
+    # Reset module-level singletons so this test sees a clean init.
+    app._nlp_ja = None
+    app._nlp_en = None
+    app._analyzer = None
+    app._anonymizer = None
+
+    app._init_presidio()
+
+    assert app._analyzer is not None
+    assert app._nlp_ja is not None
+
+
+def test_app_does_not_resolve_models_by_filesystem_path():
+    """Guard against the regressed pattern coming back via copy-paste."""
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parent.parent / "src" / "app.py").read_text()
+    assert "packages/models" not in src, (
+        "_init_presidio must not look up models via a filesystem path; "
+        "use spacy.load(<package_name>) instead."
+    )


### PR DESCRIPTION
## Summary

Production playground returned 500 on POST /api/analyze; `/ready` exposed the root cause:

```json
{"status":"not_ready","error":"[E050] Can't find model '/workspace/packages/models/ja_ner_ja-0.2.0/ja_ner_ja/ja_ner_ja-0.2.0'. It doesn't seem to be a Python package or a valid path to a data dir..."}
```

## Root Cause

- **PR #23** (4 weeks ago) switched the Dockerfile from `COPY packages/models/` + local-path install to `uv pip install <HF wheel URL>`
- `server/src/app.py` kept resolving via `app_dir.parent / 'packages' / 'models'` — a path that no longer exists in the image
- Bug stayed latent because cached image layers preserved the old `packages/models/` tree
- **PR #34** (workspace-aware Dockerfile) + **PR #37** (.dockerignore fix) invalidated the cache → playground broke

## Fix

`spacy.load("ja_ner_ja")` / `spacy.load("en_ner_en")` resolve via the wheel's `[spacy_models]` entry_point — the canonical install-then-load path.

## Regression Guards (`server/tests/test_model_loading.py`)

1. **`test_init_presidio_loads_real_ja_model`** — opt-in smoke test that runs `_init_presidio()` when the ja_ner_ja wheel is installed (skipped in default CI; meant to run in deploy-equivalent envs)
2. **`test_app_does_not_resolve_models_by_filesystem_path`** — string check preventing `packages/models` from creeping back via copy-paste

## Test

```
138 passed, 54 skipped in 4.50s
```