### PR TITLE
fix(deploy): install model wheels AFTER 2nd uv sync (root cause of 4-week regression)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,19 @@ COPY server/pyproject.toml server/pyproject.toml
 # `--extra bench` を渡さない限り install されない (default exclude)。
 RUN uv sync --frozen --no-dev --no-install-project
 
-# spaCyモデル（英語ベース）を事前ダウンロード
-RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
-
-# NERモデルをHugging Faceからインストール
-RUN uv pip install \
-    https://huggingface.co/0xhikae/ja-ner-ja/resolve/main/ja_ner_ja-0.2.0-py3-none-any.whl \
-    https://huggingface.co/0xhikae/en-ner-en/resolve/main/en_ner_en-0.1.0.tar.gz
-
 # アプリケーションコードをコピー（workspace member 単位）
 COPY packages/training/ packages/training/
 COPY server/ server/
 RUN uv sync --frozen --no-dev
+
+# spaCy / NER モデル wheel install は最後の uv sync の **後ろ** に置く必要がある。
+# 過去に sync の間に挟んでいた時期があり、`uv sync --frozen` が lockfile に存在しない
+# 既インストール wheel を prune して production を壊した (build-time smoke で発覚)。
+# 以降の RUN では sync をかけないこと。
+RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+RUN uv pip install \
+    https://huggingface.co/0xhikae/ja-ner-ja/resolve/main/ja_ner_ja-0.2.0-py3-none-any.whl \
+    https://huggingface.co/0xhikae/en-ner-en/resolve/main/en_ner_en-0.1.0.tar.gz
 
 # Build-time smoke test: catches model-load failures at image build (not runtime).
 # Background: PR #40 fixed a 4-week-latent regression where the runtime warmup


### PR DESCRIPTION
## Summary

PR #43's build-time smoke test caught the **actual** 4-week-latent regression in 7 seconds:

```
#20 RUN uv sync --frozen --no-dev
#20 Uninstalled 4 packages in 16ms
   - en-core-web-sm==3.8.0
   - en-ner-en==0.1.0
   - ja-ner-ja==0.2.0
#21 RUN uv run python -c "... spacy.load('ja_ner_ja') ..."
#21 OSError: [E050] Can't find model 'ja_ner_ja'
```

## Root Cause

PR #34's Dockerfile rewrite changed single-sync to two-sync (workspace deps then workspace project) and put the model wheel installs BETWEEN the two syncs. `uv sync --frozen --no-dev` reconciles the venv to the lockfile and removes any 'extraneous' packages — which from uv's view is exactly what the model wheels are (they were ad-hoc `uv pip install`d, not in `uv.lock`).

This was the actual regression that broke the playground — **not** the `spacy.load()` path-vs-package issue PR #40 fixed. PR #40's fix is still correct; it just resolves to `'ja_ner_ja'` which now needs to actually be in the venv.

## Fix

Move both `uv pip install` lines AFTER the second `uv sync`. Added explicit comment forbidding any future `uv sync` after the wheel installs.

## Diagnostic chain

| PR | What it did |
|---|---|
| #40 | `spacy.load(<package>)` instead of `spacy.load(<path>)` |
| #42 | post-deploy `/ready` healthcheck (catches runtime breaks) |
| #43 | build-time `spacy.load()` smoke test (caught THIS regression) |
| **#44** | **actual root-cause fix to make the smoke pass** |
