### PR TITLE
fix(deploy): keep VM always running + curl --max-time covers cold-start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,29 +47,29 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       # Catches deploys where the image starts but cannot load NER models.
-      # Background: PR #40 fixed a 4-week-latent regression where `/health`
-      # returned 200 (process running) but `/api/analyze` 500'd because models
-      # could not be resolved. `/ready` exercises the model-load path.
+      # Background: PR #40 fixed a regression where `/health` returned 200
+      # (process running) but `/api/analyze` 500'd because models could not
+      # be resolved. `/ready` exercises the model-load path.
       #
-      # Retry budget covers fly.io rolling-deploy + auto-stop wake-up + first
-      # request synchronous model init. 30 × 10s = 300s is paired with the
-      # fly.toml grace_period=180s so a slow but eventually-healthy machine
-      # is not flagged as a deploy failure.
+      # Per-attempt --max-time is generous (60s) so a single curl can ride out
+      # the worst-case cold-start; outer loop adds margin in case fly.io
+      # routing settles slowly. Total budget ~6 minutes.
       - name: Verify /ready after deploy
         run: |
           set -u
           ok=0
-          for i in $(seq 1 30); do
-            body=$(curl -sS -m 10 -H "Accept: application/json" https://pleno-anonymize.fly.dev/ready || echo "")
+          for i in $(seq 1 12); do
+            body=$(curl -sS --max-time 60 --retry 3 --retry-all-errors --retry-delay 5 \
+              -H "Accept: application/json" https://pleno-anonymize.fly.dev/ready || echo "")
             echo "attempt $i: $body"
             if echo "$body" | grep -q '"status": *"ready"'; then
               ok=1
               break
             fi
-            sleep 10
+            sleep 15
           done
           if [ "$ok" != "1" ]; then
-            echo "::error::/ready did not return status=ready within 300s after deploy"
+            echo "::error::/ready did not return status=ready within ~6m after deploy"
             exit 1
           fi
           echo "::notice::/ready is healthy"

--- a/fly.toml
+++ b/fly.toml
@@ -6,8 +6,14 @@ primary_region = 'nrt'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
+  # PR #45: keep the single VM always running.
+  # auto_stop_machines='stop' + min_machines_running=1 was deceptive — fly was
+  # stopping the sole machine after deploy and relying on auto-start on first
+  # request. Cold-start (model load) exceeded the post-deploy CI curl timeout,
+  # making the deploy look broken. Setting auto_stop=off is the right config
+  # for a low-traffic always-on app like ours.
+  auto_stop_machines = 'off'
+  auto_start_machines = false
   min_machines_running = 1
 
   [http_service.concurrency]
@@ -18,11 +24,9 @@ primary_region = 'nrt'
   [[http_service.checks]]
     interval = "30s"
     timeout = "5s"
-    # Cold-start budget: model load (spaCy ja_ner_ja + en_core_web_sm + Presidio
-    # AnalyzerEngine + recognizers) can take ~30-60s on a 2gb shared-cpu VM.
-    # 60s grace was tight; 180s leaves headroom for first-request synchronous
-    # init when auto_stop_machines woke a stopped machine.
-    grace_period = "180s"
+    # fly silently caps grace_period to 60s (warns at deploy time); keep it at
+    # the documented max. Cold-start budget moves to the CI curl-side retry.
+    grace_period = "60s"
     method = "GET"
     path = "/health"
 


### PR DESCRIPTION
## Summary

PR #44's build smoke passed (wheel install fix verified) and `flyctl deploy` succeeded, but the post-deploy `/ready` healthcheck still failed **all 30 attempts** with TCP connect timeout.

## Root cause from fly's deploy log

```
> Machine 185173db175798 reached stopped state
✔ Machine 185173db175798 is now in a good state
WARN Service HTTP check has a grace period greater than 1 minute (3m0s);
     this will be lowered to 1 minute
```

The single VM was stopped post-deploy because of `auto_stop_machines='stop'`. fly's auto-start was supposed to wake it on first request, but **cold-start (spaCy model load) exceeded the curl `--max-time` of 10s**, so each retry timed out before the wake-up could complete.

Compounding: fly silently capped `grace_period` to 60s — the 180s I set in PR #43 was wishful.

## Three fixes

1. **fly.toml**: `auto_stop_machines='off'` + `auto_start_machines=false`. Keep the single VM always running. This is the right config for our low-traffic always-on app; auto-stop introduced cold-start surface for no benefit.

2. **fly.toml**: `grace_period` back to 60s (the documented max). Cold-start budget moves to the CI curl side.

3. **ci.yml**: `curl --max-time 60 --retry 3 --retry-all-errors --retry-delay 5` so a single attempt can ride out cold-start; loop 12× / 15s for routing settle. Total ~6 minutes.

## Diagnostic chain (final)

| PR | What it caught / did |
|---|---|
| #40 | path → package name fix |
| #42 | post-deploy /ready healthcheck (catches runtime-only breaks) |
| #43 | build-time spacy.load smoke (caught venv pruning) |
| #44 | wheel install reorder (smoke passes) |
| **#45** | **fly cold-start surface eliminated** |
