### PR TITLE
ci(diag): dump flyctl status/machine/logs on healthcheck failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,17 @@ jobs:
       # the worst-case cold-start; outer loop adds margin in case fly.io
       # routing settles slowly. Total budget ~6 minutes.
       - name: Verify /ready after deploy
+        id: ready_check
         run: |
           set -u
           ok=0
           for i in $(seq 1 12); do
-            body=$(curl -sS --max-time 60 --retry 3 --retry-all-errors --retry-delay 5 \
-              -H "Accept: application/json" https://pleno-anonymize.fly.dev/ready || echo "")
-            echo "attempt $i: $body"
+            response=$(curl -sS --max-time 60 --retry 3 --retry-all-errors --retry-delay 5 \
+              -w "\n__STATUS=%{http_code} CONNECT=%{time_connect}s TOTAL=%{time_total}s" \
+              -H "Accept: application/json" https://pleno-anonymize.fly.dev/ready 2>&1 || true)
+            echo "attempt $i:"
+            echo "$response" | sed 's/^/  /'
+            body=$(echo "$response" | head -n -1)
             if echo "$body" | grep -q '"status": *"ready"'; then
               ok=1
               break
@@ -73,3 +77,21 @@ jobs:
             exit 1
           fi
           echo "::notice::/ready is healthy"
+
+      # Diagnostic: dump fly machine status + recent logs when /ready fails.
+      # Without this we are blind to whether uvicorn started, the warmup
+      # thread crashed, or the proxy is routing to a dead machine.
+      - name: Diagnose deploy on healthcheck failure
+        if: failure() && steps.ready_check.outcome == 'failure'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          echo "=== flyctl status ==="
+          flyctl status --app pleno-anonymize || true
+          echo ""
+          echo "=== flyctl machine list ==="
+          flyctl machine list --app pleno-anonymize || true
+          echo ""
+          echo "=== flyctl logs (last 300 lines) ==="
+          # --no-tail returns recent buffer then exits; cap to 300 lines.
+          timeout 30 flyctl logs --app pleno-anonymize --no-tail 2>&1 | tail -300 || true


### PR DESCRIPTION
## Why

PR #45 fixed the cold-start surface (auto_stop=off, longer curl timeout), but `/ready` still returns empty body. Local probe shows:

```
/ready -> HTTP=502 CONNECT=0.008s TOTAL=35s
/health -> curl 30s timeout (no body)
```

So fly proxy is alive (TCP connect in 8ms), but the upstream machine cannot serve even the trivial `/health` endpoint (which doesn't load NER models). The process either never started, never bound :8080, or the warmup thread crashed and the event loop is stuck.

We're flying blind without machine-level logs. This PR adds them.

## Changes

1. **Healthcheck step**: now records per-attempt HTTP status, connect time, total time. Distinguishes 'no TCP' from 'TCP but no HTTP' from '5xx body'.

2. **New `Diagnose deploy on healthcheck failure` step** (`if: failure() && steps.ready_check.outcome == 'failure'`):
   ```
   flyctl status --app pleno-anonymize
   flyctl machine list --app pleno-anonymize
   flyctl logs --app pleno-anonymize --no-tail | tail -300
   ```
   Pulls last 300 log lines from the running machine. Should reveal the actual crash reason, listen-bind issue, or warmup-thread error.

## Next

After this lands, the failing deploy run will surface actionable evidence in CI logs. Then a real fix can target the actual cause.
