### PR TITLE
docs(solutions): capture 3 learnings from production 502 incident

### DIFF
--- a/docs/solutions/2026-05-03-build-time-model-smoke-test.md
+++ b/docs/solutions/2026-05-03-build-time-model-smoke-test.md
@@ -1,0 +1,61 @@
+---
+title: Build-time spaCy model smoke test catches stale Dockerfile paths
+date: 2026-05-03
+issue: #53
+related_prs: [#23, #40, #43]
+tags: [docker, ci, observability, fail-fast, spacy]
+---
+
+# Build-time spaCy model smoke test catches stale Dockerfile paths
+
+## 何が起きたか
+
+- 4 週間前の PR #23 が Dockerfile を変更した結果、`server/src/app.py` 内の `spacy.load(<filesystem_path>)` が参照するパスが stale になっていた。
+- model load は runtime warmup の **daemon thread** で実行されており、例外が発生しても process は落ちず log のみが残った。
+- `/health` (liveness) は静的に 200 を返すため healthy と見なされ、deploy も green で通過。
+- 実トラフィックを処理する `/api/analyze` のみ 500 を返し続け、PR #40 (4 週間後) で初めて regression が発覚した。
+
+## なぜ起きたか (root cause)
+
+1. **重い初期化を background thread に逃がす設計**: warmup が daemon thread で動くため、failure が「黙って消える」。例外は logger に出るが、liveness probe は影響を受けない。
+2. **build と runtime の責務が分離されすぎている**: image build は「依存が入った」ことしか保証せず、「load できる」ことを保証しない。
+3. **Dockerfile 変更のレビュー時に runtime path との整合性が確認できない**: code レビュー単体で気付ける情報量を超える。
+
+## 検出方法 / 教訓
+
+PR #43 で `RUN python -c "import spacy; spacy.load('<path>')"` を Dockerfile に追加。
+
+- image build 中に **7 秒** で同じ failure mode を再現できる。
+- build が fail するため、broken image は registry に push されない (= production に届かない)。
+- daemon thread での silent crash と異なり、CI / build log で即座に可視化される。
+
+教訓: **production runtime で初期化する重い処理は、build 時に 1 回 dry run せよ**。
+
+## 適用ガイド (再発防止)
+
+build-time smoke test を追加すべき対象:
+
+- **model wheel の load** (spaCy, transformers, sklearn pickle 等)
+- **asset / weight の download 後の整合性チェック** (sha256, size)
+- **config validation** (pydantic settings, env var の必須項目)
+- **DB migration の dry-run** (alembic check 等、副作用なしで検証可能なもの)
+
+実装パターン:
+
+```dockerfile
+# Stage: smoke test (image build を fail-fast させる)
+RUN python -c "import spacy; nlp = spacy.load('/opt/models/ja_ner_ja'); assert nlp.pipe_names"
+```
+
+注意点:
+
+- runtime path と build-time path は **同じ string** で書く (重複は許容、整合性のほうが重要)。
+- smoke test は数秒で終わる軽量 check に絞る。training や全件推論は別ステージへ。
+- daemon thread で初期化するのを止めるわけではない。**build と runtime の二重チェック** が肝。
+
+## 関連
+
+- PR #23 — Dockerfile 変更で path stale 化
+- PR #40 — production regression の発覚
+- PR #43 — build-time smoke test 導入
+- 関連 learning: `2026-05-03-uv-sync-wheel-install-ordering.md` (同じインシデントの別 root cause)

--- a/docs/solutions/2026-05-03-metric-triad-evaluation-criteria.md
+++ b/docs/solutions/2026-05-03-metric-triad-evaluation-criteria.md
@@ -1,0 +1,70 @@
+---
+title: NER 評価基準は metric triad (corpus, metric, aggregation) で語る
+date: 2026-05-03
+issue: #55
+related_prs: []
+tags: [evaluation, ner, benchmarking, metrics, communication]
+---
+
+# NER 評価基準は metric triad (corpus, metric, aggregation) で語る
+
+## 何が起きたか
+
+社内で「F1 はいくつ？」という会話が交差した結果、3 つの異なる数字が同時に正としてやり取りされ、モデル品質の議論が噛み合わなくなった。
+
+| 指標 | corpus | metric | aggregation |
+|---|---|---|---|
+| README dev F1 | dev split (~in-domain) | strict-span F1 (spaCy Scorer) | micro |
+| v0.12.0 benchmark | adversarial 500 docs (88% negative) | strict-span F1 (spaCy Scorer) | micro |
+| S6 held-out | v0.13.0 80 docs, 3 unseen templates | matched-precision-floor recall + token-overlap F1 | per-template |
+
+3 つとも正しい計算結果。だが **「F1」という同じ名前** で呼ばれていたため、production 品質の判断軸がブレた。
+
+## なぜ起きたか (root cause)
+
+「F1」は scalar に見えて、実際は 3 つの自由度を持つ:
+
+1. **corpus**: 何を評価しているか (in-domain / adversarial / unseen template)
+2. **metric**: どう正解とみなすか (strict-span / token-overlap / precision-floor recall)
+3. **aggregation**: どう集約するか (micro / macro / per-template)
+
+corpus が違えば数字が 0.3 違う。metric が違えば 0.1 違う。aggregation が違えば順位が逆転する。**triad のうち 1 つでも省略すると比較不能になる**。
+
+## 検出方法 / 教訓
+
+- README, PR description, slack で数字を出すときは triad を **必ずセット** で書く。
+- production-realistic な **headline metric を 1 つ** だけ定める。複数あると意思決定が遅れる。
+- 推奨 headline: **v0.12.0 adversarial F1** (production の負荷分布に最も近い)
+- dev F1 は overfit 監視用、S6 は generalization 監視用の **補助指標** として位置づける。
+
+## 適用ガイド (再発防止)
+
+### 数字を共有するときの最小フォーマット
+
+```
+F1 = 0.84  (corpus: adversarial-500, metric: strict-span, aggregation: micro)
+```
+
+または triad を 1 行で:
+
+```
+adversarial-500 / strict-span / micro: F1 = 0.84
+```
+
+### README に書くべきこと
+
+- headline metric の triad を明示
+- 補助指標は別セクションに分ける
+- 数字を更新したら triad もレビューする (corpus が更新されている可能性)
+
+### モデル比較の rule
+
+- 同じ triad 内でしか比較しない
+- 異なる triad の数字を「向上した」と並べない
+- A/B 比較は **3 つすべての triad で同方向に動いたか** を確認 (1 つでも逆行したら trade-off)
+
+## 関連
+
+- README dev F1 セクション
+- v0.12.0 リリースノート (adversarial benchmark)
+- S6 held-out 評価レポート (v0.13.0)

--- a/docs/solutions/2026-05-03-uv-sync-wheel-install-ordering.md
+++ b/docs/solutions/2026-05-03-uv-sync-wheel-install-ordering.md
@@ -1,0 +1,76 @@
+---
+title: uv sync prunes wheels not in uv.lock — Dockerfile ordering matters
+date: 2026-05-03
+issue: #54
+related_prs: [#34, #44]
+tags: [docker, uv, packaging, dependency-management, fail-fast]
+---
+
+# uv sync prunes wheels not in uv.lock — Dockerfile ordering matters
+
+## 何が起きたか
+
+production の `/ready` が 503 を返す状態に。`spacy.load('ja_ner_ja')` が runtime で `E050` (model not found) を返していた。image build は **成功** しており、CI も green。
+
+## なぜ起きたか (root cause)
+
+`uv sync --frozen --no-dev` は uv.lock を venv に対する **single source of truth** として扱い、**lock に存在しない既インストール package を prune する**。
+
+PR #34 時点の Dockerfile はこの順:
+
+```dockerfile
+RUN uv sync --frozen --no-dev --no-install-project   # 1. base deps
+RUN uv pip install /tmp/ja_ner_ja-*.whl              # 2. project-local wheel
+RUN uv sync --frozen --no-dev                        # 3. project install
+                                                     #    ← ここで 2. の wheel が prune される
+```
+
+ja_ner_ja wheel は uv.lock に登録されていない (project-local wheel) ため、3 行目の `uv sync` が「lock にないので不要」と判断して削除した。結果:
+
+- `/opt/.venv/lib/python*/site-packages/ja_ner_ja/` が消える
+- import 自体は別パスから通る場合でも、spaCy の data path resolver が壊れて `E050`
+- image build は副作用なく成功 → registry に push → production で初めて顕在化
+
+## 検出方法 / 教訓
+
+- uv の **prune semantics** は「速い再現性」のために設計されている。lock に無いものは敵。
+- `uv pip install` は escape hatch だが、後段で `uv sync` を走らせるとリセットされる。
+- PR #44 修正: wheel install を **2 回目の `uv sync` の後** に移動。これで prune の対象外になる。
+
+## 適用ガイド (再発防止)
+
+優先度順:
+
+### (a) wheel を uv.lock に取り込む (推奨, 構造的解決)
+
+constraint file 経由で uv.lock に project-local wheel を登録する:
+
+```toml
+# pyproject.toml
+[tool.uv.sources]
+ja_ner_ja = { path = "./wheels/ja_ner_ja-0.13.0-py3-none-any.whl" }
+```
+
+これにより `uv sync` は wheel を「正規 dependency」として扱い、prune しない。
+
+### (b) Dockerfile に lint コメント (PR #44 で実施済)
+
+```dockerfile
+RUN uv sync --frozen --no-dev          # FINAL sync — anything after this won't be pruned
+RUN uv pip install /tmp/ja_ner_ja-*.whl  # MUST come after the final uv sync
+```
+
+### (c) CI structural check (将来)
+
+shell-level lint で「`uv pip install` の後に `uv sync` が無い」ことを assert する:
+
+```bash
+awk '/uv pip install/{seen=1} /uv sync/{if(seen){print "ERROR: uv sync after uv pip install"; exit 1}}' Dockerfile
+```
+
+## 関連
+
+- PR #34 — 問題が混入した Dockerfile
+- PR #44 — install ordering 修正
+- uv docs: `--frozen` semantics, prune behavior
+- 関連 learning: `2026-05-03-build-time-model-smoke-test.md` (同じインシデントの surfacing 機構)

--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -1,0 +1,23 @@
+# Solutions / Learning Docs
+
+production incident や PR review で得た学びを蓄積するディレクトリ。
+
+## index
+
+| date | issue | title |
+|---|---|---|
+| 2026-05-03 | #53 | [Build-time spaCy model smoke test catches stale Dockerfile paths](./2026-05-03-build-time-model-smoke-test.md) |
+| 2026-05-03 | #54 | [uv sync prunes wheels not in uv.lock — Dockerfile ordering matters](./2026-05-03-uv-sync-wheel-install-ordering.md) |
+| 2026-05-03 | #55 | [NER 評価基準は metric triad (corpus, metric, aggregation) で語る](./2026-05-03-metric-triad-evaluation-criteria.md) |
+
+## 書き方
+
+各 doc は frontmatter (title, date, issue, related_prs, tags) と以下の章立て:
+
+- 何が起きたか
+- なぜ起きたか (root cause)
+- 検出方法 / 教訓
+- 適用ガイド (再発防止)
+- 関連
+
+ファイル名: `YYYY-MM-DD-<short-slug>.md`


### PR DESCRIPTION
## Summary

production 502 incident と関連 PR review から得た 3 つの learning を `docs/solutions/` に追加します。

| issue | title |
|---|---|
| #53 | build-time spaCy model smoke test pattern (image build を 7s で fail-fast させ silent crash を防ぐ) |
| #54 | uv sync x wheel install ordering structural guard (`uv sync --frozen` が lock 外 wheel を prune する挙動への対策) |
| #55 | dev F1 vs adversarial F1 metric triad (corpus / metric / aggregation を必ずセットで語る) |

## 構成

- `docs/solutions/` (新規) — learning doc を蓄積
- `docs/solutions/README.md` — index
- 各 doc は frontmatter + 「何が起きたか / root cause / 検出 / 適用ガイド / 関連」の固定章立て

## 関連 PR

- #23 → #40 → #43 (build-time smoke test)
- #34 → #44 (uv sync ordering)

Closes #53
Closes #54
Closes #55