### PR TITLE
fix(deploy): proxy cold-start so stopped machine recovers

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,15 +6,16 @@ primary_region = 'nrt'
 [http_service]
   internal_port = 8080
   force_https = true
-  # PR #45: keep the single VM always running.
-  # auto_stop_machines='stop' + min_machines_running=1 was deceptive — fly was
-  # stopping the sole machine after deploy and relying on auto-start on first
-  # request. Cold-start (model load) exceeded the post-deploy CI curl timeout,
-  # making the deploy look broken. Setting auto_stop=off is the right config
-  # for a low-traffic always-on app like ours.
+  # auto_stop=off keeps fly from stopping the machine; auto_start=true lets
+  # the proxy cold-start it back if the machine ever lands in 'stopped' state
+  # (deploy update transient, platform action). PR #45 set auto_start=false
+  # together with auto_stop=off, which created a no-recovery trap: once the
+  # machine fell into 'stopped' the proxy refused to restart it and every
+  # request 503'd while the machine API still saw the machine as 'active'.
+  # min_machines_running is a no-op when auto_stop_machines='off' (fly only
+  # honors it for 'stop'/'suspend'), so it's removed.
   auto_stop_machines = 'off'
-  auto_start_machines = false
-  min_machines_running = 1
+  auto_start_machines = true
 
   [http_service.concurrency]
     type = "requests"


### PR DESCRIPTION
## What

Closes #47.

Set `auto_start_machines = true` and remove the no-op `min_machines_running = 1` from \`fly.toml\`.

## Root cause

CI run [25270919879](https://github.com/plenoai/pleno-anonymize/actions/runs/25270919879) diagnose step (PR #46) revealed a desync between fly proxy state and the machine itself:

- \`flyctl status\` reported machine STATE: \`stopped\`, CHECKS 0/1
- machine logs showed \`/health\` returning **200 every 30s** for the full window — uvicorn was alive
- proxy logs showed the proxy receiving requests and trying to \`Starting machine\` over and over, getting \`[PM07] failed to change machine state: machine still active, refusing to start\` from the machine API

Net effect: every external request 503'd for 35+ minutes while the app was actually running.

## Why PR #45's config was a trap

PR #45 set:
\`\`\`toml
auto_stop_machines = 'off'
auto_start_machines = false
min_machines_running = 1
\`\`\`

Two issues:

1. \`auto_start_machines = false\` means the proxy refuses to cold-start a machine that lands in \`stopped\` state (deploy update transient, platform action). With \`auto_stop = off\`, the only path to a stopped state is the deploy or fly platform — but once there, there is **no recovery path**.
2. \`min_machines_running\` only takes effect with \`auto_stop_machines = 'stop'\` or \`'suspend'\`. With \`'off'\` it is silently a no-op, so it was not actually keeping the machine running.

## Fix

\`\`\`toml
auto_stop_machines = 'off'    # fly never stops the machine on its own
auto_start_machines = true    # proxy can cold-start it if it ever stops
\`\`\`

\`min_machines_running\` removed (no-op with \`off\`).

## Verification plan

After merge → main → deploy:
1. CI \`Verify /ready after deploy\` step should pass within ~6m
2. \`curl https://anonymize.plenoai.com/ready\` → \`{"status":"ready"}\`
3. \`curl -X POST https://anonymize.plenoai.com/api/analyze -d '{"text":"田中太郎は東京に住んでいます"}' -H 'Content-Type: application/json'\` → 200 with entities

If the current production machine stays stuck in stopped, a one-shot \`flyctl machine start 185173db175798 --app pleno-anonymize\` will unblock it; with this PR merged, the trap cannot recur.