### PR TITLE
feat(recognizers): add JapaneseBankAccountRecognizer

### DIFF
--- a/packages/training/src/pleno_ner_training/recognizers_ja.py
+++ b/packages/training/src/pleno_ner_training/recognizers_ja.py
@@ -262,6 +262,94 @@ URLRecognizer = PatternRecognizer(
     context=["URL", "リンク", "サイト", "ホームページ"],
 )
 
+# --- 銀行口座 (BANK_ACCOUNT) ---
+# 形式依存 entity。NER 単独で precision=32% (v0.12.0) のため regex で形式を縛る。
+#
+# 設計:
+# - <主要日本の銀行名>銀行<支店名>(支店|本店|本店営業部|XX営業部)(普通|当座)\d{7,8}
+#   - 銀行名 alternation で precision を確保 (任意の漢字列にしない)
+#   - 支店パートは「コーポ」「センター」等を含む branch を吸収するため広めに
+# - ゆうちょ銀行記号\d{5}番号\d{7,8}
+#   - 専用形式 (記号5桁 + 番号7〜8桁)
+# - 「銀行員」「ABC 銀行」のような曖昧文脈は alternation により自然に弾かれる
+#
+# 主要 30+ 行 + メガバンク + ネット銀行 + 信託 + 主要地銀をカバー。
+# 中堅地銀でカバレッジ落ちる場合は alternation に追記する。
+_JA_BANK_NAMES = [
+    # メガバンク / 都銀
+    "三菱UFJ",
+    "三井住友",
+    "みずほ",
+    "りそな",
+    "埼玉りそな",
+    # 信託銀行
+    "三井住友信託",
+    "三菱UFJ信託",
+    # ネット銀行
+    "楽天",
+    "PayPay",
+    "ソニー",
+    "住信SBIネット",
+    "auじぶん",
+    "セブン",
+    "イオン",
+    "GMOあおぞらネット",
+    "あおぞら",
+    "ローソン",
+    # 主要地銀・第二地銀・新生
+    "横浜",
+    "千葉",
+    "静岡",
+    "常陽",
+    "京都",
+    "広島",
+    "西日本シティ",
+    "福岡",
+    "北海道",
+    "北陸",
+    "群馬",
+    "東邦",
+    "山陰合同",
+    "新生",
+    "シティバンク",
+    "信金中央",
+]
+# 長い alternative を先に置き、短い prefix 銀行 (例 "三井住友") が長い銀行名
+# (例 "三井住友信託") の前に部分マッチしないようにする。
+_JA_BANK_NAMES_SORTED = sorted(_JA_BANK_NAMES, key=len, reverse=True)
+_JA_BANK_ALT = "|".join(_JA_BANK_NAMES_SORTED)
+
+# 支店パート: 「<漢字/かな/カタカナ/数字>{0,12}支店」「本店」「本店営業部」「<漢字/かな>{1,8}営業部」
+# - 「第二営業支店」「四条支店」「梅田支店」「日本橋支店」を全て吸収
+# - 「本店」「本店営業部」も 受け入れ (entity_types 例参照)
+_JA_BANK_BRANCH_PART = (
+    r"(?:[一-龥ぁ-んァ-ヶー々〆\d]{0,12}支店|本店営業部|本店|[一-龥ぁ-んァ-ヶー]{1,8}営業部)"
+)
+
+JA_BANK_ACCOUNT_PATTERNS = [
+    Pattern(
+        name="bank_account_branch",
+        regex=(
+            r"(?:" + _JA_BANK_ALT + r")銀行"
+            + _JA_BANK_BRANCH_PART
+            + r"(?:普通|当座)\d{7,8}"
+        ),
+        score=0.85,
+    ),
+    Pattern(
+        name="bank_account_yucho",
+        regex=r"ゆうちょ銀行記号\d{5}番号\d{7,8}",
+        score=0.9,
+    ),
+]
+
+JapaneseBankAccountRecognizer = PatternRecognizer(
+    supported_entity="BANK_ACCOUNT",
+    supported_language="ja",
+    patterns=JA_BANK_ACCOUNT_PATTERNS,
+    context=["銀行", "口座", "振込", "振込先", "支店", "普通", "当座", "ゆうちょ"],
+)
+
 # 全Recognizerのリスト
 ALL_JA_RECOGNIZERS = [
     JapanesePhoneRecognizer,
@@ -276,4 +364,5 @@ ALL_JA_RECOGNIZERS = [
     ResidenceCardRecognizer,
     PostalCodeRecognizer,
     URLRecognizer,
+    JapaneseBankAccountRecognizer,
 ]

--- a/packages/training/tests/test_recognizers_ja.py
+++ b/packages/training/tests/test_recognizers_ja.py
@@ -1,0 +1,167 @@
+"""Tests for pleno_ner_training.recognizers_ja.
+
+Focus: regex correctness of pattern recognizers, with emphasis on the newly
+added BANK_ACCOUNT recognizer (issue #49) which must achieve f1 >= 0.85 on
+the v0.12.0 benchmark.
+
+Tests use raw `re.compile` against `Pattern.regex` rather than spinning up a
+full Presidio AnalyzerEngine — this keeps the suite fast and isolates the
+regex from analyzer-level overlap resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from pleno_ner_training.recognizers_ja import (
+    ALL_JA_RECOGNIZERS,
+    JA_BANK_ACCOUNT_PATTERNS,
+    JapaneseBankAccountRecognizer,
+)
+
+
+# ---------- registry sanity ----------------------------------------------
+
+
+def test_bank_account_recognizer_registered():
+    assert JapaneseBankAccountRecognizer in ALL_JA_RECOGNIZERS
+
+
+def test_bank_account_recognizer_metadata():
+    # Presidio stores `supported_entity` as a single-element `supported_entities`
+    # list. We assert via the public attribute to remain forward-compatible.
+    assert JapaneseBankAccountRecognizer.supported_entities == ["BANK_ACCOUNT"]
+    assert JapaneseBankAccountRecognizer.supported_language == "ja"
+
+
+# ---------- compiled regex (used as a single union) ----------------------
+
+
+@pytest.fixture(scope="module")
+def bank_pattern() -> re.Pattern[str]:
+    union = "|".join(p.regex for p in JA_BANK_ACCOUNT_PATTERNS)
+    return re.compile(union)
+
+
+# ---------- positive cases -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # benchmark-style: <bank>銀行<branch>支店(普通|当座)<7-8 digits>
+        ("みずほ銀行渋谷支店普通1234567", "みずほ銀行渋谷支店普通1234567"),
+        ("りそな銀行日本橋支店普通5566778", "りそな銀行日本橋支店普通5566778"),
+        ("楽天銀行第二営業支店普通4567890", "楽天銀行第二営業支店普通4567890"),
+        ("三井住友銀行品川支店普通7722114", "三井住友銀行品川支店普通7722114"),
+        ("三井住友銀行梅田支店普通8844221", "三井住友銀行梅田支店普通8844221"),
+        ("京都銀行四条支店普通6611223", "京都銀行四条支店普通6611223"),
+        # 当座 (current account) variant
+        ("みずほ銀行本店当座9876543", "みずほ銀行本店当座9876543"),
+        # 信託銀行 (must come before 三井住友 in alternation)
+        (
+            "三井住友信託銀行東京営業部普通1112223",
+            "三井住友信託銀行東京営業部普通1112223",
+        ),
+        # ネット銀行 (alphanumeric prefix)
+        (
+            "GMOあおぞらネット銀行法人営業支店普通1234567",
+            "GMOあおぞらネット銀行法人営業支店普通1234567",
+        ),
+        ("PayPay銀行ビジネス営業部普通1234567", "PayPay銀行ビジネス営業部普通1234567"),
+        # 8桁 account variant
+        ("三菱UFJ銀行新宿支店普通12345678", "三菱UFJ銀行新宿支店普通12345678"),
+        # ゆうちょ
+        ("ゆうちょ銀行記号10100番号12345671", "ゆうちょ銀行記号10100番号12345671"),
+        ("ゆうちょ銀行記号10180番号12345678", "ゆうちょ銀行記号10180番号12345678"),
+        # surrounded by Japanese context
+        (
+            "振込先はみずほ銀行渋谷支店普通1234567です。",
+            "みずほ銀行渋谷支店普通1234567",
+        ),
+    ],
+)
+def test_bank_account_positive(bank_pattern: re.Pattern[str], text: str, expected: str):
+    matches = [m.group(0) for m in bank_pattern.finditer(text)]
+    assert expected in matches, f"expected {expected!r} in {matches!r}"
+
+
+# ---------- negative cases -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # bank mention without account number
+        "三菱UFJ銀行で口座を開設しました",
+        "みずほ銀行渋谷支店",
+        # phone, not bank
+        "電話番号 03-1234-5678",
+        # bare numbers
+        "私は1234567をパスワードにした",
+        "資本金1000万円",
+        # bank-adjacent vocabulary
+        "銀行員と話した",
+        "中央銀行の総裁",
+        # unknown bank name (alternation must reject)
+        "ABC銀行渋谷支店普通1234567",
+        "テスト銀行新宿支店普通1234567",
+        # account-only without bank prefix
+        "普通1234567",
+        # ゆうちょ format with too-short 記号
+        "ゆうちょ銀行記号101番号12345671",
+        # 当座/普通 with too-short tail (6 digits)
+        "みずほ銀行渋谷支店普通123456",
+    ],
+)
+def test_bank_account_negative(bank_pattern: re.Pattern[str], text: str):
+    matches = [m.group(0) for m in bank_pattern.finditer(text)]
+    assert matches == [], f"unexpected match {matches!r} in {text!r}"
+
+
+# ---------- benchmark-driven f1 ------------------------------------------
+
+
+_BENCHMARK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "data"
+    / "benchmark"
+    / "v0.12.0"
+    / "ja"
+    / "raw.json"
+)
+
+
+@pytest.mark.skipif(not _BENCHMARK_PATH.exists(), reason="benchmark data missing")
+def test_bank_account_f1_on_v0_12_0_benchmark(bank_pattern: re.Pattern[str]):
+    """Recognizer must achieve f1 >= 0.85 on v0.12.0 BANK_ACCOUNT spans."""
+    docs = json.loads(_BENCHMARK_PATH.read_text(encoding="utf-8"))
+    tp = fp = fn = 0
+    for doc in docs:
+        text = doc["text"]
+        gold = {
+            (e["start"], e["end"])
+            for e in doc.get("entities", [])
+            if e["label"] == "BANK_ACCOUNT"
+        }
+        pred = {(m.start(), m.end()) for m in bank_pattern.finditer(text)}
+        tp += len(gold & pred)
+        fp += len(pred - gold)
+        fn += len(gold - pred)
+
+    if tp + fp + fn == 0:
+        pytest.skip("no BANK_ACCOUNT entities in benchmark")
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (
+        2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    )
+    assert f1 >= 0.85, (
+        f"BANK_ACCOUNT recognizer f1={f1:.3f} (P={precision:.3f}, "
+        f"R={recall:.3f}, tp={tp}, fp={fp}, fn={fn}) below required 0.85"
+    )


### PR DESCRIPTION
## Summary

Adds `JapaneseBankAccountRecognizer` to lift BANK_ACCOUNT precision on the v0.12.0 benchmark from NER's 32% to 100% via format-bound regex.

## Why

NER alone scores BANK_ACCOUNT precision = 32% on v0.12.0 because bare 7–8 digit account numbers collapse with other numeric entities. Bank account fields have a deterministic structure (`<bank>銀行<branch>(普通|当座)<digits>` and ゆうちょ専用形式) so a Presidio `PatternRecognizer` with constrained bank-name alternation handles them robustly without harming recall.

## Design

- `<主要日本の銀行名>銀行<支店パート>(普通|当座)\d{7,8}`
- `ゆうちょ銀行記号\d{5}番号\d{7,8}`
- 30+ banks alternation (megabanks / trust / net banks / 主要地銀) — unknown banks like `ABC銀行` are rejected.
- Branch part accepts `<kanji/kana/digits>{0,12}支店`, `本店`, `本店営業部`, and `XX営業部` to cover `第二営業支店`, `本店当座`, etc.
- 8-digit account variant supported (ゆうちょ tail in benchmark is 8 digits).
- Long alternatives sorted first so e.g. `三井住友信託` matches before `三井住友`.
- Lookbehind intentionally omitted: bank names start with kanji, and benchmark contexts (e.g. `振込先みずほ…`) frequently have kanji preceding the match — a `(?<![一-龥])` would kill recall.

## Evaluation

`packages/training/data/benchmark/v0.12.0/ja/raw.json` (24 BANK_ACCOUNT spans):

| metric | value |
|---|---|
| tp | 24 |
| fp | 0 |
| fn | 0 |
| precision | 1.000 |
| recall | 1.000 |
| **f1** | **1.000** |

Issue acceptance bar: f1 ≥ 0.85.

## Tests

`packages/training/tests/test_recognizers_ja.py` (new, 29 tests, all green):

- registration in `ALL_JA_RECOGNIZERS`
- 14 positive cases (megabanks / trust / net banks / ゆうちょ / `本店当座` / 8-digit / surrounded by Japanese context)
- 11 negative cases (bank mention without account, phone, bare digits, unknown bank, too-short fields)
- benchmark-driven `f1 >= 0.85` assertion against v0.12.0 raw.json

```
29 passed in 2.34s
```

`tests/test_compare_baselines.py::test_f0c_round_trip_on_real_recognizers_file` and `test_full_chain_integration` (which check the recognizers file is committed cleanly) both pass.

## Notes

- spaCy Scorer evaluates NER only, so this change improves the **production redaction pipeline (Presidio path) only**. Overall v0.12.0 NER F1 still requires #48.
- 中堅地銀でカバレッジが落ちた場合は `_JA_BANK_NAMES` への追記で対応可能。

Closes #49