### PR TITLE
feat(48): include zero-entity docs as hard negatives

### DIFF
--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -377,11 +377,28 @@ convert-hf-v02-tiny:
 		--output data/hf/ja-v02-tiny \
 		--tokenizer ku-nlp/deberta-v2-tiny-japanese
 
+# v02-tiny + hard negatives (entities=[] docs as all-O training).
+# Same target schema as convert-hf-v02-tiny, different output dir.
+convert-hf-v02-tiny-hardneg:
+	uv run python -m pleno_ner_training.convert_to_hf_dataset \
+		--input data/raw/ja-v02/generated.json \
+		--output data/hf/ja-v02-tiny-hardneg \
+		--tokenizer ku-nlp/deberta-v2-tiny-japanese \
+		--include-negatives
+
 train-hf-v02-tiny:
 	uv run python -m pleno_ner_training.train_hf \
 		--dataset data/hf/ja-v02-tiny \
 		--model ku-nlp/deberta-v2-tiny-japanese \
 		--output output/hf-ja-v02-tiny \
+		--fp16 --num-epochs 20 --batch-size 16 \
+		--learning-rate 3e-5 --warmup-ratio 0.15
+
+train-hf-v02-tiny-hardneg:
+	uv run python -m pleno_ner_training.train_hf \
+		--dataset data/hf/ja-v02-tiny-hardneg \
+		--model ku-nlp/deberta-v2-tiny-japanese \
+		--output output/hf-ja-v02-tiny-hardneg \
 		--fp16 --num-epochs 20 --batch-size 16 \
 		--learning-rate 3e-5 --warmup-ratio 0.15
 

--- a/packages/training/models/v02-tiny-hardneg-eval-v012.md
+++ b/packages/training/models/v02-tiny-hardneg-eval-v012.md
@@ -1,0 +1,64 @@
+# hf-ja-v02-tiny-hardneg: v0.12.0 adversarial evaluation
+
+Trained: 2026-05-03 on RunPod RTX A5000 (~13 min, 20 epochs, 10580 steps).
+Pod: `hbkmdx4jjywii6` (terminated).
+
+Base model: `ku-nlp/deberta-v2-tiny-japanese`
+Train data: `raw_ja_v02_generated.json` with `--include-negatives`
+- 8533 positive docs + 2032 hard-neg docs (entities=[] kept as all-O)
+- 400 zero-entity docs dropped by PII heuristic (label-miss noise)
+
+Hyperparams: lr=3e-5, bs=16, warmup=0.15, weight_decay=0.01, fp16
+
+## Metrics
+
+| split | precision | recall | F1 |
+| --- | --- | --- | --- |
+| dev (in-domain) | 0.892 | 0.942 | 0.917 |
+| test (in-domain) | 0.894 | 0.939 | 0.916 |
+| **adversarial v0.12.0** | 0.263 | 0.989 | **0.416** |
+
+## Comparison vs baseline (v02-tiny without hard-neg)
+
+| metric | baseline | hardneg | delta |
+| --- | --- | --- | --- |
+| dev F1 | 0.929 | 0.917 | -0.012 |
+| **adversarial F1** | 0.374 | 0.416 | **+0.042** |
+| adversarial precision | 0.231 | 0.263 | +0.032 |
+| adversarial recall | 0.979 | 0.989 | +0.010 |
+
+## Per-label on v0.12.0 (hardneg)
+
+| label | TP | FP | FN | P | R | F1 |
+| --- | --- | --- | --- | --- | --- | --- |
+| ADDRESS | 45 | 45 | 0 | 0.500 | 1.000 | 0.667 |
+| BANK_ACCOUNT | 24 | 38 | 0 | 0.387 | 1.000 | 0.558 |
+| DATE_OF_BIRTH | 23 | 32 | 0 | 0.418 | 1.000 | 0.590 |
+| ORGANIZATION | 36 | 390 | 1 | 0.085 | 0.973 | 0.156 |
+| PERSON | 58 | 15 | 1 | 0.795 | 0.983 | 0.879 |
+
+## Diagnosis
+
+Including 2032 zero-entity docs nudged precision from 0.231 → 0.263 (+14% relative)
+but did not break the over-prediction problem. ORGANIZATION still emits 390 false
+positives — the in-corpus negatives are too easy and don't contain the look-alike
+noun phrases that the adversarial benchmark uses.
+
+## Acceptance vs #48
+
+| AC | target | actual | met |
+| --- | --- | --- | --- |
+| Overall F1 | ≥ 0.70 | 0.416 | NO |
+| Per-entity precision | ≥ 0.70 | only PERSON (0.795) | NO |
+| PERSON / ADDRESS recall | ≥ 0.95 | 0.983 / 1.000 | YES |
+
+## Next iteration
+
+Real hard-negative mining (not just including in-corpus negatives):
+1. Pull a large clean Japanese corpus (Wikipedia abstracts, JNLI/JSNLI text, news)
+2. Predict with current v02-tiny on it
+3. Every emitted span becomes a labeled `O` example
+4. Re-train
+
+The adversarial v0.12.0 benchmark is built specifically with FP-pressure phrases;
+ordinary "no-PII" text in `generated.json` doesn't carry the same signal density.

--- a/packages/training/src/pleno_ner_training/convert_to_hf_dataset.py
+++ b/packages/training/src/pleno_ner_training/convert_to_hf_dataset.py
@@ -10,10 +10,27 @@ from __future__ import annotations
 
 import json
 import random
+import re
 from pathlib import Path
 
 from datasets import Dataset, DatasetDict, ClassLabel, Features, Sequence, Value
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+# Heuristic patterns to drop zero-entity docs that actually contain PII text
+# (label-miss noise). Keeping these as O-only examples would teach the model
+# to NOT tag real PII -- the opposite of what we want.
+PII_HINT_RE = re.compile(
+    "|".join(
+        [
+            r"\d{1,2}-\d{1,4}-\d{1,4}",
+            r"\d{4,}\s*-?\s*\d{4,}",
+            r"[一-龥]{2,4}\s*[一-龥]{1,3}\s*(さん|様|氏)",
+            r"(株式会社|有限会社|合同会社)",
+            r"(東京都|大阪府|京都府|北海道|沖縄県|千代田区|港区|渋谷区)",
+            r"(平成|令和|昭和)\s*[一-龥0-9]+\s*年",
+        ]
+    )
+)
 
 # BIOラベル定義: O + 5エンティティ × 2 (B/I)
 ENTITY_LABELS = ["ADDRESS", "BANK_ACCOUNT", "DATE_OF_BIRTH", "ORGANIZATION", "PERSON"]
@@ -103,22 +120,34 @@ def load_and_convert(
     input_path: Path,
     tokenizer: PreTrainedTokenizerFast,
     max_length: int = 512,
+    include_negatives: bool = False,
 ) -> list[dict]:
-    """JSONファイルを読み込み、トークン化してBIOタグ付きデータに変換する."""
+    """JSONファイルを読み込み、トークン化してBIOタグ付きデータに変換する.
+
+    include_negatives=True で、entities=[] の文書も全 O ラベルで取り込む
+    (over-prediction を抑える hard-negative 訓練). PII らしき文字列を含む
+    label-miss 候補はヒューリスティックで除外する.
+    """
     with open(input_path, encoding="utf-8") as f:
         raw_data = json.load(f)
 
     converted = []
     skipped = 0
+    negatives_kept = 0
+    negatives_dropped = 0
 
     for item in raw_data:
         text = item.get("text", "")
         entities = item.get("entities", [])
 
-        # エンティティがないドキュメントはスキップ
         if not entities:
-            skipped += 1
-            continue
+            if not include_negatives:
+                skipped += 1
+                continue
+            if not text or PII_HINT_RE.search(text):
+                negatives_dropped += 1
+                continue
+            negatives_kept += 1
 
         result = align_labels_with_tokens(text, entities, tokenizer, max_length)
         if result is not None:
@@ -126,7 +155,13 @@ def load_and_convert(
         else:
             skipped += 1
 
-    print(f"Converted: {len(converted)}, Skipped: {skipped}")
+    if include_negatives:
+        print(
+            f"Converted: {len(converted)}, Skipped: {skipped}, "
+            f"Negatives kept: {negatives_kept}, dropped (PII-suspicious): {negatives_dropped}"
+        )
+    else:
+        print(f"Converted: {len(converted)}, Skipped: {skipped}")
     return converted
 
 
@@ -201,13 +236,23 @@ def main() -> None:
     )
     parser.add_argument("--max-length", type=int, default=512)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--include-negatives",
+        action="store_true",
+        help="entities=[] doc を all-O 例として取り込み、過剰予測を抑える",
+    )
     args = parser.parse_args()
 
     print(f"Loading tokenizer: {args.tokenizer}")
     tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
 
     print(f"Loading and converting data from {args.input}...")
-    data = load_and_convert(args.input, tokenizer, args.max_length)
+    data = load_and_convert(
+        args.input,
+        tokenizer,
+        args.max_length,
+        include_negatives=args.include_negatives,
+    )
 
     if not data:
         print("ERROR: No data was converted. Check input file.")


### PR DESCRIPTION
## Why

Baseline v02-tiny adversarial v0.12.0 F1=0.374 (P=0.231) — severe over-prediction
because `convert_to_hf_dataset.py` discarded the 22% of `generated.json` documents
labeled `entities=[]`. The model never learned to NOT-tag look-alike phrases.

## What

- `--include-negatives` flag keeps zero-entity docs as all-O training examples.
- A heuristic regex drops the ~16% of zero-entity docs that contain PII text
  (label-miss noise) so we don't actively confuse the model.
- New Makefile targets `convert-hf-v02-tiny-hardneg` / `train-hf-v02-tiny-hardneg`.

## Result

| metric | baseline | hardneg | delta |
| --- | --- | --- | --- |
| adversarial F1 | 0.374 | **0.416** | +0.042 |
| adversarial P | 0.231 | 0.263 | +0.032 |
| adversarial R | 0.979 | 0.989 | +0.010 |

Improvement is in the right direction but #48 acceptance F1 ≥ 0.70 not met.
ORGANIZATION still emits 390 FP — in-corpus negatives are too weak for the
adversarial benchmark's FP-pressure phrases.

## Next iteration (separate PR)

Real hard-negative mining on an external clean corpus (Wikipedia, JNLI text):
predict with current model, take every emitted span as labeled O, re-train.

Refs #48