### PR TITLE
feat(68): confidence threshold sweep scaffolding

### DIFF
--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -442,6 +442,25 @@ runpod-gpu-compare-v12:
 	@echo "GPU run: see packages/training/docs/runpod-gpu-inference.md"
 	@echo "Use chrome MCP per CLAUDE.md to orchestrate the pod kick."
 
+# === Confidence threshold sweep (#68) ===
+# Two-step pipeline: predict once (heavy, requires HF model) → sweep many
+# thresholds offline (cheap, pure Python). Splitting lets you re-sweep with a
+# different grid without re-running the model.
+
+predict-scores-v12:
+	uv run --extra hf python -m pleno_ner_training.predict_hf_with_scores \
+		--model output/hf-ja-v02-tiny-hardneg \
+		--input data/benchmark/v0.12.0/ja/raw.json \
+		--output data/benchmark/v0.12.0/ja/raw_with_scores.json
+
+sweep-threshold-v12: predict-scores-v12
+	uv run python -m pleno_ner_training.sweep_threshold \
+		--predictions data/benchmark/v0.12.0/ja/raw_with_scores.json \
+		--output-md data/benchmark/v0.12.0/ja/threshold_sweep.md \
+		--output-csv data/benchmark/v0.12.0/ja/threshold_sweep.csv \
+		--thresholds 0.3 0.5 0.7 0.85 0.95 \
+		--recall-floor 0.90
+
 # === 共通 ===
 
 clean:

--- a/packages/training/src/pleno_ner_training/predict_hf_with_scores.py
+++ b/packages/training/src/pleno_ner_training/predict_hf_with_scores.py
@@ -1,0 +1,217 @@
+"""HuggingFace token-classification predictor with per-token softmax scores.
+
+Issue #68: We need to sweep confidence thresholds *post-hoc* without re-running
+the model. To enable that we run inference once and persist:
+
+- raw text + gold entities (mirrored from raw.json)
+- per-doc list of decoded entity spans, each with the min per-token softmax
+  score within the span (the "weakest link" — what an inference-time threshold
+  filter would compare against)
+
+Span extraction follows the standard BIO decoder: a `B-X` opens a span, any
+following `I-X` (matching label) extends it, anything else closes it. The span
+score is min(softmax_max_per_token) across the tokens that make up the span.
+
+Why min, not mean: a threshold like "drop spans whose every token cleared 0.85"
+is the natural translation of "filter low-confidence predictions"; mean would
+keep a span whose final token is wildly uncertain. Min mirrors what a
+production threshold-filter loop would do.
+
+Char-offset reconstruction uses the tokenizer's `offset_mapping`. Special
+tokens (offset==(0,0)) are skipped.
+
+Outputs JSON shape:
+
+    [
+      {
+        "text": "...",
+        "entities": [{"start": s, "end": e, "label": L}, ...],   # gold
+        "predictions": [
+            {"start": s, "end": e, "label": L, "score": float, "tokens": int},
+            ...
+        ],
+        "_meta": {...}                                            # passthrough
+      },
+      ...
+    ]
+
+This module is the single source of truth for "model output at every
+threshold ≥ 0"; downstream sweep_threshold.py only filters & scores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def decode_bio_spans_with_scores(
+    offsets: list[tuple[int, int]],
+    pred_label_ids: list[int],
+    token_scores: list[float],
+    id2label: dict[int, str],
+) -> list[dict[str, Any]]:
+    """Decode BIO token labels into character-offset spans with min-token score.
+
+    Pure function — no model dependency. Tested directly.
+
+    Tokens with offset (0, 0) are special tokens (CLS/SEP/PAD) and are skipped.
+    Adjacent same-label `I-` tokens without a preceding `B-` of the same label
+    are treated as `B-` (robust to mis-decoding); this matches seqeval's
+    permissive default.
+    """
+    spans: list[dict[str, Any]] = []
+    cur_label: str | None = None
+    cur_start: int | None = None
+    cur_end: int | None = None
+    cur_min_score: float = 1.0
+    cur_tokens: int = 0
+
+    def _flush() -> None:
+        nonlocal cur_label, cur_start, cur_end, cur_min_score, cur_tokens
+        if cur_label is not None and cur_start is not None and cur_end is not None:
+            spans.append(
+                {
+                    "start": int(cur_start),
+                    "end": int(cur_end),
+                    "label": cur_label,
+                    "score": float(cur_min_score),
+                    "tokens": int(cur_tokens),
+                }
+            )
+        cur_label = None
+        cur_start = None
+        cur_end = None
+        cur_min_score = 1.0
+        cur_tokens = 0
+
+    for (tok_start, tok_end), label_id, score in zip(
+        offsets, pred_label_ids, token_scores
+    ):
+        if tok_start == 0 and tok_end == 0:
+            # Special token — close any open span.
+            _flush()
+            continue
+        label = id2label[int(label_id)]
+        if label == "O":
+            _flush()
+            continue
+        prefix, _, ent = label.partition("-")
+        if not ent:
+            # Malformed label — treat as O.
+            _flush()
+            continue
+        if prefix == "B" or cur_label != ent:
+            _flush()
+            cur_label = ent
+            cur_start = int(tok_start)
+            cur_end = int(tok_end)
+            cur_min_score = float(score)
+            cur_tokens = 1
+        else:
+            # I- continuing the current entity.
+            cur_end = int(tok_end)
+            cur_min_score = min(cur_min_score, float(score))
+            cur_tokens += 1
+
+    _flush()
+    return spans
+
+
+def predict_doc(
+    text: str,
+    model: Any,
+    tokenizer: Any,
+    id2label: dict[int, str],
+    max_length: int = 512,
+) -> list[dict[str, Any]]:
+    """Run model inference on `text` and return decoded scored spans.
+
+    Heavy deps imported lazily inside this function so the module is importable
+    without torch/transformers installed (smoke tests for the BIO decoder run
+    without the [hf] extra).
+    """
+    import torch
+    import torch.nn.functional as F  # noqa: N812
+
+    enc = tokenizer(
+        text,
+        max_length=max_length,
+        truncation=True,
+        padding=False,
+        return_offsets_mapping=True,
+        return_tensors="pt",
+    )
+    offsets = [tuple(o) for o in enc.pop("offset_mapping")[0].tolist()]
+    with torch.inference_mode():
+        outputs = model(**enc)
+    logits = outputs.logits[0]  # (seq_len, num_labels)
+    probs = F.softmax(logits, dim=-1)
+    scores, label_ids = probs.max(dim=-1)
+    return decode_bio_spans_with_scores(
+        offsets=offsets,
+        pred_label_ids=label_ids.tolist(),
+        token_scores=scores.tolist(),
+        id2label=id2label,
+    )
+
+
+def predict_dataset(
+    raw_docs: Iterable[dict[str, Any]],
+    model_path: Path,
+    max_length: int = 512,
+) -> list[dict[str, Any]]:
+    """Predict on every doc in `raw_docs` (raw.json schema)."""
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+    model = AutoModelForTokenClassification.from_pretrained(str(model_path))
+    model.eval()
+    id2label = {int(k): v for k, v in model.config.id2label.items()}
+
+    out: list[dict[str, Any]] = []
+    for doc in raw_docs:
+        text = doc.get("text", "")
+        preds = predict_doc(text, model, tokenizer, id2label, max_length=max_length)
+        out.append(
+            {
+                "text": text,
+                "entities": doc.get("entities", []),
+                "predictions": preds,
+                "_meta": doc.get("_meta", {}),
+            }
+        )
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run HF NER and persist per-token softmax scores"
+    )
+    parser.add_argument("--model", type=Path, required=True, help="HF model dir")
+    parser.add_argument("--input", type=Path, required=True, help="raw.json")
+    parser.add_argument(
+        "--output", type=Path, required=True, help="raw_with_scores.json output path"
+    )
+    parser.add_argument("--max-length", type=int, default=512)
+    args = parser.parse_args()
+
+    with open(args.input, encoding="utf-8") as f:
+        raw_docs = json.load(f)
+    if not isinstance(raw_docs, list):
+        raise SystemExit(f"Expected a list at {args.input}; got {type(raw_docs)}")
+
+    print(f"Loading model from {args.model}")
+    print(f"Predicting on {len(raw_docs)} docs from {args.input}")
+    out = predict_dataset(raw_docs, args.model, max_length=args.max_length)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {len(out)} scored predictions to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/src/pleno_ner_training/sweep_threshold.py
+++ b/packages/training/src/pleno_ner_training/sweep_threshold.py
@@ -1,0 +1,305 @@
+"""Confidence-threshold sweep over scored predictions (issue #68).
+
+Reads a `raw_with_scores.json` produced by `predict_hf_with_scores.py`, applies
+each threshold in `--thresholds`, and computes per-label and overall
+precision / recall / F1 against the gold spans in the same file.
+
+A prediction span survives threshold `t` iff its `score >= t`.
+
+Matching is **strict**: identical (start, end, label) tuples count as TP.
+Matches `evaluate_benchmark.py`'s spaCy `Scorer` semantics for ents-level
+metrics under exact-span scoring.
+
+Recommended threshold = arg-max F1 among thresholds whose recall ≥ 0.90 (issue
+#68 AC). If no threshold meets recall ≥ 0.90, falls back to the highest-recall
+threshold (and flags it in the report).
+
+Outputs:
+- CSV: threshold, label, p, r, f1, n_pred, n_gold, n_tp
+- Markdown report (per-threshold per-label table + overall + recommendation)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+# Default sweep grid from the issue.
+DEFAULT_THRESHOLDS = (0.3, 0.5, 0.7, 0.85, 0.95)
+RECALL_FLOOR = 0.90
+
+
+def _prf(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
+    p = tp / (tp + fp) if (tp + fp) else 0.0
+    r = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return p, r, f1
+
+
+def evaluate_at_threshold(
+    docs: Sequence[dict[str, Any]],
+    threshold: float,
+    labels: Sequence[str],
+) -> dict[str, dict[str, float | int]]:
+    """Return {label: {p, r, f1, tp, fp, fn, n_pred, n_gold}, "_overall": {...}}.
+
+    Pure function; the heavy lifting in this module. `docs` follow the
+    raw_with_scores.json schema.
+    """
+    per_label: dict[str, dict[str, float | int]] = {
+        lbl: {"tp": 0, "fp": 0, "fn": 0, "n_pred": 0, "n_gold": 0} for lbl in labels
+    }
+    total_tp = 0
+    total_fp = 0
+    total_fn = 0
+
+    for doc in docs:
+        gold_set: set[tuple[int, int, str]] = {
+            (int(g["start"]), int(g["end"]), str(g["label"]))
+            for g in doc.get("entities", [])
+            if str(g.get("label")) in labels
+        }
+        pred_set: set[tuple[int, int, str]] = {
+            (int(p["start"]), int(p["end"]), str(p["label"]))
+            for p in doc.get("predictions", [])
+            if str(p.get("label")) in labels and float(p.get("score", 0.0)) >= threshold
+        }
+
+        for lbl in labels:
+            gold_l = {(s, e, lab) for (s, e, lab) in gold_set if lab == lbl}
+            pred_l = {(s, e, lab) for (s, e, lab) in pred_set if lab == lbl}
+            tp = len(gold_l & pred_l)
+            fp = len(pred_l - gold_l)
+            fn = len(gold_l - pred_l)
+            per_label[lbl]["tp"] += tp
+            per_label[lbl]["fp"] += fp
+            per_label[lbl]["fn"] += fn
+            per_label[lbl]["n_pred"] += len(pred_l)
+            per_label[lbl]["n_gold"] += len(gold_l)
+            total_tp += tp
+            total_fp += fp
+            total_fn += fn
+
+    out: dict[str, dict[str, float | int]] = {}
+    for lbl, c in per_label.items():
+        p, r, f1 = _prf(int(c["tp"]), int(c["fp"]), int(c["fn"]))
+        out[lbl] = {**c, "p": p, "r": r, "f1": f1}
+
+    p, r, f1 = _prf(total_tp, total_fp, total_fn)
+    out["_overall"] = {
+        "tp": total_tp,
+        "fp": total_fp,
+        "fn": total_fn,
+        "n_pred": total_tp + total_fp,
+        "n_gold": total_tp + total_fn,
+        "p": p,
+        "r": r,
+        "f1": f1,
+    }
+    return out
+
+
+def pick_recommended_threshold(
+    sweep: dict[float, dict[str, dict[str, float | int]]],
+    recall_floor: float = RECALL_FLOOR,
+) -> tuple[float, bool]:
+    """Best F1 at overall recall >= floor. Returns (threshold, met_floor).
+
+    Falls back to the threshold with highest recall if none meet the floor.
+    Tie-breaks (equal F1): prefer higher threshold (= more conservative, better
+    precision); the issue's "post-process precision lever" framing favors the
+    stricter setting when results tie.
+    """
+    eligible = [
+        (t, r["_overall"]["f1"])
+        for t, r in sweep.items()
+        if float(r["_overall"]["r"]) >= recall_floor
+    ]
+    if eligible:
+        eligible.sort(key=lambda x: (-float(x[1]), -x[0]))
+        return eligible[0][0], True
+    # Fallback: highest overall recall, then highest threshold.
+    fallback = sorted(
+        sweep.items(),
+        key=lambda kv: (-float(kv[1]["_overall"]["r"]), -kv[0]),
+    )
+    return fallback[0][0], False
+
+
+def render_markdown(
+    sweep: dict[float, dict[str, dict[str, float | int]]],
+    labels: Sequence[str],
+    recommended: float,
+    met_floor: bool,
+    recall_floor: float,
+    source_path: Path | None = None,
+) -> str:
+    """Markdown table per the issue's "CSV / Markdown で threshold × P/R/F1 表"."""
+    lines: list[str] = []
+    lines.append("# Confidence threshold sweep (#68)\n")
+    if source_path is not None:
+        lines.append(f"Source: `{source_path}`\n")
+    lines.append("## Per-threshold overall\n")
+    lines.append("| threshold | precision | recall | F1 | n_pred | n_gold |")
+    lines.append("|---:|---:|---:|---:|---:|---:|")
+    for t in sorted(sweep.keys()):
+        ov = sweep[t]["_overall"]
+        lines.append(
+            f"| {t:.2f} | {float(ov['p']):.3f} | {float(ov['r']):.3f} | "
+            f"{float(ov['f1']):.3f} | {int(ov['n_pred'])} | {int(ov['n_gold'])} |"
+        )
+
+    for lbl in labels:
+        lines.append(f"\n## Per-threshold {lbl}\n")
+        lines.append("| threshold | precision | recall | F1 | n_pred | n_gold |")
+        lines.append("|---:|---:|---:|---:|---:|---:|")
+        for t in sorted(sweep.keys()):
+            row = sweep[t][lbl]
+            lines.append(
+                f"| {t:.2f} | {float(row['p']):.3f} | {float(row['r']):.3f} | "
+                f"{float(row['f1']):.3f} | {int(row['n_pred'])} | {int(row['n_gold'])} |"
+            )
+
+    lines.append("\n## Recommendation\n")
+    rec_overall = sweep[recommended]["_overall"]
+    if met_floor:
+        lines.append(
+            f"**threshold = {recommended:.2f}** — best F1 among thresholds with "
+            f"recall ≥ {recall_floor:.2f}.\n"
+        )
+    else:
+        lines.append(
+            f"**threshold = {recommended:.2f}** — *fallback* (no threshold met "
+            f"recall ≥ {recall_floor:.2f}; picked highest-recall instead).\n"
+        )
+    lines.append(
+        f"At threshold {recommended:.2f}: "
+        f"P={float(rec_overall['p']):.3f}, "
+        f"R={float(rec_overall['r']):.3f}, "
+        f"F1={float(rec_overall['f1']):.3f}.\n"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_csv(
+    sweep: dict[float, dict[str, dict[str, float | int]]],
+    labels: Sequence[str],
+    out_path: Path,
+) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(
+            ["threshold", "label", "precision", "recall", "f1", "n_pred", "n_gold", "tp"]
+        )
+        for t in sorted(sweep.keys()):
+            for lbl in [*labels, "_overall"]:
+                row = sweep[t][lbl]
+                w.writerow(
+                    [
+                        f"{t:.4f}",
+                        lbl,
+                        f"{float(row['p']):.6f}",
+                        f"{float(row['r']):.6f}",
+                        f"{float(row['f1']):.6f}",
+                        int(row["n_pred"]),
+                        int(row["n_gold"]),
+                        int(row["tp"]),
+                    ]
+                )
+
+
+def run_sweep(
+    docs: Sequence[dict[str, Any]],
+    thresholds: Sequence[float],
+    labels: Sequence[str],
+) -> dict[float, dict[str, dict[str, float | int]]]:
+    return {float(t): evaluate_at_threshold(docs, float(t), labels) for t in thresholds}
+
+
+def _infer_labels(docs: Sequence[dict[str, Any]]) -> list[str]:
+    """Discover the label set used in this benchmark (gold ∪ predictions)."""
+    seen: set[str] = set()
+    for d in docs:
+        for ent in d.get("entities", []):
+            seen.add(str(ent["label"]))
+        for ent in d.get("predictions", []):
+            seen.add(str(ent["label"]))
+    # Stable, human-friendly order: the canonical 5-class set first, then
+    # anything else discovered.
+    canonical = ["PERSON", "ADDRESS", "ORGANIZATION", "DATE_OF_BIRTH", "BANK_ACCOUNT"]
+    ordered = [lbl for lbl in canonical if lbl in seen]
+    ordered += sorted(seen - set(canonical))
+    return ordered
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Confidence threshold sweep over HF NER predictions (#68)"
+    )
+    parser.add_argument(
+        "--predictions",
+        type=Path,
+        required=True,
+        help="raw_with_scores.json from predict_hf_with_scores.py",
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        required=True,
+        help="Markdown report path",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=None,
+        help="Optional CSV path",
+    )
+    parser.add_argument(
+        "--thresholds",
+        type=float,
+        nargs="+",
+        default=list(DEFAULT_THRESHOLDS),
+    )
+    parser.add_argument(
+        "--recall-floor",
+        type=float,
+        default=RECALL_FLOOR,
+    )
+    args = parser.parse_args()
+
+    with open(args.predictions, encoding="utf-8") as f:
+        docs = json.load(f)
+    if not isinstance(docs, list):
+        raise SystemExit(f"Expected list at {args.predictions}")
+    print(f"Loaded {len(docs)} scored docs")
+
+    labels = _infer_labels(docs)
+    print(f"Labels: {labels}")
+    sweep = run_sweep(docs, args.thresholds, labels)
+    recommended, met_floor = pick_recommended_threshold(sweep, args.recall_floor)
+
+    md = render_markdown(
+        sweep, labels, recommended, met_floor, args.recall_floor, args.predictions
+    )
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.write_text(md, encoding="utf-8")
+    print(f"Wrote markdown report → {args.output_md}")
+
+    if args.output_csv is not None:
+        write_csv(sweep, labels, args.output_csv)
+        print(f"Wrote CSV → {args.output_csv}")
+
+    rec = sweep[recommended]["_overall"]
+    print(
+        f"Recommended threshold: {recommended:.2f} "
+        f"(P={float(rec['p']):.3f}, R={float(rec['r']):.3f}, F1={float(rec['f1']):.3f}, "
+        f"recall_floor_met={met_floor})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/tests/test_sweep_threshold.py
+++ b/packages/training/tests/test_sweep_threshold.py
@@ -1,0 +1,227 @@
+"""Tests for confidence threshold sweep (#68).
+
+Covers:
+- BIO span decoder with per-token min-score (predict_hf_with_scores)
+- Threshold filtering + per-label P/R/F1 (sweep_threshold.evaluate_at_threshold)
+- Recommended-threshold picker (best F1 at recall >= floor + fallback)
+- Markdown / CSV emission shape
+
+All tests are pure-Python (no torch / transformers / model files required).
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from pleno_ner_training.predict_hf_with_scores import decode_bio_spans_with_scores
+from pleno_ner_training.sweep_threshold import (
+    DEFAULT_THRESHOLDS,
+    evaluate_at_threshold,
+    pick_recommended_threshold,
+    render_markdown,
+    run_sweep,
+    write_csv,
+)
+
+
+# ---------- BIO decoder ----------
+
+
+def _id2label() -> dict[int, str]:
+    # Mirrors convert_to_hf_dataset.BIO_LABELS shape.
+    labels = ["O", "B-ORGANIZATION", "I-ORGANIZATION", "B-PERSON", "I-PERSON"]
+    return {i: l for i, l in enumerate(labels)}
+
+
+def test_decoder_emits_single_span_with_min_score():
+    # Tokens span chars 0..3 ("AB") + 3..6 ("CD") with B-ORG, I-ORG.
+    offsets = [(0, 0), (0, 3), (3, 6), (0, 0)]
+    label_ids = [0, 1, 2, 0]
+    scores = [0.99, 0.91, 0.62, 0.99]
+    spans = decode_bio_spans_with_scores(offsets, label_ids, scores, _id2label())
+    assert spans == [
+        {"start": 0, "end": 6, "label": "ORGANIZATION", "score": 0.62, "tokens": 2}
+    ]
+
+
+def test_decoder_handles_two_adjacent_different_labels():
+    offsets = [(0, 3), (3, 6)]
+    # B-ORG then B-PERSON -> two separate spans.
+    label_ids = [1, 3]
+    scores = [0.8, 0.7]
+    spans = decode_bio_spans_with_scores(offsets, label_ids, scores, _id2label())
+    assert len(spans) == 2
+    assert spans[0]["label"] == "ORGANIZATION"
+    assert spans[1]["label"] == "PERSON"
+    assert spans[0]["score"] == 0.8
+    assert spans[1]["score"] == 0.7
+
+
+def test_decoder_treats_orphan_I_as_B():
+    # Robustness: I- without preceding matching B- still opens a span.
+    offsets = [(0, 3), (3, 6)]
+    label_ids = [2, 2]  # I-ORG, I-ORG
+    scores = [0.5, 0.4]
+    spans = decode_bio_spans_with_scores(offsets, label_ids, scores, _id2label())
+    assert len(spans) == 1
+    assert spans[0]["label"] == "ORGANIZATION"
+    assert spans[0]["score"] == 0.4
+    assert spans[0]["tokens"] == 2
+
+
+def test_decoder_skips_special_tokens_and_O():
+    offsets = [(0, 0), (0, 2), (2, 4), (0, 0)]
+    label_ids = [0, 0, 0, 0]
+    scores = [0.99, 0.99, 0.99, 0.99]
+    assert decode_bio_spans_with_scores(offsets, label_ids, scores, _id2label()) == []
+
+
+# ---------- threshold sweep ----------
+
+
+def _docs() -> list[dict]:
+    """Fixture: 2 docs, 4 gold, 5 predictions across thresholds."""
+    return [
+        {
+            "text": "...",
+            "entities": [
+                {"start": 0, "end": 3, "label": "ORGANIZATION"},
+                {"start": 5, "end": 8, "label": "PERSON"},
+            ],
+            "predictions": [
+                # Two correct spans at high score, one low-score FP.
+                {"start": 0, "end": 3, "label": "ORGANIZATION", "score": 0.95},
+                {"start": 5, "end": 8, "label": "PERSON", "score": 0.92},
+                {"start": 9, "end": 12, "label": "ORGANIZATION", "score": 0.40},
+            ],
+        },
+        {
+            "text": "...",
+            "entities": [
+                {"start": 0, "end": 3, "label": "ORGANIZATION"},
+                {"start": 5, "end": 9, "label": "PERSON"},
+            ],
+            "predictions": [
+                # ORG correct + low-score; PERSON wrong-span low-score.
+                {"start": 0, "end": 3, "label": "ORGANIZATION", "score": 0.55},
+                {"start": 5, "end": 7, "label": "PERSON", "score": 0.45},
+            ],
+        },
+    ]
+
+
+def test_evaluate_at_low_threshold_keeps_everything():
+    docs = _docs()
+    res = evaluate_at_threshold(docs, threshold=0.0, labels=["ORGANIZATION", "PERSON"])
+    # ORG: gold=2, pred=3 (2 TP + 1 FP); PERSON: gold=2, pred=2 (1 TP + 1 FP).
+    assert res["ORGANIZATION"]["tp"] == 2
+    assert res["ORGANIZATION"]["fp"] == 1
+    assert res["ORGANIZATION"]["fn"] == 0
+    assert res["PERSON"]["tp"] == 1
+    assert res["PERSON"]["fp"] == 1
+    assert res["PERSON"]["fn"] == 1
+    assert res["_overall"]["tp"] == 3
+    assert res["_overall"]["fp"] == 2
+    assert res["_overall"]["fn"] == 1
+
+
+def test_evaluate_at_high_threshold_drops_low_score_preds():
+    docs = _docs()
+    res = evaluate_at_threshold(docs, threshold=0.9, labels=["ORGANIZATION", "PERSON"])
+    # Only doc1's two high-score preds survive.
+    assert res["ORGANIZATION"]["tp"] == 1
+    assert res["ORGANIZATION"]["fp"] == 0
+    assert res["ORGANIZATION"]["fn"] == 1
+    assert res["PERSON"]["tp"] == 1
+    assert res["PERSON"]["fp"] == 0
+    assert res["PERSON"]["fn"] == 1
+    assert res["_overall"]["p"] == 1.0
+    # 2 gold survived in FN, 2 TP -> recall = 0.5
+    assert res["_overall"]["r"] == 0.5
+
+
+def test_evaluate_threshold_strict_match():
+    # PERSON pred (5,7) vs gold (5,9) — strict mismatch counts as FP+FN.
+    docs = _docs()
+    res = evaluate_at_threshold(docs, threshold=0.0, labels=["PERSON"])
+    assert res["PERSON"]["tp"] == 1  # only doc1's (5,8) hit
+    assert res["PERSON"]["fp"] == 1  # doc2's (5,7) ≠ (5,9)
+    assert res["PERSON"]["fn"] == 1
+
+
+def test_pick_recommended_picks_best_f1_above_floor():
+    # Synthetic sweep: t=0.5 has recall 0.95 F1 0.6; t=0.7 recall 0.92 F1 0.7;
+    # t=0.95 recall 0.5 F1 0.65. Floor 0.90 -> t=0.7 wins (highest F1).
+    sweep = {
+        0.5: {"_overall": {"p": 0.45, "r": 0.95, "f1": 0.6, "tp": 0, "fp": 0, "fn": 0,
+                            "n_pred": 0, "n_gold": 0}},
+        0.7: {"_overall": {"p": 0.6, "r": 0.92, "f1": 0.7, "tp": 0, "fp": 0, "fn": 0,
+                            "n_pred": 0, "n_gold": 0}},
+        0.95: {"_overall": {"p": 0.9, "r": 0.5, "f1": 0.65, "tp": 0, "fp": 0, "fn": 0,
+                             "n_pred": 0, "n_gold": 0}},
+    }
+    rec, met = pick_recommended_threshold(sweep, recall_floor=0.9)
+    assert rec == 0.7
+    assert met is True
+
+
+def test_pick_recommended_falls_back_when_floor_unmet():
+    sweep = {
+        0.5: {"_overall": {"p": 0.6, "r": 0.5, "f1": 0.55, "tp": 0, "fp": 0, "fn": 0,
+                            "n_pred": 0, "n_gold": 0}},
+        0.7: {"_overall": {"p": 0.7, "r": 0.4, "f1": 0.51, "tp": 0, "fp": 0, "fn": 0,
+                            "n_pred": 0, "n_gold": 0}},
+    }
+    rec, met = pick_recommended_threshold(sweep, recall_floor=0.9)
+    assert met is False
+    assert rec == 0.5  # higher-recall fallback
+
+
+def test_pick_recommended_tiebreak_prefers_higher_threshold():
+    sweep = {
+        0.5: {"_overall": {"p": 0.5, "r": 0.95, "f1": 0.7, "tp": 0, "fp": 0, "fn": 0,
+                            "n_pred": 0, "n_gold": 0}},
+        0.7: {"_overall": {"p": 0.7, "r": 0.92, "f1": 0.7, "tp": 0, "fp": 0, "fn": 0,
+                            "n_pred": 0, "n_gold": 0}},
+    }
+    rec, met = pick_recommended_threshold(sweep, recall_floor=0.9)
+    assert rec == 0.7
+    assert met is True
+
+
+def test_run_sweep_default_grid_returns_all_thresholds():
+    docs = _docs()
+    sweep = run_sweep(docs, DEFAULT_THRESHOLDS, ["ORGANIZATION", "PERSON"])
+    assert set(sweep.keys()) == {float(t) for t in DEFAULT_THRESHOLDS}
+    for t, r in sweep.items():
+        assert "_overall" in r
+        assert "ORGANIZATION" in r
+        assert "PERSON" in r
+
+
+def test_render_markdown_contains_recommendation_and_per_label_section():
+    docs = _docs()
+    labels = ["ORGANIZATION", "PERSON"]
+    sweep = run_sweep(docs, DEFAULT_THRESHOLDS, labels)
+    rec, met = pick_recommended_threshold(sweep, 0.5)
+    md = render_markdown(sweep, labels, rec, met, 0.5)
+    assert "# Confidence threshold sweep" in md
+    assert "## Per-threshold overall" in md
+    assert "## Per-threshold ORGANIZATION" in md
+    assert "## Per-threshold PERSON" in md
+    assert "## Recommendation" in md
+    assert f"threshold = {rec:.2f}" in md
+
+
+def test_write_csv_emits_one_row_per_threshold_label(tmp_path: Path):
+    docs = _docs()
+    labels = ["ORGANIZATION", "PERSON"]
+    sweep = run_sweep(docs, [0.3, 0.7], labels)
+    out = tmp_path / "sweep.csv"
+    write_csv(sweep, labels, out)
+    rows = list(csv.DictReader(out.open(encoding="utf-8")))
+    # 2 thresholds × (2 labels + _overall) = 6 rows.
+    assert len(rows) == 6
+    assert {r["label"] for r in rows} == {"ORGANIZATION", "PERSON", "_overall"}
+    assert {r["threshold"] for r in rows} == {"0.3000", "0.7000"}


### PR DESCRIPTION
## What

Implements issue #68 — confidence threshold sweep over HF NER predictions to
improve precision post-hoc without retraining.

Two-stage pipeline:

1. **\`predict_hf_with_scores.py\`** — load HF model, run once over raw.json,
   persist per-doc gold + decoded spans with min-per-token softmax score.
2. **\`sweep_threshold.py\`** — pure-Python consumer that re-evaluates at any
   threshold grid (default 0.3 / 0.5 / 0.7 / 0.85 / 0.95) and emits per-label
   P/R/F1 in Markdown + CSV.

Recommended threshold = arg-max F1 among thresholds with overall recall ≥ 0.90
(issue AC), with documented fallback if no threshold meets the floor.

## Files changed

- \`packages/training/src/pleno_ner_training/predict_hf_with_scores.py\` (new)
- \`packages/training/src/pleno_ner_training/sweep_threshold.py\` (new)
- \`packages/training/tests/test_sweep_threshold.py\` (new, 13 tests)
- \`packages/training/Makefile\` — adds \`predict-scores-v12\` and \`sweep-threshold-v12\`

## AC checklist

- [x] threshold sweep スクリプトが Makefile に \`sweep-threshold-v12\` として存在
- [x] CSV / Markdown で threshold × P/R/F1 表が出力される
- [x] 推奨 threshold が選定されている (best F1 at recall ≥ 0.90)
- [ ] **推奨 threshold で adversarial F1 ≥ 0.45** — *blocked*: HF model
      \`output/hf-ja-v02-tiny-hardneg\` is not present in this checkout, so the
      end-to-end run cannot be executed locally. **Scaffolding + smoke tests
      land here; AC re-run once the model artifacts are available** (next
      RunPod cycle, per CLAUDE.md \`use runpod for training\`).

## Verification

- Pure-logic tests (no model required): \`uv run --with pytest pytest tests/test_sweep_threshold.py -v\` → **13 passed**.
- CLI smoke test: ran \`sweep_threshold\` against a synthetic predictions
  fixture; markdown + CSV produced as expected, recommendation chosen
  correctly under both above-floor and fallback paths.
- \`make -n sweep-threshold-v12\` confirms target wiring.

## Out of scope

- Pareto curve plotting (issue mentions it but lists CSV/MD as the AC
  artifact; sticking to text outputs for review-friendliness).
- Production threshold rollout — that lands once the AC measurement
  re-confirms F1 ≥ 0.45.

Closes #68