### PR TITLE
feat(training): unify HF + spaCy benchmark eval (#69, #70)

### DIFF
--- a/packages/training/data/benchmark/v0.12.0/ja/scores.json
+++ b/packages/training/data/benchmark/v0.12.0/ja/scores.json
@@ -38,6 +38,54 @@
     "negative_doc_clean_rate": 0.5840909090909091,
     "negative_fp_total": 353,
     "suite_kind": "benchmark",
-    "purpose": "OCR・key-value 崩れと一般文書の偽陽性圧力を強めた curated DLP benchmark"
+    "purpose": "OCR・key-value 崩れと一般文書の偽陽性圧力を強めた curated DLP benchmark",
+    "corpus": "v0.12.0/ja",
+    "metric": "strict_span_f1",
+    "aggregation": "micro",
+    "model_kind": "spacy_cnn"
+  },
+  "hf_v02_tiny": {
+    "ents_p": 0.231,
+    "ents_r": 0.979,
+    "ents_f": 0.374,
+    "ents_per_type": {
+      "PERSON": {"p": 0.750, "r": 0.966, "f": 0.844, "tp": 57, "fp": 19, "fn": 2},
+      "ADDRESS": {"p": 0.529, "r": 1.000, "f": 0.692, "tp": 45, "fp": 40, "fn": 0},
+      "ORGANIZATION": {"p": 0.067, "r": 0.946, "f": 0.124, "tp": 35, "fp": 491, "fn": 2},
+      "DATE_OF_BIRTH": {"p": 0.411, "r": 1.000, "f": 0.582, "tp": 23, "fp": 33, "fn": 0},
+      "BANK_ACCOUNT": {"p": 0.444, "r": 1.000, "f": 0.615, "tp": 24, "fp": 30, "fn": 0}
+    },
+    "suite_kind": "benchmark",
+    "purpose": "OCR・key-value 崩れと一般文書の偽陽性圧力を強めた curated DLP benchmark",
+    "corpus": "v0.12.0/ja",
+    "metric": "strict_span_f1",
+    "aggregation": "micro",
+    "model_kind": "hf_token_classification",
+    "base_model": "ku-nlp/deberta-v2-tiny-japanese",
+    "trained": "2026-05-03",
+    "source": "packages/training/models/v02-tiny-eval-v012.md (one-off tmp/eval_v012.py prior to #69 unification)",
+    "notes": "v02-tiny baseline, no hard-negative mining. Severe over-prediction (491 FP on ORGANIZATION). Rerun via `python -m pleno_ner_training.evaluate_benchmark --hf-model output/hf-ja-v02-tiny --version v0.12.0 --merge` once model artifact is restored."
+  },
+  "hf_v02_tiny_hardneg": {
+    "ents_p": 0.263,
+    "ents_r": 0.989,
+    "ents_f": 0.416,
+    "ents_per_type": {
+      "PERSON": {"p": 0.795, "r": 0.983, "f": 0.879, "tp": 58, "fp": 15, "fn": 1},
+      "ADDRESS": {"p": 0.500, "r": 1.000, "f": 0.667, "tp": 45, "fp": 45, "fn": 0},
+      "ORGANIZATION": {"p": 0.085, "r": 0.973, "f": 0.156, "tp": 36, "fp": 390, "fn": 1},
+      "DATE_OF_BIRTH": {"p": 0.418, "r": 1.000, "f": 0.590, "tp": 23, "fp": 32, "fn": 0},
+      "BANK_ACCOUNT": {"p": 0.387, "r": 1.000, "f": 0.558, "tp": 24, "fp": 38, "fn": 0}
+    },
+    "suite_kind": "benchmark",
+    "purpose": "OCR・key-value 崩れと一般文書の偽陽性圧力を強めた curated DLP benchmark",
+    "corpus": "v0.12.0/ja",
+    "metric": "strict_span_f1",
+    "aggregation": "micro",
+    "model_kind": "hf_token_classification",
+    "base_model": "ku-nlp/deberta-v2-tiny-japanese",
+    "trained": "2026-05-03",
+    "source": "packages/training/models/v02-tiny-hardneg-eval-v012.md (one-off tmp/eval_v012.py prior to #69 unification)",
+    "notes": "Hard-negative mining (2032 zero-entity docs from generated.json). +0.042 F1 vs v02-tiny baseline but precision still collapses on ORGANIZATION (390 FP). Rerun via `python -m pleno_ner_training.evaluate_benchmark --hf-model output/hf-ja-v02-tiny-hardneg --version v0.12.0 --merge` once model artifact is restored."
   }
 }

--- a/packages/training/src/pleno_ner_training/evaluate_benchmark.py
+++ b/packages/training/src/pleno_ner_training/evaluate_benchmark.py
@@ -2,6 +2,10 @@
 
 学習パイプラインのテストデータではなく、独立したベンチマークデータで
 モデルを評価する。外部モデルとの比較も同時に実施。
+
+spaCy モデル経路と HuggingFace token-classification モデル経路の双方を
+同じ spaCy `Scorer` (strict-span F1, micro aggregation) で測ることで
+公平比較を可能にする (#69)。
 """
 
 import json
@@ -11,7 +15,7 @@ from pathlib import Path
 
 import spacy
 from spacy.scorer import Scorer
-from spacy.tokens import DocBin
+from spacy.tokens import Doc, DocBin
 from spacy.training import Example
 
 from pleno_ner_training.benchmark_config import (
@@ -19,6 +23,7 @@ from pleno_ner_training.benchmark_config import (
     BENCHMARK_VERSIONS,
     LATEST_BENCHMARK_VERSION,
 )
+
 
 
 def load_benchmark_docs(nlp: spacy.Language, path: Path) -> list:
@@ -65,6 +70,173 @@ def evaluate_on_benchmark(
 
     # モデルサイズ
     model_dir = Path(nlp.path) if nlp.path else Path(model_path)
+    if model_dir.exists():
+        size_bytes = sum(f.stat().st_size for f in model_dir.rglob("*") if f.is_file())
+        scores["model_size_mb"] = round(size_bytes / (1024 * 1024), 1)
+
+    return scores
+
+
+def _derive_hf_entry_key(model_path: str) -> str:
+    """`output/hf-ja-v02-tiny-hardneg` → `hf_v02_tiny_hardneg`.
+
+    scores.json key 命名を機械的に決めることで、ad-hoc 命名の衝突を防ぐ (#70)。"""
+    name = Path(model_path).name
+    # 言語タグ ja/en は scores.json が language ディレクトリで分離済みなので除く
+    parts = name.split("-")
+    cleaned = [p for p in parts if p not in {"ja", "en"}]
+    return "_".join(cleaned) if cleaned else name.replace("-", "_")
+
+
+def _bio_tags_to_char_spans(
+    tags: list[str],
+    offsets: list[tuple[int, int]],
+) -> list[tuple[int, int, str]]:
+    """BIOラベル列とトークン char-offsets から (start, end, label) スパンを抽出.
+
+    HF token-classification の subword 出力を char offset 空間に逆変換する。
+    特殊トークン (offset == (0, 0)) は無視する。"""
+    spans: list[tuple[int, int, str]] = []
+    cur_label: str | None = None
+    cur_start: int | None = None
+    cur_end: int | None = None
+
+    for tag, (tok_start, tok_end) in zip(tags, offsets):
+        # spaCy は (0,0) を special token / pad として扱う
+        if tok_start == 0 and tok_end == 0:
+            if cur_label is not None and cur_start is not None and cur_end is not None:
+                spans.append((cur_start, cur_end, cur_label))
+                cur_label, cur_start, cur_end = None, None, None
+            continue
+
+        if tag == "O" or tag == "":
+            if cur_label is not None and cur_start is not None and cur_end is not None:
+                spans.append((cur_start, cur_end, cur_label))
+                cur_label, cur_start, cur_end = None, None, None
+            continue
+
+        # tag は "B-LABEL" or "I-LABEL"
+        if "-" not in tag:
+            continue
+        prefix, label = tag.split("-", 1)
+
+        if prefix == "B" or cur_label != label:
+            # 前のスパンを確定
+            if cur_label is not None and cur_start is not None and cur_end is not None:
+                spans.append((cur_start, cur_end, cur_label))
+            cur_label = label
+            cur_start = tok_start
+            cur_end = tok_end
+        else:  # prefix == "I" and same label
+            cur_end = tok_end
+
+    if cur_label is not None and cur_start is not None and cur_end is not None:
+        spans.append((cur_start, cur_end, cur_label))
+
+    return spans
+
+
+def evaluate_hf_on_benchmark(
+    model_path: str,
+    benchmark_path: Path,
+    language: str = "ja",
+    max_length: int = 512,
+) -> dict:
+    """HuggingFace token-classification モデルをベンチマークで評価.
+
+    spaCy Scorer 互換 (strict-span F1) で測るため:
+      1. fast tokenizer の return_offsets_mapping=True で char offset 取得
+      2. argmax で BIO ラベル列を作成
+      3. char-offset 空間でスパンに集約
+      4. spaCy Doc + Example に詰めて Scorer.score() に渡す
+    """
+    # 遅延 import: HF deps は [hf] extra にあり、spaCy 経路では不要
+    import torch
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    if not getattr(tokenizer, "is_fast", False):
+        raise RuntimeError(
+            f"HF model at {model_path} must ship a fast tokenizer "
+            "(return_offsets_mapping required)."
+        )
+    model = AutoModelForTokenClassification.from_pretrained(model_path)
+    model.eval()
+    id2label: dict[int, str] = {int(k): v for k, v in model.config.id2label.items()}
+
+    # gold は spaCy DocBin。blank 言語 vocab で読めば十分 (NER labels は doc 内)
+    blank_nlp = spacy.blank(language)
+    gold_docs = load_benchmark_docs(blank_nlp, benchmark_path)
+
+    examples: list[Example] = []
+    total_time = 0.0
+    negative_docs = 0
+    clean_negative_docs = 0
+    negative_fp_total = 0
+
+    for gold_doc in gold_docs:
+        text = gold_doc.text
+
+        start = time.perf_counter()
+        with torch.no_grad():
+            enc = tokenizer(
+                text,
+                max_length=max_length,
+                truncation=True,
+                padding=False,
+                return_offsets_mapping=True,
+                return_tensors="pt",
+            )
+            offsets = enc.pop("offset_mapping")[0].tolist()
+            logits = model(**enc).logits[0]
+            tag_ids = logits.argmax(dim=-1).tolist()
+        total_time += time.perf_counter() - start
+
+        tags = [id2label.get(int(i), "O") for i in tag_ids]
+        char_spans = _bio_tags_to_char_spans(tags, offsets)
+
+        # gold doc と同じ text/tokens を持つ pred Doc を作る。
+        # spaCy Scorer は ent の char offset を比較するので tokenization は同一でなくてよい。
+        pred_doc = Doc(blank_nlp.vocab, words=[t.text for t in gold_doc], spaces=[t.whitespace_ != "" for t in gold_doc])
+        pred_ents = []
+        for s, e, label in char_spans:
+            span = pred_doc.char_span(s, e, label=label, alignment_mode="expand")
+            if span is not None:
+                pred_ents.append(span)
+        try:
+            pred_doc.ents = pred_ents  # type: ignore[assignment]
+        except ValueError:
+            # 重複スパンが出たら長い方を優先 (greedy non-overlap)
+            occupied: list[tuple[int, int]] = []
+            unique = []
+            for span in sorted(pred_ents, key=lambda s: (-(s.end - s.start), s.start)):
+                if any(span.start < oe and os < span.end for os, oe in occupied):
+                    continue
+                unique.append(span)
+                occupied.append((span.start, span.end))
+            unique.sort(key=lambda s: s.start)
+            pred_doc.ents = unique  # type: ignore[assignment]
+
+        examples.append(Example(pred_doc, gold_doc))
+        if not gold_doc.ents:
+            negative_docs += 1
+            negative_fp_total += len(pred_doc.ents)
+            if not pred_doc.ents:
+                clean_negative_docs += 1
+
+    scores = Scorer().score(examples)
+    scores["latency_ms_per_doc"] = round(
+        (total_time / len(gold_docs) * 1000) if gold_docs else 0, 1
+    )
+    scores["num_docs"] = len(gold_docs)
+    scores["negative_docs"] = negative_docs
+    scores["negative_clean_docs"] = clean_negative_docs
+    scores["negative_doc_clean_rate"] = (
+        clean_negative_docs / negative_docs if negative_docs else 0
+    )
+    scores["negative_fp_total"] = negative_fp_total
+
+    model_dir = Path(model_path)
     if model_dir.exists():
         size_bytes = sum(f.stat().st_size for f in model_dir.rglob("*") if f.is_file())
         scores["model_size_mb"] = round(size_bytes / (1024 * 1024), 1)
@@ -160,12 +332,34 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Benchmark evaluation")
-    parser.add_argument("--model", required=True, help="Primary model path")
+    parser.add_argument("--model", default=None, help="spaCy model path")
+    parser.add_argument(
+        "--hf-model",
+        default=None,
+        help="HuggingFace token-classification model path (directory). "
+             "Mutually optional with --model; one of the two must be set.",
+    )
+    parser.add_argument(
+        "--hf-entry-key",
+        default=None,
+        help="scores.json key for the HF model (default: derived from "
+             "directory name, e.g. hf-ja-v02-tiny-hardneg → hf_v02_tiny_hardneg)",
+    )
     parser.add_argument("--language", default="ja", choices=["ja", "en"])
     parser.add_argument("--version", default=LATEST_BENCHMARK_VERSION, choices=BENCHMARK_VERSIONS)
     parser.add_argument("--benchmark-data", type=Path, default=None)
     parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument(
+        "--merge",
+        action="store_true",
+        help="Merge into the existing scores.json instead of overwriting "
+             "(use to add an HF entry alongside the existing spaCy entry).",
+    )
     args = parser.parse_args()
+
+    if not args.model and not args.hf_model:
+        parser.error("at least one of --model / --hf-model is required")
+
     config = BENCHMARK_CONFIGS[args.version]
 
     data_root = Path(__file__).parents[2] / "data"
@@ -180,9 +374,17 @@ def main() -> None:
 
     results: dict[str, dict] = {"_version": args.version}
 
-    # プライマリモデル評価
-    print(f"Evaluating {args.model}...")
-    results["pleno_ner"] = evaluate_on_benchmark(args.model, benchmark_path)
+    if args.model:
+        print(f"Evaluating spaCy {args.model}...")
+        results["pleno_ner"] = evaluate_on_benchmark(args.model, benchmark_path)
+
+    if args.hf_model:
+        print(f"Evaluating HF {args.hf_model}...")
+        hf_scores = evaluate_hf_on_benchmark(
+            args.hf_model, benchmark_path, language=args.language
+        )
+        entry_key = args.hf_entry_key or _derive_hf_entry_key(args.hf_model)
+        results[entry_key] = hf_scores
 
     print_benchmark_report(results, args.language, config.suite_kind)
 
@@ -192,9 +394,11 @@ def main() -> None:
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # scores から non-serializable な値を除去
+    # scores から non-serializable な値を除去 + triad metadata 注入 (#70)
     serializable = {}
     for model_name, scores in results.items():
+        if model_name == "_version":
+            continue
         serializable[model_name] = {
             "ents_p": scores.get("ents_p", 0),
             "ents_r": scores.get("ents_r", 0),
@@ -209,7 +413,20 @@ def main() -> None:
             "negative_fp_total": scores.get("negative_fp_total", 0),
             "suite_kind": config.suite_kind,
             "purpose": config.purpose,
+            # 比較表で metric/aggregation/corpus を一意に identify するための triad
+            "corpus": f"{args.version}/{args.language}",
+            "metric": "strict_span_f1",
+            "aggregation": "micro",
         }
+
+    if args.merge and output_path.exists():
+        try:
+            with open(output_path, encoding="utf-8") as f:
+                existing = json.load(f)
+        except json.JSONDecodeError:
+            existing = {}
+        existing.update(serializable)
+        serializable = existing
 
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(serializable, f, ensure_ascii=False, indent=2, default=str)

--- a/packages/training/tests/test_evaluate_benchmark.py
+++ b/packages/training/tests/test_evaluate_benchmark.py
@@ -1,0 +1,188 @@
+"""Smoke tests for #69 / #70: HF model loader in evaluate_benchmark.
+
+The actual HF model `output/hf-ja-v02-tiny-hardneg` is produced on RunPod and
+is NOT in the repo, so we cannot run a real end-to-end eval here. Instead we:
+
+- Test pure helpers (`_bio_tags_to_char_spans`, `_derive_hf_entry_key`).
+- Verify `--hf-model` is wired into argparse.
+- Verify the loader fails with a clean error when the model dir does not exist
+  (so a typo gives a useful error instead of silently using spaCy).
+- Verify scores.json triad metadata is injected for HF entries (#70 AC).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from pleno_ner_training.evaluate_benchmark import (
+    _bio_tags_to_char_spans,
+    _derive_hf_entry_key,
+)
+
+TRAINING_ROOT = Path(__file__).resolve().parents[1]
+SCORES_JSON = TRAINING_ROOT / "data" / "benchmark" / "v0.12.0" / "ja" / "scores.json"
+
+
+# ---------------------------------------------------------------------------
+# _bio_tags_to_char_spans: pure helper, no HF deps required
+# ---------------------------------------------------------------------------
+
+
+def test_bio_to_char_spans_simple_b_i_sequence():
+    # text = "山田太郎 さん", tags B-PERSON I-PERSON O O
+    tags = ["B-PERSON", "I-PERSON", "O", "O"]
+    offsets = [(0, 2), (2, 4), (5, 7)]
+    # mismatched length defensively: zip stops at shorter, so trim
+    tags = tags[: len(offsets)]
+    spans = _bio_tags_to_char_spans(tags, offsets)
+    assert spans == [(0, 4, "PERSON")]
+
+
+def test_bio_to_char_spans_two_adjacent_b_b():
+    # B-B without I means two separate entities
+    tags = ["B-PERSON", "B-PERSON"]
+    offsets = [(0, 2), (2, 4)]
+    spans = _bio_tags_to_char_spans(tags, offsets)
+    assert spans == [(0, 2, "PERSON"), (2, 4, "PERSON")]
+
+
+def test_bio_to_char_spans_skips_special_tokens():
+    # Special tokens have offset (0, 0) and must NOT be merged into spans
+    tags = ["O", "B-PERSON", "I-PERSON", "O"]
+    offsets = [(0, 0), (0, 2), (2, 4), (0, 0)]
+    spans = _bio_tags_to_char_spans(tags, offsets)
+    assert spans == [(0, 4, "PERSON")]
+
+
+def test_bio_to_char_spans_label_change_implicit_b():
+    # "I-X" right after "I-Y" must close Y and open X (defensive parse)
+    tags = ["B-PERSON", "I-ORGANIZATION"]
+    offsets = [(0, 2), (2, 4)]
+    spans = _bio_tags_to_char_spans(tags, offsets)
+    assert spans == [(0, 2, "PERSON"), (2, 4, "ORGANIZATION")]
+
+
+def test_bio_to_char_spans_empty_returns_empty():
+    assert _bio_tags_to_char_spans([], []) == []
+
+
+def test_bio_to_char_spans_only_o_tags():
+    spans = _bio_tags_to_char_spans(["O", "O"], [(0, 1), (1, 2)])
+    assert spans == []
+
+
+# ---------------------------------------------------------------------------
+# _derive_hf_entry_key: scores.json key naming
+# ---------------------------------------------------------------------------
+
+
+def test_derive_hf_entry_key_strips_language_tag():
+    assert _derive_hf_entry_key("output/hf-ja-v02-tiny-hardneg") == "hf_v02_tiny_hardneg"
+
+
+def test_derive_hf_entry_key_baseline():
+    assert _derive_hf_entry_key("output/hf-ja-v02-tiny") == "hf_v02_tiny"
+
+
+def test_derive_hf_entry_key_en_variant():
+    assert _derive_hf_entry_key("/abs/path/hf-en-v01") == "hf_v01"
+
+
+def test_derive_hf_entry_key_no_language_tag_passthrough():
+    assert _derive_hf_entry_key("custom-model") == "custom_model"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface: --hf-model is parseable
+# ---------------------------------------------------------------------------
+
+
+def test_cli_hf_model_arg_in_help():
+    out = subprocess.run(
+        [sys.executable, "-m", "pleno_ner_training.evaluate_benchmark", "--help"],
+        cwd=TRAINING_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "--hf-model" in out.stdout
+    assert "--hf-entry-key" in out.stdout
+    assert "--merge" in out.stdout
+
+
+def test_cli_requires_at_least_one_model():
+    """No --model and no --hf-model → argparse error exit 2."""
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pleno_ner_training.evaluate_benchmark",
+            "--version",
+            "v0.12.0",
+        ],
+        cwd=TRAINING_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode != 0
+    assert "--model" in out.stderr or "--hf-model" in out.stderr
+
+
+# ---------------------------------------------------------------------------
+# scores.json shape (#70 AC: existing entry preserved + triad metadata)
+# ---------------------------------------------------------------------------
+
+
+def test_scores_json_preserves_pleno_ner_entry():
+    """#70 AC: 既存 spaCy entry は破壊しない."""
+    if not SCORES_JSON.exists():
+        pytest.skip(f"{SCORES_JSON} not present")
+    data = json.loads(SCORES_JSON.read_text(encoding="utf-8"))
+    assert "pleno_ner" in data
+    assert "ents_f" in data["pleno_ner"]
+
+
+def test_scores_json_has_hf_entries_with_triad():
+    """#70 AC: 最低 2 つの HF entry + triad metadata."""
+    if not SCORES_JSON.exists():
+        pytest.skip(f"{SCORES_JSON} not present")
+    data = json.loads(SCORES_JSON.read_text(encoding="utf-8"))
+    hf_keys = [k for k in data if k.startswith("hf_")]
+    assert len(hf_keys) >= 2, f"need >=2 HF entries, got {hf_keys}"
+    for key in hf_keys:
+        entry = data[key]
+        assert "corpus" in entry, f"{key} missing triad.corpus"
+        assert "metric" in entry, f"{key} missing triad.metric"
+        assert "aggregation" in entry, f"{key} missing triad.aggregation"
+        # Required score fields
+        for field in ("ents_p", "ents_r", "ents_f", "ents_per_type"):
+            assert field in entry, f"{key} missing {field}"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_hf_on_benchmark fails fast on missing model dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("transformers") is None,
+    reason="transformers not installed (only in [hf] extra)",
+)
+def test_evaluate_hf_missing_model_raises(tmp_path: Path):
+    """Calling with a non-existent model path should raise, not crash silently.
+
+    We don't care about the exact exception type — just that it surfaces."""
+    from pleno_ner_training.evaluate_benchmark import evaluate_hf_on_benchmark
+
+    benchmark = tmp_path / "fake.spacy"
+    benchmark.write_bytes(b"not a real docbin")
+    with pytest.raises(Exception):
+        evaluate_hf_on_benchmark(
+            str(tmp_path / "does-not-exist"), benchmark, language="ja"
+        )


### PR DESCRIPTION
## Why

これまで `evaluate_benchmark` は spaCy 専用で、HF model (`hf-ja-v02-tiny-hardneg` 等) は one-off `tmp/eval_v012.py` でしか測れず、スコアの出所が割れて canonical 比較ができなかった。

## What

### #69 — `evaluate_benchmark` に HF loader 追加
- `--hf-model PATH` 引数を追加 (spaCy `--model` と並列、片方必須)
- HF fast tokenizer の `return_offsets_mapping=True` で char offset を取得
- BIO ラベル列を `_bio_tags_to_char_spans` で char-offset スパンに逆変換
- gold doc と同じ tokenization の `Doc` を作って `pred_doc.ents` に詰める
- `Example(pred_doc, gold_doc)` を spaCy `Scorer` に渡し、spaCy 経路と完全に同じ key 構造 (`ents_p`, `ents_r`, `ents_f`, `ents_per_type`) を返す
- `--merge` で既存 scores.json を破壊せず追記

### #70 — `v0.12.0/ja/scores.json` に HF entry 併記
- `hf_v02_tiny` (F1=0.374), `hf_v02_tiny_hardneg` (F1=0.416) を併記
- 数値は `packages/training/models/v02-tiny*-eval-v012.md` から引用 (one-off `tmp/eval_v012.py` 由来)
- 各 entry に triad metadata: `corpus`, `metric`, `aggregation`
- `notes` に「次回は #69 の unified path で再計測すべし」と明記
- 既存 `pleno_ner` entry は破壊しない (後方互換)

## Tests

`packages/training/tests/test_evaluate_benchmark.py` (15 tests, all pass):
- `_bio_tags_to_char_spans` の B/I 連続・特殊トークン無視・暗黙 B 等 6 ケース
- `_derive_hf_entry_key` の言語タグ除去 4 ケース
- CLI 表面: `--hf-model` 認識、`--model` も `--hf-model` も無いと argparse error
- `scores.json` の構造: `pleno_ner` 保存 + HF entry 2 つ + triad
- HF model dir 不在時の fail-fast (smoke; transformers 未 install なら skip)

`uv run pytest tests/ -k evaluate -v` → **18 passed, 0 failed**.

実モデル `output/hf-ja-v02-tiny-hardneg` は repo に無い (RunPod artifact) ので、unit smoke のみで loader を検証。実機での再計測は #69 unified path が動く状態で待機。

## AC

#69:
- [x] `--hf-model` 引数追加
- [x] HF token offset → char offset 逆変換
- [x] spaCy Scorer 互換 output JSON

#70:
- [x] HF entry 2 つ併記
- [x] triad metadata 各 entry に明示
- [x] 既存 spaCy entry 破壊なし

Closes #69
Closes #70