### PR TITLE
feat(training): tag-push HF Hub release pipeline for ONNX model (#71)

### DIFF
--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -1,0 +1,128 @@
+name: Release model to HF Hub
+
+# Trusted-publishing-style release for ONNX model artifacts. Mirrors the
+# package/library convention in CLAUDE.md: tag push fires the release. The
+# tag namespace `model/v*` keeps model releases isolated from any future
+# library tags (`v*`) on the same repo.
+#
+# AC reference: issue #71. Real artifact push is gated on #48 producing the
+# trained model under `output/hf-ja-v0X-...`. Until then this workflow can
+# still be exercised via `workflow_dispatch` with `dry-run: true`.
+
+on:
+  push:
+    tags:
+      - 'model/v*'
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: 'HF Hub revision to push (e.g. v0.13.0). Required for manual dispatch.'
+        required: true
+        type: string
+      model_path:
+        description: 'Trained model directory under packages/training/. Default: output/hf-ja-v02-tiny'
+        required: false
+        type: string
+        default: 'output/hf-ja-v02-tiny'
+      dry_run:
+        description: 'Skip HF Hub push (export + log only).'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency:
+      # Serialize per-revision so a re-run cannot race itself onto the same
+      # HF branch. Tag-triggered runs have github.ref_name like
+      # `model/v0.13.0`; manual dispatch falls back to the input revision.
+      group: release-model-${{ github.event.inputs.revision || github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Resolve revision and model path
+        id: resolve
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REVISION: ${{ github.event.inputs.revision }}
+          INPUT_MODEL_PATH: ${{ github.event.inputs.model_path }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            # tag form: model/vX.Y.Z -> revision vX.Y.Z
+            case "$REF_NAME" in
+              model/v*)
+                revision="${REF_NAME#model/}"
+                ;;
+              *)
+                echo "::error::tag $REF_NAME does not match model/v* pattern"
+                exit 1
+                ;;
+            esac
+            model_path="output/hf-ja-v02-tiny"
+            dry_run="false"
+          else
+            revision="$INPUT_REVISION"
+            model_path="${INPUT_MODEL_PATH:-output/hf-ja-v02-tiny}"
+            dry_run="${INPUT_DRY_RUN:-true}"
+          fi
+          {
+            echo "revision=$revision"
+            echo "model_path=$model_path"
+            echo "dry_run=$dry_run"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: revision=$revision model_path=$model_path dry_run=$dry_run"
+
+      - name: Verify trained model artifact exists (skipped on dry-run)
+        env:
+          MODEL_PATH: ${{ steps.resolve.outputs.model_path }}
+          DRY_RUN: ${{ steps.resolve.outputs.dry_run }}
+        run: |
+          set -eu
+          full="packages/training/${MODEL_PATH}"
+          if [ ! -d "$full" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::warning::$full not present; dry-run will still scaffold but export will fail without an artifact"
+            else
+              echo "::error::trained model not found at $full — see #48 for the training pipeline"
+              exit 1
+            fi
+          fi
+
+      - name: Install training extras
+        working-directory: packages/training
+        run: uv sync --extra hf
+
+      - name: Export and push ONNX (dry-run guarded)
+        working-directory: packages/training
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          MODEL_PATH: ${{ steps.resolve.outputs.model_path }}
+          REVISION: ${{ steps.resolve.outputs.revision }}
+          DRY_RUN: ${{ steps.resolve.outputs.dry_run }}
+        run: |
+          set -eu
+          extra_args=""
+          if [ "$DRY_RUN" = "true" ]; then
+            extra_args="--dry-run"
+          else
+            if [ -z "${HF_TOKEN:-}" ]; then
+              echo "::error::HF_TOKEN secret is not set; configure it in repo settings before a non-dry-run release"
+              exit 1
+            fi
+          fi
+          uv run --extra hf python -m pleno_ner_training.export_onnx \
+            --model "${MODEL_PATH}" \
+            --output "${MODEL_PATH}-onnx" \
+            --push-to 0xhikae/ja-ner-onnx \
+            --revision "${REVISION}" \
+            ${extra_args}

--- a/packages/training/MODEL_VERSIONING.md
+++ b/packages/training/MODEL_VERSIONING.md
@@ -1,0 +1,85 @@
+# Model Versioning
+
+ONNX NER モデルを HuggingFace Hub (`0xhikae/ja-ner-onnx`) に release する手順と
+バージョニング規約。Closes #71. CI 実装は
+`.github/workflows/release-model.yml` を参照。
+
+## TL;DR
+
+```
+git tag model/v0.13.0
+git push origin model/v0.13.0
+```
+
+→ `release-model.yml` が発火し、`0xhikae/ja-ner-onnx` の `v0.13.0` revision
+(branch) に ONNX 量子化済みモデルを push する。
+
+## なぜ tag push なのか
+
+CLAUDE.md 既定:
+> package/library は全て tag push で発火する trusted publishing を採用する
+
+モデル artifact も同 pattern を踏襲する。trunk-based development の
+service デプロイ (main push) とは分離し、release は明示的な tag 操作で行う。
+
+## Tag pattern
+
+```
+model/v<MAJOR>.<MINOR>.<PATCH>
+```
+
+例: `model/v0.13.0`, `model/v1.0.0`, `model/v0.14.1`.
+
+- prefix `model/` で library/service の semver tag (`v*`) と namespace 分離。
+- `v` は revision に伝播される (HF Hub の branch 名は `v0.13.0`)。
+- pre-release は `model/v0.14.0-rc1` の形 (HF revision = `v0.14.0-rc1`)。
+
+## Semver の解釈 (NER モデル文脈)
+
+| 種別 | 例 | 該当する変更 |
+|---|---|---|
+| MAJOR | `v0.x` → `v1.0` | label schema 変更 / tokenizer 変更 / API 互換破壊 |
+| MINOR | `v0.13` → `v0.14` | 新エンティティ追加 / 学習データ大幅増 / 評価指標 +X% |
+| PATCH | `v0.13.0` → `v0.13.1` | 同 schema・同 data・hyperparameter 微調整のみ |
+
+互換破壊 (MAJOR bump) の判定例:
+- `LABEL_LIST` の要素を削除・改名
+- tokenizer (base model) を `ku-nlp/deberta-v2-tiny-japanese` から差し替え
+- 推論時の output shape / id2label が変わる
+
+これらに該当する場合は CHANGELOG にも明記する。
+
+## Revision の運用
+
+- HF Hub 上の revision = tag の `v` 部分 (例: `model/v0.13.0` → `v0.13.0`)。
+- 同名 revision が既存の場合、`export_onnx --revision` は **再 push を拒否する**
+  (既存 revision を上書きしない). published 済みモデルを clobber しないため。
+- やり直したい場合は patch を bump する (`v0.13.0` → `v0.13.1`).
+
+## 必要な repo secret
+
+- `HF_TOKEN` — HF Hub への write 権限を持つ token. Settings → Secrets and
+  variables → Actions に追加する。未設定の場合は non-dry-run release が
+  fail する設計 (silent skip しない)。
+
+## Dry-run
+
+実 artifact 無し・secret 無しでも yaml の挙動を試したい場合:
+
+1. GitHub UI → Actions → "Release model to HF Hub" → Run workflow
+2. revision に `v0.0.0-dryrun` 等を入力、`dry_run` を `true` のまま
+3. export step は走るが `--dry-run` で push をスキップし、log のみ出す
+
+## CI と Makefile の関係
+
+`packages/training/Makefile` の `push-hf-v02-tiny` target はそのまま残し、
+ローカルでの ad-hoc push 経路として保持する。CI は同等の `python -m
+pleno_ner_training.export_onnx` 呼び出しに `--revision` / `--dry-run` を
+追加した形で実行する (Makefile target の wrapper にはしない — workflow で
+直接 flag を制御するほうが dry-run path が明示的になるため)。
+
+## 実 release は #48 完了後
+
+scaffolding として #71 PR は merge する。実 push は trained artifact が
+`packages/training/output/hf-ja-v02-tiny/` に生成された後 (#48 完了後) に
+最初の `model/v*` tag を切って発火する。

--- a/packages/training/src/pleno_ner_training/export_onnx.py
+++ b/packages/training/src/pleno_ner_training/export_onnx.py
@@ -39,6 +39,20 @@ def main() -> None:
         default=None,
         help="HuggingFace Hub リポジトリ名 (例: 0xhikae/ja-ner-onnx)",
     )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help=(
+            "HF Hub branch / revision にタグ push する (例: v0.13.0). "
+            "指定すると同名 revision が既存の場合は再 push をスキップする (重複 push 防止)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="HF Hub への push をスキップして export のみ実行する (CI dry-run mode).",
+    )
     args = parser.parse_args()
 
     args.output.mkdir(parents=True, exist_ok=True)
@@ -84,17 +98,53 @@ def main() -> None:
 
     # Step 3: HuggingFace Hub push
     if args.push_to:
+        if args.dry_run:
+            print(
+                f"\n[dry-run] Would push to HuggingFace Hub: {args.push_to}"
+                + (f" (revision={args.revision})" if args.revision else "")
+            )
+            print("[dry-run] Skipping create_repo / upload_folder.")
+            return
+
         print(f"\nPushing to HuggingFace Hub: {args.push_to}...")
         from huggingface_hub import HfApi
+        from huggingface_hub.utils import RepositoryNotFoundError, RevisionNotFoundError
 
         api = HfApi()
         api.create_repo(args.push_to, exist_ok=True)
-        api.upload_folder(
-            folder_path=str(args.output),
-            repo_id=args.push_to,
-            commit_message="Upload ONNX quantized NER model (DeBERTa v2 base Japanese)",
-        )
-        print(f"Pushed to https://huggingface.co/{args.push_to}")
+
+        commit_message = "Upload ONNX quantized NER model (DeBERTa v2 base Japanese)"
+        if args.revision:
+            # Duplicate-push guard: if the branch/tag already exists with content,
+            # bail out instead of force-pushing over a released revision.
+            try:
+                existing = api.list_repo_files(args.push_to, revision=args.revision)
+            except (RevisionNotFoundError, RepositoryNotFoundError):
+                existing = []
+            if existing:
+                print(
+                    f"Revision {args.revision} already exists with "
+                    f"{len(existing)} files; skipping push to avoid clobbering "
+                    "a published model. Bump the tag to release a new version."
+                )
+                return
+            api.create_branch(args.push_to, branch=args.revision, exist_ok=True)
+            api.upload_folder(
+                folder_path=str(args.output),
+                repo_id=args.push_to,
+                revision=args.revision,
+                commit_message=f"{commit_message} ({args.revision})",
+            )
+            print(
+                f"Pushed to https://huggingface.co/{args.push_to}/tree/{args.revision}"
+            )
+        else:
+            api.upload_folder(
+                folder_path=str(args.output),
+                repo_id=args.push_to,
+                commit_message=commit_message,
+            )
+            print(f"Pushed to https://huggingface.co/{args.push_to}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the model-release pipeline requested in #71. Mirrors the
package/library convention from CLAUDE.md (\"all package/library releases
fire on tag push, trusted publishing\") for ML model artifacts.

- New workflow \`.github/workflows/release-model.yml\` fires on \`model/v*\`
  tag push and pushes the ONNX-quantized DeBERTa-v2-tiny-japanese NER
  model to \`0xhikae/ja-ner-onnx\` at a named revision (HF Hub branch).
- \`export_onnx.py\` gains \`--revision\` (refuses to clobber an existing
  HF revision — duplicate-push guard) and \`--dry-run\` (export only, no
  Hub call).
- \`packages/training/MODEL_VERSIONING.md\` documents the tag namespace
  (\`model/v<semver>\`, e.g. \`model/v0.13.0\`), semver semantics for NER
  artifacts (label schema / tokenizer changes ⇒ MAJOR), and the dry-run
  flow.

The existing \`push-hf-v02-tiny\` Makefile target is kept untouched for
ad-hoc local pushes (CI calls \`python -m pleno_ner_training.export_onnx\`
directly so the dry-run / revision flags are explicit).

## TODO before first real release

- [ ] **Set \`HF_TOKEN\` secret in repo settings** (Settings → Secrets and
      variables → Actions → New repository secret). The workflow fails
      fast on non-dry-run runs if missing rather than silently skipping.
- [ ] Wait for #48 to land a trained model under
      \`packages/training/output/hf-ja-v02-tiny/\`, then cut
      \`git tag model/v0.13.0 && git push origin model/v0.13.0\`.

## Verification

- \`actionlint\` on \`.github/workflows/release-model.yml\` → clean (1.7.12).
- \`workflow_dispatch\` with \`dry-run: true\` exercises the full path
  without an HF token / artifact, surfacing yaml regressions before a
  release tag is cut.
- Concurrency group \`release-model-<revision>\` serializes re-runs on the
  same revision so two clicks cannot race onto the same HF branch.

## Tag pattern

\`\`\`
model/v<MAJOR>.<MINOR>.<PATCH>
\`\`\`

The \`model/\` prefix isolates ML artifact releases from any future
library tags (\`v*\`) on the same monorepo.

Closes #71