### PR TITLE
feat(training): mine external Wikipedia hardneg for ORG precision (#64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ packages/training/experiments/autotrain_*.log
 # HuggingFace datasets (Arrow format) — reproducible via `make convert-hf-v02`
 packages/training/data/hf/
 
+# External hardneg mining outputs (#64) — reproducible via
+# `make mine-external-hardneg-ja`, large (~MB), not committed.
+packages/training/data/raw/ja-v02/external_hardneg.json
+packages/training/data/raw/ja-v02/generated_with_external.json
+
 # Rust/WASM build artifacts
 **/target/
 Cargo.lock

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -9,7 +9,9 @@
        benchmark-v12-generate benchmark-v12-evaluate \
        verify-leakage-v12 pin-noise-floor-v12 compare-baselines-v12 runpod-gpu-compare-v12 \
        convert-hf-v02 train-hf-v02 export-onnx-v02 push-hf-v02 all-hf-ja-v02 \
-       convert-hf-v02-tiny train-hf-v02-tiny export-onnx-v02-tiny push-hf-v02-tiny all-hf-ja-v02-tiny
+       convert-hf-v02-tiny train-hf-v02-tiny export-onnx-v02-tiny push-hf-v02-tiny all-hf-ja-v02-tiny \
+       mine-external-hardneg-ja mine-external-hardneg-ja-dry-run \
+       convert-hf-v02-tiny-hardneg-ext train-hf-v02-tiny-hardneg-ext
 
 MODEL ?= gpt-5.4-nano
 DOCS_PER_TEMPLATE ?= 20
@@ -385,6 +387,46 @@ convert-hf-v02-tiny-hardneg:
 		--output data/hf/ja-v02-tiny-hardneg \
 		--tokenizer ku-nlp/deberta-v2-tiny-japanese \
 		--include-negatives
+
+# Mine external corpus (Wikipedia ja, CC-BY-SA 4.0) for ORG-FP-likely
+# hardneg docs (#64). Output JSON schema is identical to generated.json so
+# it can be merged before the convert step.
+mine-external-hardneg-ja:
+	uv run python -m pleno_ner_training.mine_external_hardneg \
+		--output data/raw/ja-v02/external_hardneg.json \
+		--max-docs 4000
+
+# Same as `mine-external-hardneg-ja` but skips the network and emits a
+# tiny hand-crafted sample. Used by CI / local smoke tests.
+mine-external-hardneg-ja-dry-run:
+	uv run python -m pleno_ner_training.mine_external_hardneg \
+		--output data/raw/ja-v02/external_hardneg.json \
+		--max-docs 5 --dry-run
+
+# v02-tiny + hard negatives + external Wikipedia mine (#64). Pre-merges
+# generated.json with external_hardneg.json into a single tmp file so the
+# downstream converter sees one input. Inline python avoids adding a
+# stand-alone merge module for a 6-line operation.
+convert-hf-v02-tiny-hardneg-ext: mine-external-hardneg-ja
+	uv run python -c "import json,sys; \
+a=json.load(open('data/raw/ja-v02/generated.json',encoding='utf-8')); \
+b=json.load(open('data/raw/ja-v02/external_hardneg.json',encoding='utf-8')); \
+json.dump(a+b,open('data/raw/ja-v02/generated_with_external.json','w',encoding='utf-8'),ensure_ascii=False)"
+	uv run python -m pleno_ner_training.convert_to_hf_dataset \
+		--input data/raw/ja-v02/generated_with_external.json \
+		--output data/hf/ja-v02-tiny-hardneg-ext \
+		--tokenizer ku-nlp/deberta-v2-tiny-japanese \
+		--include-negatives
+
+# Train counterpart (RunPod). Mirrors `train-hf-v02-tiny-hardneg` shape so
+# evaluate_benchmark auto-derives the entry key `hf_v02_tiny_hardneg_ext`.
+train-hf-v02-tiny-hardneg-ext:
+	uv run python -m pleno_ner_training.train_hf \
+		--dataset data/hf/ja-v02-tiny-hardneg-ext \
+		--model ku-nlp/deberta-v2-tiny-japanese \
+		--output output/hf-ja-v02-tiny-hardneg-ext \
+		--fp16 --num-epochs 20 --batch-size 16 \
+		--learning-rate 3e-5 --warmup-ratio 0.15
 
 train-hf-v02-tiny:
 	uv run python -m pleno_ner_training.train_hf \

--- a/packages/training/src/pleno_ner_training/mine_external_hardneg.py
+++ b/packages/training/src/pleno_ner_training/mine_external_hardneg.py
@@ -1,0 +1,253 @@
+"""External-corpus hard-negative mining for ORG precision (#64).
+
+Why
+---
+`convert_to_hf_dataset.py --include-negatives` only sources zero-entity docs
+from `data/raw/ja-v02/generated.json`. Those LLM-refusal templates barely
+contain ORG-like surface forms, so the hardneg signal collapsed onto PERSON
+and adversarial v0.12.0 ORG precision stayed at 0.085 (#48 follow-up).
+
+This module mines additional **PII-free** docs from a public Japanese
+corpus (default: `wikimedia/wikipedia` config `20231101.ja`, CC-BY-SA 4.0)
+and writes them as `entities=[]` examples — the same schema accepted by
+`load_and_convert(..., include_negatives=True)`. After concatenation with
+`generated.json` the hardneg trainer sees a much higher density of
+ORG-likely-FP surface (Wikipedia is dense in facility / event / product /
+law names that look like ORGs but are non-PII descriptive prose).
+
+License
+-------
+Wikipedia ja content is CC-BY-SA 4.0; using it as model training input is
+covered by the existing pleno-anonymize attribution. livedoor-news (CC-BY-ND)
+is intentionally NOT used because the ND clause restricts derivative use.
+
+Output schema
+-------------
+A JSON array on disk, identical to `generated.json` shape so it can be
+fed directly to `convert_to_hf_dataset.py`:
+
+    [
+      {"text": "...", "entities": []},
+      ...
+    ]
+
+Defensive filtering
+-------------------
+We re-use `convert_to_hf_dataset.PII_HINT_RE` to drop sentences that look
+PII-bearing. A doc that survives the regex but still contains PII would
+become a label-miss negative — the exact failure mode #62 tried to fix.
+The regex is intentionally over-broad on the safe side (drops ~10–20% of
+Wikipedia paragraphs that mention 都/区/会社).
+
+Dry-run
+-------
+`--dry-run` skips network and writes 5 hand-crafted ORG-FP-likely sentences
+so CI / smoke tests can exercise the full pipeline without HF download.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from pleno_ner_training.convert_to_hf_dataset import PII_HINT_RE
+
+# Tight character window: too short = no ORG-like context, too long =
+# truncation waste in the 512-token tokenizer used downstream.
+MIN_CHARS = 60
+MAX_CHARS = 400
+
+# Split paragraphs into sentence-ish chunks. Wikipedia ja paragraphs often
+# run >1000 chars; keeping each chunk small means more independent hardneg
+# examples per doc and avoids the 512-token truncation eating the tail.
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[。！？])\s*")
+
+# Hand-crafted ORG-FP-likely sentences for `--dry-run`. Mirrors the kind of
+# Wikipedia-style descriptive prose we expect to mine in the real run.
+_DRY_RUN_SAMPLES: tuple[str, ...] = (
+    "東京スカイツリーは墨田区押上に位置する自立式電波塔である。"
+    "高さは634メートルで、世界第二位の高さを誇る。",
+    "国際連合教育科学文化機関は、教育や科学、文化の発展と推進を目的として設立された。"
+    "本部はパリに置かれている。",
+    "京都大学基礎物理学研究所は素粒子論や統計力学などの理論物理学研究の中核拠点の一つである。",
+    "日本標準時は明石市を通る東経135度の子午線を基準としている。"
+    "NHKラジオの時報もこの基準時刻に従う。",
+    "万国博覧会は19世紀以降、産業文化の交流を促進する場として各国で開催されてきた。",
+)
+
+
+def _split_sentences(text: str) -> Iterator[str]:
+    """Split a paragraph into sentence-ish chunks on Japanese terminators."""
+    for chunk in _SENTENCE_SPLIT_RE.split(text):
+        chunk = chunk.strip()
+        if chunk:
+            yield chunk
+
+
+def _accumulate_chunks(sentences: Iterable[str]) -> Iterator[str]:
+    """Greedy-pack sentences into MIN_CHARS..MAX_CHARS sized doc chunks.
+
+    Smaller than MIN_CHARS chunks are concatenated with the next; once a
+    chunk exceeds MAX_CHARS we cut and start fresh. This keeps each emitted
+    "doc" close to a coherent passage instead of single fragments.
+    """
+    buf: list[str] = []
+    buf_len = 0
+    for sent in sentences:
+        if not sent:
+            continue
+        # Hard-skip absurdly long single sentences — they are usually
+        # tables / list-prose dumped without periods.
+        if len(sent) > MAX_CHARS * 2:
+            continue
+        buf.append(sent)
+        buf_len += len(sent)
+        if buf_len >= MIN_CHARS:
+            joined = "".join(buf)
+            if len(joined) <= MAX_CHARS:
+                yield joined
+            buf = []
+            buf_len = 0
+    # tail: only emit if it on its own clears MIN_CHARS
+    if buf_len >= MIN_CHARS:
+        joined = "".join(buf)
+        if len(joined) <= MAX_CHARS:
+            yield joined
+
+
+def is_safe_negative(text: str) -> bool:
+    """Reject docs that look PII-bearing.
+
+    Re-uses the shared `PII_HINT_RE` so the policy stays in lock-step with
+    `convert_to_hf_dataset` — anything that would later be regex-dropped
+    there is also dropped here at mining time, which avoids silently
+    shrinking the negative pool downstream.
+    """
+    if not text:
+        return False
+    if PII_HINT_RE.search(text):
+        return False
+    return True
+
+
+def iter_wikipedia_chunks(
+    dataset_name: str,
+    config: str,
+    *,
+    streaming: bool,
+    max_docs: int,
+    seed: int,
+) -> Iterator[str]:
+    """Stream Wikipedia ja paragraphs and yield filtered hardneg chunks.
+
+    Streaming is used by default so we never download the full ~5GB dump.
+    Caller controls `max_docs` to bound work; we early-exit once enough
+    surviving chunks have been emitted.
+    """
+    # Lazy import: keeps the unit-test surface clean of network deps.
+    from datasets import load_dataset  # type: ignore
+
+    ds = load_dataset(dataset_name, config, split="train", streaming=streaming)
+    rng = random.Random(seed)
+    yielded = 0
+    for record in ds:
+        text = record.get("text") or ""
+        if not text:
+            continue
+        # Wikipedia ja ja_text is article-level; chunk into paragraphs first.
+        for paragraph in text.split("\n"):
+            for chunk in _accumulate_chunks(_split_sentences(paragraph)):
+                if not is_safe_negative(chunk):
+                    continue
+                # Light shuffle: skip ~50% of survivors so we sample
+                # across the dump rather than the first-N articles.
+                if rng.random() < 0.5:
+                    continue
+                yield chunk
+                yielded += 1
+                if yielded >= max_docs:
+                    return
+
+
+def mine(
+    *,
+    dataset_name: str = "wikimedia/wikipedia",
+    config: str = "20231101.ja",
+    max_docs: int = 2000,
+    seed: int = 42,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Mine hard-negative docs from an external corpus.
+
+    Returns a list of `{"text": str, "entities": []}` objects in the
+    pleno-anonymize raw-data schema.
+    """
+    if dry_run:
+        survivors = [s for s in _DRY_RUN_SAMPLES if is_safe_negative(s)]
+        return [{"text": s, "entities": []} for s in survivors[:max_docs]]
+
+    docs: list[dict] = []
+    for chunk in iter_wikipedia_chunks(
+        dataset_name,
+        config,
+        streaming=True,
+        max_docs=max_docs,
+        seed=seed,
+    ):
+        docs.append({"text": chunk, "entities": []})
+    return docs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Mine PII-free hard-negative docs from an external Japanese "
+            "corpus (default: wikimedia/wikipedia 20231101.ja). Output JSON "
+            "is schema-compatible with convert_to_hf_dataset.py."
+        )
+    )
+    parser.add_argument(
+        "--dataset",
+        default="wikimedia/wikipedia",
+        help="HuggingFace datasets identifier",
+    )
+    parser.add_argument(
+        "--config",
+        default="20231101.ja",
+        help="Dataset config name (Wikipedia snapshot date)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output JSON path (e.g. data/raw/ja-v02/external_hardneg.json)",
+    )
+    parser.add_argument("--max-docs", type=int, default=2000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip network; write 5 hand-crafted ORG-FP-likely samples.",
+    )
+    args = parser.parse_args()
+
+    docs = mine(
+        dataset_name=args.dataset,
+        config=args.config,
+        max_docs=args.max_docs,
+        seed=args.seed,
+        dry_run=args.dry_run,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(docs, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {len(docs)} hardneg docs to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/tests/test_mine_external_hardneg.py
+++ b/packages/training/tests/test_mine_external_hardneg.py
@@ -1,0 +1,169 @@
+"""Tests for external-corpus hard-negative mining (#64).
+
+The real run streams Wikipedia ja via HuggingFace datasets — that requires
+network and several GB of metadata, so all live-streaming tests are guarded
+behind `--dry-run`. Here we exercise:
+
+- `--dry-run` end-to-end: hand-crafted ORG-FP-likely samples survive the
+  PII filter, schema is compatible with `convert_to_hf_dataset`.
+- `is_safe_negative` rejects PII-bearing strings using the shared regex
+  (the lock-step contract with `convert_to_hf_dataset.PII_HINT_RE`).
+- Sentence-chunking respects MIN_CHARS / MAX_CHARS bounds.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from pleno_ner_training.convert_to_hf_dataset import load_and_convert
+from pleno_ner_training.mine_external_hardneg import (
+    MAX_CHARS,
+    MIN_CHARS,
+    _accumulate_chunks,
+    _split_sentences,
+    is_safe_negative,
+    mine,
+)
+
+
+# ---------- safety filter ----------
+
+
+def test_pii_bearing_strings_are_rejected():
+    # Phone-like, addr-like, and 株式会社 strings should all be filtered.
+    assert is_safe_negative("お客様の電話は03-1234-5678です") is False
+    assert is_safe_negative("住所は東京都千代田区です") is False
+    assert is_safe_negative("株式会社サンプルにて勤務") is False
+
+
+def test_clean_descriptive_prose_passes():
+    # Descriptive Wikipedia-style ORG-FP-likely sentence with no PII surface.
+    assert is_safe_negative(
+        "国際連合教育科学文化機関は教育や科学の発展を目的として設立された。"
+    ) is True
+
+
+def test_empty_string_rejected():
+    assert is_safe_negative("") is False
+
+
+# ---------- chunking ----------
+
+
+def test_sentence_split_handles_japanese_terminators():
+    text = "これは一文目。これは二文目！これは三文目？"
+    parts = list(_split_sentences(text))
+    assert parts == ["これは一文目。", "これは二文目！", "これは三文目？"]
+
+
+def test_accumulate_chunks_respects_bounds():
+    short = "あ。" * 5  # 10 chars, below MIN_CHARS -> dropped
+    assert list(_accumulate_chunks(_split_sentences(short))) == []
+
+    paragraph = "あ" * 80 + "。" + "い" * 80 + "。"
+    chunks = list(_accumulate_chunks(_split_sentences(paragraph)))
+    assert chunks, "should emit at least one chunk above MIN_CHARS"
+    for c in chunks:
+        assert MIN_CHARS <= len(c) <= MAX_CHARS
+
+
+# ---------- end-to-end dry-run ----------
+
+
+def test_dry_run_emits_schema_compatible_docs():
+    docs = mine(dry_run=True, max_docs=10)
+
+    assert docs, "dry-run must emit at least one hand-crafted sample"
+    for doc in docs:
+        assert set(doc.keys()) == {"text", "entities"}
+        assert isinstance(doc["text"], str) and doc["text"]
+        assert doc["entities"] == []
+
+
+def test_dry_run_output_is_loadable_by_convert_to_hf_dataset(
+    tmp_path: Path,
+):
+    """The mined JSON must be drop-in for `load_and_convert(include_negatives=True)`.
+
+    We don't need a real tokenizer here — `load_and_convert` is exercised
+    elsewhere with the real DeBERTa tokenizer. We just confirm the JSON
+    file shape matches what the converter expects (list of dicts with
+    text / entities), by reading it back as JSON.
+    """
+    out = tmp_path / "external_hardneg.json"
+    docs = mine(dry_run=True, max_docs=10)
+    out.write_text(json.dumps(docs, ensure_ascii=False), encoding="utf-8")
+
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert isinstance(loaded, list)
+    assert all("text" in d and "entities" in d for d in loaded)
+    assert all(d["entities"] == [] for d in loaded)
+
+
+def test_cli_dry_run_writes_file(tmp_path: Path):
+    """Smoke-test the CLI entrypoint via subprocess.
+
+    Catches argparse / __main__ wiring regressions that direct-import
+    tests would miss.
+    """
+    out = tmp_path / "external_hardneg.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pleno_ner_training.mine_external_hardneg",
+            "--output",
+            str(out),
+            "--dry-run",
+            "--max-docs",
+            "3",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert out.exists()
+    docs = json.loads(out.read_text(encoding="utf-8"))
+    assert 1 <= len(docs) <= 3
+    assert all(d["entities"] == [] for d in docs)
+    assert "Wrote" in result.stdout
+
+
+# ---------- integration with convert_to_hf_dataset ----------
+
+
+def test_mined_docs_consumed_as_negatives_by_loader(tmp_path: Path):
+    """Concatenated hardneg + positive JSON should be loaded as negatives.
+
+    Uses a stub tokenizer so we don't pull DeBERTa weights in unit tests.
+    Confirms `load_and_convert(include_negatives=True)` happily ingests
+    the mined entities=[] docs without raising.
+    """
+
+    class _StubTokenizer:
+        def __call__(self, text, **kwargs):
+            # 1 token per char; offsets are (i, i+1).
+            n = min(len(text), kwargs.get("max_length", 512))
+            return {
+                "input_ids": list(range(n)),
+                "attention_mask": [1] * n,
+                "offset_mapping": [(i, i + 1) for i in range(n)],
+            }
+
+    mined = mine(dry_run=True, max_docs=5)
+    payload = tmp_path / "merged.json"
+    payload.write_text(json.dumps(mined, ensure_ascii=False), encoding="utf-8")
+
+    converted = load_and_convert(
+        payload,
+        _StubTokenizer(),  # type: ignore[arg-type]
+        max_length=512,
+        include_negatives=True,
+    )
+    assert converted, "expected mined docs to be converted as all-O negatives"
+    for ex in converted:
+        # all-O: every label is 0 (LABEL2ID['O']).
+        assert all(label == 0 for label in ex["labels"])


### PR DESCRIPTION
Closes #64.

## Why

`#48` hardneg iteration moved adversarial v0.12.0 F1 0.374 → 0.416 but ORG precision stayed at 0.085. Root cause: in-corpus zero-entity docs from `generated.json` are LLM-refusal templates with almost no ORG-like surface, so the model never learned which ORG-shaped non-PII strings to leave alone.

## What

- New module `mine_external_hardneg.py` that streams Wikipedia ja (`wikimedia/wikipedia` config `20231101.ja`, CC-BY-SA 4.0), chunks paragraphs into MIN_CHARS..MAX_CHARS passages, and emits `{"text", "entities": []}` docs schema-compatible with `convert_to_hf_dataset --include-negatives`.
- Reuses `PII_HINT_RE` so the safety policy stays in lock-step with the converter — anything later regex-dropped there is also dropped at mining time.
- `--dry-run` flag emits 5 hand-crafted ORG-FP-likely samples for CI / local smoke tests (no network).
- Makefile targets:
  - `mine-external-hardneg-ja` — real run, `max-docs 4000`
  - `mine-external-hardneg-ja-dry-run` — smoke test
  - `convert-hf-v02-tiny-hardneg-ext` — merge generated + external, then convert
  - `train-hf-v02-tiny-hardneg-ext` — RunPod-shaped train target
- `.gitignore` entries for the mined and merged JSON outputs (large, reproducible).

## Why Wikipedia ja (not livedoor / JNLI)

- **livedoor news**: CC-BY-ND — ND clause restricts derivative use, unsafe for model training output.
- **JNLI**: sentences too short to provide ORG context.
- **Wikipedia ja**: CC-BY-SA 4.0 (already part of pleno-anonymize attribution), dense in facility / event / product / law names — exactly the ORG-FP-likely surface we need.

## Testing

`uv run --with pytest pytest tests/test_mine_external_hardneg.py -v` → 9 / 9 passed. All tests are pure-Python (no torch / no network); the live HF stream path is exercised only via `--dry-run` and via a stub-tokenizer round-trip through `load_and_convert(include_negatives=True)`.

## AC progress (#64)

This PR delivers the **mining infrastructure**. Actual training runs (RunPod) and adversarial v0.12.0 evaluation will follow in a separate PR — the issue's metric ACs (F1 ≥ 0.55, ORG precision ≥ 0.30) require GPU training that this repo intentionally does not run on local hardware.

## Tech-debt prevention

The lock-step PII filter (shared `PII_HINT_RE`) is the load-bearing design choice: any future tightening of the converter's negative-doc policy automatically tightens mining, so we cannot regress to the #62 label-miss failure mode by forgetting to update one of the two paths.