### PR TITLE
feat(training): strengthen PII heuristic filter to plug hardneg leak (#66, #67)

### DIFF
--- a/packages/training/src/pleno_ner_training/convert_to_hf_dataset.py
+++ b/packages/training/src/pleno_ner_training/convert_to_hf_dataset.py
@@ -19,15 +19,68 @@ from transformers import AutoTokenizer, PreTrainedTokenizerFast
 # Heuristic patterns to drop zero-entity docs that actually contain PII text
 # (label-miss noise). Keeping these as O-only examples would teach the model
 # to NOT tag real PII -- the opposite of what we want.
+#
+# History: the original (v0) set caught only ~16% of zero-entity docs, leaking
+# ADDRESS / BANK_ACCOUNT / DATE_OF_BIRTH look-alikes into the hard-negative
+# pool and causing the regression observed in #66 (hardneg run vs. baseline:
+# ADDRESS F1 0.692 → 0.667, BANK_ACCOUNT F1 0.615 → 0.558). The expanded set
+# below (#67) lifts the catch rate to ~25% on `ja-v02/generated.json` by
+# adding postal codes (〒), Japanese phone numbers, email, 16-digit card-like
+# blocks, IBAN, 口座番号 / 普通 / 当座, bank+digits, the remaining 41
+# prefectures, [市区町村]+丁目, ISO-style YYYY年M月D日, 名義+name and the
+# residual XML/《》-tagged PII spans that leaked from prompt templates.
 PII_HINT_RE = re.compile(
     "|".join(
         [
+            # Generic digit clusters (legacy, kept for back-compat).
             r"\d{1,2}-\d{1,4}-\d{1,4}",
             r"\d{4,}\s*-?\s*\d{4,}",
+            # Honorific-suffixed personal names.
             r"[一-龥]{2,4}\s*[一-龥]{1,3}\s*(さん|様|氏)",
+            # Corporate entities.
             r"(株式会社|有限会社|合同会社)",
-            r"(東京都|大阪府|京都府|北海道|沖縄県|千代田区|港区|渋谷区)",
+            # Era-formatted dates (legacy, narrow set).
             r"(平成|令和|昭和)\s*[一-龥0-9]+\s*年",
+            # --- #67: address-bearing phrases ---------------------------------
+            # Postal code 〒XXX-XXXX (with optional space / no hyphen).
+            r"〒\s*\d{3}-?\d{4}",
+            # All 47 prefectures (the original list only had 6).
+            r"(東京都|大阪府|京都府|北海道|沖縄県"
+            r"|神奈川県|埼玉県|千葉県|愛知県|兵庫県|福岡県|静岡県|広島県"
+            r"|宮城県|新潟県|岡山県|長野県|岐阜県|茨城県|栃木県|群馬県"
+            r"|三重県|奈良県|滋賀県|和歌山県|福井県|石川県|富山県|山梨県"
+            r"|岩手県|青森県|秋田県|山形県|福島県|鳥取県|島根県|山口県"
+            r"|徳島県|香川県|愛媛県|高知県|佐賀県|長崎県|熊本県|大分県"
+            r"|宮崎県|鹿児島県"
+            r"|千代田区|港区|渋谷区)",
+            # 市/区/町/村 + 丁目 (chome) — strong address signal.
+            r"[一-龥]{1,4}(市|区|町|村)[一-龥]{1,8}\d+丁目",
+            # 1-2-3 / 1-2-3-4 banchi-go style.
+            r"\d+\s*[-－]\s*\d+\s*[-－]\s*\d+",
+            # --- #67: contact identifiers -------------------------------------
+            # Japanese landline / mobile phone (0X-XXXX-XXXX, 0XXX-XX-XXXX, …).
+            r"0\d{1,4}-\d{1,4}-\d{4}",
+            # Email address.
+            r"[\w.+-]+@[\w-]+\.[\w.-]+",
+            # --- #67: financial identifiers -----------------------------------
+            # 16-digit credit-card / IBAN-ish 4-block group.
+            r"\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}",
+            # IBAN (ISO 13616).
+            r"[A-Z]{2}\d{2}[A-Z0-9]{10,30}",
+            # 口座番号 / 普通 / 当座 + digits.
+            r"(口座番号|普通|当座)\s*[:：]?\s*\d{3,8}",
+            # Bank/branch keyword followed by a 4+ digit run within 30 chars.
+            r"(銀行|信金|信用金庫|信用組合|労金|農協|ゆうちょ)[^\n]{0,30}\d{4,}",
+            # --- #67: birthdate / personal -----------------------------------
+            # ISO-style YYYY年M月D日.
+            r"\d{4}\s*年\s*\d{1,2}\s*月\s*\d{1,2}\s*日",
+            # 漢字氏名 + (カナ読み) — the name+furigana pattern in dialogues.
+            r"[一-龥]{1,4}\s*[一-龥]{1,4}[（(][ァ-ヶー\s]{2,15}[)）]",
+            # 名義 + 漢字/カナ name.
+            r"名義[はがでも:：\s]+[一-龥ァ-ヶー]{2,8}",
+            # --- #67: residual PII XML/《》 prompt-template artefacts ---------
+            r"<(PERSON|ADDRESS|ORGANIZATION|DATE_OF_BIRTH|BANK_ACCOUNT)\b",
+            r"《(PERSON|ADDRESS|ORGANIZATION|DATE_OF_BIRTH|BANK_ACCOUNT)>",
         ]
     )
 )

--- a/packages/training/tests/test_pii_filter.py
+++ b/packages/training/tests/test_pii_filter.py
@@ -1,0 +1,152 @@
+"""Unit tests for the zero-entity hard-negative PII filter (#67).
+
+`PII_HINT_RE` lives in `convert_to_hf_dataset.py` and is the gate that
+decides whether an `entities=[]` document is kept as an all-O hard-negative
+or dropped as label-miss noise. Letting label-miss docs through teaches the
+model to *not* tag real PII — exactly the regression observed in #66 (hardneg
+run vs. baseline: ADDRESS F1 0.692 → 0.667, BANK_ACCOUNT F1 0.615 → 0.558).
+
+These tests pin the regex's intent: each PII surface form that the original
+v0 set missed (postal codes, phone numbers, email, account numbers, the
+remaining 41 prefectures, ISO-style birthdates, …) is asserted to match,
+and a curated set of clearly non-PII strings is asserted NOT to match. If
+someone narrows or removes a branch in the future, the test will tell us
+which PII class regressed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pleno_ner_training.convert_to_hf_dataset import PII_HINT_RE
+
+
+# ---------------------------------------------------------------------------
+# Strings that MUST match — each corresponds to a PII class we cannot leak
+# into the hard-negative pool.
+# ---------------------------------------------------------------------------
+
+POSITIVE_CASES: list[tuple[str, str]] = [
+    # --- legacy patterns (kept for back-compat) ------------------------------
+    ("legacy/digit-cluster-3", "電話 03-1234-5678 までご連絡ください。"),
+    ("legacy/digit-cluster-grouped", "受付番号 12345 - 67890 です。"),
+    ("legacy/honorific-name", "山田 太郎さんのご来店です。"),
+    ("legacy/corp", "株式会社サンプル商事と契約しました。"),
+    ("legacy/era-date", "令和5年に入社しました。"),
+    ("legacy/prefecture-tokyo", "東京都港区赤坂"),
+    # --- #67: postal code ----------------------------------------------------
+    ("postal/with-hyphen", "〒100-0001 千代田区千代田1-1"),
+    ("postal/no-hyphen", "〒1000001"),
+    ("postal/with-space", "〒 100-0001"),
+    # --- #67: Japanese phone -------------------------------------------------
+    ("phone/landline", "0120-456-7890 までお電話ください。"),
+    ("phone/mobile", "携帯は090-1234-5678です。"),
+    ("phone/long-area", "問い合わせ 03-1234-5678"),
+    # --- #67: email ----------------------------------------------------------
+    ("email/basic", "連絡先は taro.yamada@example.com です。"),
+    ("email/plus-tag", "support+pii@example.co.jp"),
+    # --- #67: financial identifiers -----------------------------------------
+    ("card/16-spaced", "カード番号 4111 1111 1111 1111"),
+    ("card/16-hyphen", "4111-1111-1111-1111"),
+    ("card/16-solid", "4111111111111111"),
+    ("iban/de", "IBAN: DE89370400440532013000"),
+    ("account/koza", "口座番号 1234567"),
+    ("account/futsuu", "普通 7654321"),
+    ("account/touza", "当座: 9876543"),
+    ("bank/with-digits", "三菱UFJ銀行渋谷支店 0123456"),
+    ("bank/yuucho", "ゆうちょ銀行記号10100 番号12345678"),
+    # --- #67: more prefectures (the original list missed 41 of them) -------
+    ("prefecture/kanagawa", "神奈川県横浜市"),
+    ("prefecture/aichi", "愛知県名古屋市"),
+    ("prefecture/fukuoka", "福岡県福岡市中央区"),
+    ("prefecture/hiroshima", "広島県広島市中区基町"),
+    # --- #67: ward + chome ---------------------------------------------------
+    ("address/ward-chome", "中区基町10丁目"),
+    # --- #67: banchi / go ----------------------------------------------------
+    ("address/banchi", "1-2-3 のビルです。"),
+    # --- #67: ISO-style birthdate -------------------------------------------
+    ("dob/iso", "生年月日は1990年4月1日です。"),
+    ("dob/iso-spaced", "1992 年 4 月 10 日"),
+    # --- #67: name + furigana ------------------------------------------------
+    ("name/furigana", "田村健司（タムラケンジ）"),
+    # --- #67: 名義 + name ----------------------------------------------------
+    ("meigi/kanji", "名義はヤマダタロウ"),
+    # --- #67: residual prompt-template tags ---------------------------------
+    ("tag/xml-person", "<PERSON>木村優香</PERSON>"),
+    ("tag/xml-address", "<ADDRESS>福岡県福岡市中央区</ADDRESS>"),
+    ("tag/brace-person", "《PERSON>木村優香</PERSON》"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Strings that MUST NOT match — typical clean Japanese with no PII signal.
+# These guard against the regex turning into a "drop everything" wildcard.
+# ---------------------------------------------------------------------------
+
+NEGATIVE_CASES: list[tuple[str, str]] = [
+    ("neutral/diary", "昨日は雨が降ったので家で本を読んでいた。"),
+    ("neutral/refusal", "ご依頼にはお応えできません。代わりに別の文章を作成します。"),
+    ("neutral/short", "わかりました。"),
+    ("neutral/numbers-but-not-pii", "売上は120個でした。"),
+    ("neutral/year-only", "2025年に発表されました。"),  # year alone is OK
+    ("neutral/era-no-digits", "昭和の風景"),  # era without 年-digits
+]
+
+
+@pytest.mark.parametrize("case_id,text", POSITIVE_CASES, ids=[c[0] for c in POSITIVE_CASES])
+def test_pii_hint_re_matches_pii_surface_form(case_id: str, text: str) -> None:
+    """Every PII surface form we care about must trigger PII_HINT_RE.
+
+    Failure here means the regex would let a label-miss zero-entity doc into
+    the hard-negative pool, recreating the #66 ADDRESS / BANK_ACCOUNT
+    regression.
+    """
+    assert PII_HINT_RE.search(text), (
+        f"[{case_id}] expected PII match in: {text!r}"
+    )
+
+
+@pytest.mark.parametrize("case_id,text", NEGATIVE_CASES, ids=[c[0] for c in NEGATIVE_CASES])
+def test_pii_hint_re_does_not_match_clean_text(case_id: str, text: str) -> None:
+    """Clean prose without PII must pass through (kept as hard-negative)."""
+    assert not PII_HINT_RE.search(text), (
+        f"[{case_id}] unexpected PII match in: {text!r}"
+    )
+
+
+def test_pii_hint_re_drop_rate_floor_on_ja_v02() -> None:
+    """Regression guard for #67 acceptance criterion.
+
+    On `data/raw/ja-v02/generated.json` the expanded regex must drop at least
+    ~25% of zero-entity docs (the original v0 set dropped 16.4%). We pin a
+    conservative 22% floor so non-PII edits to the data file don't break the
+    test, while still failing loudly if a regex branch is removed.
+
+    Skipped when the data file is unavailable (CI without LFS).
+    """
+    import json
+    from pathlib import Path
+
+    data_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "raw"
+        / "ja-v02"
+        / "generated.json"
+    )
+    if not data_path.exists():
+        pytest.skip(f"raw data not available: {data_path}")
+
+    with open(data_path, encoding="utf-8") as f:
+        records = json.load(f)
+
+    zero = [r for r in records if not r.get("entities") and r.get("text")]
+    if not zero:
+        pytest.skip("no zero-entity docs in raw data")
+
+    dropped = sum(1 for r in zero if PII_HINT_RE.search(r["text"]))
+    rate = dropped / len(zero)
+    assert rate >= 0.22, (
+        f"PII_HINT_RE drop rate regressed: {rate:.3f} "
+        f"(zero={len(zero)}, drop={dropped}); expected >= 0.22"
+    )


### PR DESCRIPTION
## Summary

Closes #66, #67.

The hard-negative training run (`v02-tiny-hardneg`) regressed ADDRESS / BANK_ACCOUNT against the no-hardneg baseline:

| label | baseline F1 | hardneg F1 | delta |
|---|---:|---:|---:|
| ADDRESS | 0.692 | **0.667** | -0.025 |
| BANK_ACCOUNT | 0.615 | **0.558** | -0.057 |

Root cause (#66): `PII_HINT_RE` in `convert_to_hf_dataset.py` only captured ~16% of zero-entity docs in `raw/ja-v02/generated.json`, leaking docs like `楽天銀行、普通、口座番号は1234567、名義はヤマダ タロウ` into the hard-negative pool as all-O examples. Training on that taught the model to *not* tag bank-name + account-number — exactly the wrong lesson.

## What changed (#67)

`PII_HINT_RE` now also catches:
- `〒XXX-XXXX` postal code
- `0X-XXXX-XXXX` Japanese phone
- email
- 16-digit credit card / IBAN
- `口座番号 / 普通 / 当座 + digits`
- bank/branch keyword + nearby digits
- all 47 prefectures (was 5)
- `[市区町村] + 丁目`
- `YYYY年M月D日` birthdate
- 漢字名 + `(カナ読み)`
- 名義 + name
- residual `<PERSON>` / `<ADDRESS>` / `《》` prompt-template tags

## Numbers (drop-rate before / after)

| corpus | zero-entity | OLD drop | NEW drop |
|---|---:|---:|---:|
| `ja-v02/generated.json` | 2,432 | 400 (16.45%) | **597 (24.55%)** |
| `ja-v02-extra/generated.json` | 3,056 | 277 (9.06%) | 415 (13.58%) |

Primary training corpus moved from 16.4% → 24.55%, hitting the AC band (~25%).

## Tests

`packages/training/tests/test_pii_filter.py` — 43 cases:
- 36 must-match positives covering every PII class (postal, phone, email, card, IBAN, account, prefectures, birthdate, …)
- 6 must-not-match clean-prose negatives (refusal templates, year-only, era-only, neutral diary)
- 1 corpus-level floor test asserting ≥22% drop on `ja-v02/generated.json`

```
43 passed in 37.71s
```

## Verification

Actual F1 recovery on ADDRESS / BANK_ACCOUNT will be verified after the #48 hardneg re-train; this PR fixes the data-pipeline cause.

## Notes

- LFS files in `packages/models/**` show as modified locally (LFS smudge artifacts) but are intentionally not staged.