### PR TITLE
fix(docker): copy packages/recognizers source into builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ WORKDIR /workspace
 # member の pyproject.toml は必要 (実体コードは sync 後にも不要)。
 COPY pyproject.toml uv.lock ./
 COPY packages/training/pyproject.toml packages/training/pyproject.toml
+COPY packages/scanner/pyproject.toml packages/scanner/pyproject.toml
+# pleno-recognizers は server の dependency なので source ごと copy が必要
+# (uv は workspace member を wheel build するため pyproject だけでは足りない)。
+COPY packages/recognizers/ packages/recognizers/
 COPY server/pyproject.toml server/pyproject.toml
 # server image は OSS baselines (ginza/ja-ginza/ja_core_news_trf) を含めない
 # image size 膨張を構造的に抑制 (plan U1 Deployment image impact)。


### PR DESCRIPTION
## What

Add COPY packages/recognizers source into the Dockerfile builder stage.

## Why

PR #84 added pleno-recognizers as a workspace dependency of server. The Dockerfile builder stage only copied packages/training/pyproject.toml and server/pyproject.toml, so uv sync fails with:

    error: Failed to determine installation plan
      Caused by: Distribution not found at: file:///workspace/packages/recognizers

This breaks deploy on every push to main.

## Verification

CI deploy job will rebuild the image; that step catches the regression at build time.