### PR TITLE
feat(scanner): add --base-url cloud mode for NER-backed analysis

### DIFF
--- a/packages/scanner/README.md
+++ b/packages/scanner/README.md
@@ -36,6 +36,34 @@ uv run pleno-scan protect
 uv run pleno-scan baseline ./my-repo --out .plenoignore-baseline.json
 ```
 
+### Local vs cloud mode
+
+By default, `pleno-scan` runs **locally** with the regex pass only. Pass `--base-url` (or set `PLENO_BASE_URL`) to delegate analysis to a pleno-anonymize HTTP API — this enables NER-based entities (`PERSON`, `ADDRESS`, `ORGANIZATION`) that the local regex pass cannot detect.
+
+```sh
+# Local (default): regex only, multiprocess, no network
+uv run pleno-scan dir ./my-repo
+
+# Cloud: server-side analysis (Presidio + spaCy NER + regex)
+uv run pleno-scan dir ./my-repo --base-url https://pleno-anonymize.fly.dev
+
+# Or via env var (CI-friendly)
+PLENO_BASE_URL=https://pleno-anonymize.fly.dev pleno-scan dir ./my-repo
+
+# Auth (if your endpoint requires it)
+uv run pleno-scan dir ./my-repo \
+    --base-url https://internal.example.com \
+    --api-key "$PLENO_API_KEY"
+
+# Throttle parallel HTTP requests
+uv run pleno-scan dir ./my-repo --base-url ... --concurrency 4
+```
+
+| Mode | Entities | Latency | Network | Use when |
+|---|---|---|---|---|
+| Local | 13 regex-based JA patterns | ~ms / file | none | CI, pre-commit, offline |
+| Cloud | regex + NER (PERSON / ADDRESS / ORGANIZATION / etc.) | ~100s ms / file | required | one-off audits, higher recall |
+
 ### Output formats
 
 - `--report-format human` (default) — colorized table

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -7,11 +7,11 @@ dependencies = [
     "pleno-recognizers",
     "click>=8.1",
     "pathspec>=0.12",
+    "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]
 deep = ["pleno-anonymize-server"]
-ai = ["httpx>=0.27.0"]
 
 [project.scripts]
 pleno-scan = "pleno_scan.cli:main"

--- a/packages/scanner/src/pleno_scan/cli.py
+++ b/packages/scanner/src/pleno_scan/cli.py
@@ -11,6 +11,7 @@ import click
 from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
 
 from pleno_scan import __version__
+from pleno_scan.cloud_pass import CloudConfig, scan_files_cloud
 from pleno_scan.git_history import scan_history as _scan_history
 from pleno_scan.github import list_org_repos, shallow_clone
 from pleno_scan.ignore import IgnoreSet, filter_findings, load_baseline, write_baseline
@@ -23,6 +24,15 @@ from pleno_scan.walker import walk
 
 def _common_options(f):
     f = click.option("--entities", default=None, help="Comma-separated entity types to scan for.")(f)
+    f = click.option("--language", default="ja", show_default=True, help="Analysis language (ja|en). Cloud mode only.")(f)
+    f = click.option("--base-url", "base_url", default=None,
+                     envvar="PLENO_BASE_URL",
+                     help="Use cloud analysis at this URL (e.g. https://pleno-anonymize.fly.dev). "
+                          "When omitted, scans run locally with the regex pass only.")(f)
+    f = click.option("--api-key", default=None, envvar="PLENO_API_KEY",
+                     help="Bearer token for the cloud API. Cloud mode only.")(f)
+    f = click.option("--concurrency", type=int, default=8, show_default=True,
+                     help="Parallel HTTP requests in cloud mode.")(f)
     f = click.option("--report-format", type=click.Choice(["human", "json", "sarif"]), default="human")(f)
     f = click.option("--report-path", type=click.Path(dir_okay=False, path_type=Path), default=None)(f)
     f = click.option("--baseline", "baseline_path", type=click.Path(dir_okay=False, path_type=Path), default=None)(f)
@@ -30,11 +40,27 @@ def _common_options(f):
     f = click.option("--max-file-size", type=int, default=1024 * 1024, show_default=True)(f)
     f = click.option("--include", multiple=True, help="Glob to include (gitignore syntax).")(f)
     f = click.option("--exclude", multiple=True, help="Glob to exclude (gitignore syntax).")(f)
-    f = click.option("--workers", type=int, default=None, help="Parallel workers (default: CPU count).")(f)
+    f = click.option("--workers", type=int, default=None, help="Parallel local-mode workers (default: CPU count).")(f)
     f = click.option("--only-verified", is_flag=True, help="Suppress unverified/failed findings.")(f)
     f = click.option("--no-color", is_flag=True, help="Disable ANSI colors.")(f)
     f = click.option("--exit-zero", is_flag=True, help="Always exit 0 even when findings exist.")(f)
     return f
+
+
+def _cloud_config(base_url: str | None, api_key: str | None, language: str,
+                  concurrency: int, entities_csv: str | None) -> CloudConfig | None:
+    if not base_url:
+        return None
+    ents: tuple[str, ...] | None = None
+    if entities_csv and entities_csv.strip().upper() != "ALL":
+        ents = tuple(e.strip() for e in entities_csv.split(",") if e.strip())
+    return CloudConfig(
+        base_url=base_url,
+        language=language,
+        api_key=api_key,
+        concurrency=concurrency,
+        entities=ents,
+    )
 
 
 # Default profile: excludes high-noise patterns. Use --entities ALL to enable everything.
@@ -85,9 +111,9 @@ def _scan_directory(
     workers: int | None,
     ignore_set: IgnoreSet,
     baseline: set[str],
+    cloud: CloudConfig | None = None,
 ) -> ScanStats:
     recognizers = _select_recognizers(entities)
-    patterns = compile_patterns(recognizers)
 
     t0 = time.monotonic()
     files = list(walk(
@@ -116,7 +142,16 @@ def _scan_directory(
         file_lines[rel_str] = text.splitlines()
         bytes_total += len(text.encode("utf-8", errors="ignore"))
 
-    findings = scan_files(file_pairs, patterns, workers=workers)
+    if cloud is not None:
+        # Cloud mode: server-side analysis (NER + regex + Presidio context).
+        findings = scan_files_cloud(file_pairs, file_text, cloud)
+    else:
+        # Local mode: regex-only multiprocess pass.
+        patterns = compile_patterns(recognizers)
+        findings = scan_files(file_pairs, patterns, workers=workers)
+
+    # Verification (checksum + context) runs in both modes — the local
+    # checksum can still flag obviously-fake values the server accepted.
     findings = verify(findings, recognizers, file_text_for=file_text)
     kept, _ = filter_findings(
         findings, ignore_set=ignore_set, baseline=baseline, file_lines=file_lines
@@ -153,12 +188,14 @@ def main() -> None:
 @main.command(name="dir")
 @click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @_common_options
-def cmd_dir(path: Path, entities, report_format, report_path, baseline_path,
+def cmd_dir(path: Path, entities, language, base_url, api_key, concurrency,
+            report_format, report_path, baseline_path,
             ignore_file, max_file_size, include, exclude, workers, only_verified,
             no_color, exit_zero) -> None:
     """Scan a directory tree."""
     ignore_set = _resolve_ignore(ignore_file, path)
     baseline = load_baseline(baseline_path) if baseline_path else set()
+    cloud = _cloud_config(base_url, api_key, language, concurrency, entities)
     stats = _scan_directory(
         path.resolve(),
         entities=entities,
@@ -168,6 +205,7 @@ def cmd_dir(path: Path, entities, report_format, report_path, baseline_path,
         workers=workers,
         ignore_set=ignore_set,
         baseline=baseline,
+        cloud=cloud,
     )
     stats = _maybe_filter_verified(stats, only_verified)
     color = sys.stdout.isatty() and not no_color and report_format == "human"
@@ -180,12 +218,18 @@ def cmd_dir(path: Path, entities, report_format, report_path, baseline_path,
 @click.option("--no-history", is_flag=True, help="Skip git history pass.")
 @click.option("--max-commits", type=int, default=None, help="Cap commits scanned.")
 @_common_options
-def cmd_git(path: Path, no_history, max_commits, entities, report_format, report_path,
+def cmd_git(path: Path, no_history, max_commits, entities, language, base_url, api_key,
+            concurrency, report_format, report_path,
             baseline_path, ignore_file, max_file_size, include, exclude, workers,
             only_verified, no_color, exit_zero) -> None:
-    """Scan a local git repository (working tree + history)."""
+    """Scan a local git repository (working tree + history).
+
+    History pass always runs locally (regex only) since per-line cloud calls
+    would be chatty and gain little for short diff lines.
+    """
     ignore_set = _resolve_ignore(ignore_file, path)
     baseline = load_baseline(baseline_path) if baseline_path else set()
+    cloud = _cloud_config(base_url, api_key, language, concurrency, entities)
     recognizers = _select_recognizers(entities)
     patterns = compile_patterns(recognizers)
 
@@ -198,6 +242,7 @@ def cmd_git(path: Path, no_history, max_commits, entities, report_format, report
         workers=workers,
         ignore_set=ignore_set,
         baseline=baseline,
+        cloud=cloud,
     )
 
     if not no_history:
@@ -222,7 +267,8 @@ def cmd_git(path: Path, no_history, max_commits, entities, report_format, report
 @click.option("--full", is_flag=True, help="Full clone (default: shallow depth=1).")
 @click.option("--scan-history/--no-scan-history", "include_history", default=False, help="Scan git history (requires --full).")
 @_common_options
-def cmd_github(target, org, full, include_history, entities, report_format, report_path,
+def cmd_github(target, org, full, include_history, entities, language, base_url, api_key,
+               concurrency, report_format, report_path,
                baseline_path, ignore_file, max_file_size, include, exclude, workers,
                only_verified, no_color, exit_zero) -> None:
     """Clone a GitHub repo (or all repos in an org) and scan."""
@@ -232,6 +278,7 @@ def cmd_github(target, org, full, include_history, entities, report_format, repo
     targets = list_org_repos(target) if org else [target]
 
     aggregate = ScanStats()
+    cloud = _cloud_config(base_url, api_key, language, concurrency, entities)
     recognizers = _select_recognizers(entities)
     patterns = compile_patterns(recognizers)
 
@@ -249,6 +296,7 @@ def cmd_github(target, org, full, include_history, entities, report_format, repo
                 workers=workers,
                 ignore_set=ignore_set,
                 baseline=baseline,
+                cloud=cloud,
             )
             # Re-prefix file paths so output is unambiguous across many repos.
             sub.findings = [

--- a/packages/scanner/src/pleno_scan/cloud_pass.py
+++ b/packages/scanner/src/pleno_scan/cloud_pass.py
@@ -1,0 +1,168 @@
+"""Cloud-mode scan: delegate analysis to a pleno-anonymize HTTP API.
+
+Used when --base-url is supplied. Sends each file (chunked under the
+server's 100k-char limit) to POST /api/analyze and translates the
+returned offsets back into Finding(line, col).
+
+Cloud mode benefits:
+- Includes NER entities (PERSON, ADDRESS, ORGANIZATION) the local
+  regex pass cannot see.
+- Presidio's contextual scoring is applied server-side.
+
+Cloud mode costs:
+- Network latency. Use --concurrency to parallelize.
+- Server's 100k-char request cap requires chunking large files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import bisect
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import httpx
+
+from pleno_scan.models import Finding
+
+
+# Server caps text at 100_000 chars (server.AnalyzeRequest). Leave headroom.
+_CHUNK_LIMIT = 90_000
+
+
+@dataclass(frozen=True, slots=True)
+class CloudConfig:
+    base_url: str
+    language: str = "ja"
+    api_key: str | None = None
+    concurrency: int = 8
+    timeout_s: float = 120.0
+    entities: tuple[str, ...] | None = None
+
+
+def _line_offsets(text: str) -> list[int]:
+    offsets = [0]
+    pos = 0
+    while True:
+        idx = text.find("\n", pos)
+        if idx == -1:
+            break
+        offsets.append(idx + 1)
+        pos = idx + 1
+    return offsets
+
+
+def _line_col(line_starts: list[int], offset: int) -> tuple[int, int]:
+    line_idx = bisect.bisect_right(line_starts, offset) - 1
+    return line_idx + 1, offset - line_starts[line_idx] + 1
+
+
+def _chunk(text: str, limit: int = _CHUNK_LIMIT) -> Iterable[tuple[int, str]]:
+    """Yield (offset_in_full_text, chunk_text). Splits on newlines when possible."""
+    if len(text) <= limit:
+        yield 0, text
+        return
+    pos = 0
+    n = len(text)
+    while pos < n:
+        end = min(pos + limit, n)
+        if end < n:
+            nl = text.rfind("\n", pos, end)
+            if nl > pos:
+                end = nl + 1
+        yield pos, text[pos:end]
+        pos = end
+
+
+async def _analyze(
+    client: httpx.AsyncClient, cfg: CloudConfig, text: str
+) -> list[dict]:
+    headers: dict[str, str] = {"content-type": "application/json"}
+    if cfg.api_key:
+        headers["authorization"] = f"Bearer {cfg.api_key}"
+    body: dict = {"text": text, "language": cfg.language}
+    if cfg.entities:
+        body["entities"] = list(cfg.entities)
+    url = cfg.base_url.rstrip("/") + "/api/analyze"
+    r = await client.post(url, json=body, headers=headers)
+    r.raise_for_status()
+    return r.json()
+
+
+async def _scan_one(
+    client: httpx.AsyncClient,
+    cfg: CloudConfig,
+    file: str,
+    text: str,
+) -> list[Finding]:
+    if not text:
+        return []
+    line_starts = _line_offsets(text)
+    findings: list[Finding] = []
+    for offset, chunk in _chunk(text):
+        try:
+            results = await _analyze(client, cfg, chunk)
+        except (httpx.HTTPError, ValueError):
+            continue
+        for r in results:
+            start = offset + int(r["start"])
+            end = offset + int(r["end"])
+            line, col = _line_col(line_starts, start)
+            line_end_idx = bisect.bisect_right(line_starts, start)
+            line_end = (
+                line_starts[line_end_idx]
+                if line_end_idx < len(line_starts)
+                else len(text)
+            )
+            snippet = text[line_starts[line - 1] : line_end].rstrip("\n")
+            if len(snippet) > 240:
+                rel = start - line_starts[line - 1]
+                snippet = snippet[max(0, rel - 80) : rel + 160]
+            findings.append(
+                Finding(
+                    entity=str(r["entity_type"]),
+                    file=file,
+                    line=line,
+                    col=col,
+                    score=float(r["score"]),
+                    snippet=snippet,
+                    matched=text[start:end],
+                    pattern_name="cloud",
+                )
+            )
+    return findings
+
+
+async def _scan_files_cloud_async(
+    files: list[tuple[Path, Path]],
+    file_text: dict[str, str],
+    cfg: CloudConfig,
+) -> list[Finding]:
+    sem = asyncio.Semaphore(cfg.concurrency)
+    timeout = httpx.Timeout(cfg.timeout_s)
+    findings: list[Finding] = []
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        async def _task(rel_str: str) -> list[Finding]:
+            async with sem:
+                return await _scan_one(client, cfg, rel_str, file_text[rel_str])
+
+        results = await asyncio.gather(
+            *[_task(rel.as_posix()) for rel, _ in files], return_exceptions=False
+        )
+
+    for r in results:
+        findings.extend(r)
+    return findings
+
+
+def scan_files_cloud(
+    files: list[tuple[Path, Path]],
+    file_text: dict[str, str],
+    cfg: CloudConfig,
+) -> list[Finding]:
+    """Synchronous entry point — runs the async scanner via asyncio.run."""
+    if not files:
+        return []
+    return asyncio.run(_scan_files_cloud_async(files, file_text, cfg))

--- a/packages/scanner/tests/test_cloud_pass.py
+++ b/packages/scanner/tests/test_cloud_pass.py
@@ -1,0 +1,109 @@
+"""Cloud-mode tests using a mocked httpx transport (no real network)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from pleno_scan.cloud_pass import CloudConfig, _chunk, scan_files_cloud
+
+
+def test_chunk_short_text_yields_single():
+    out = list(_chunk("hello"))
+    assert out == [(0, "hello")]
+
+
+def test_chunk_splits_on_newline_boundary():
+    text = "aaaa\nbbbb\ncccc\n"
+    out = list(_chunk(text, limit=8))
+    # First chunk should end at a newline boundary, not mid-line.
+    offsets = [o for o, _ in out]
+    assert offsets[0] == 0
+    rejoined = "".join(c for _, c in out)
+    assert rejoined == text
+
+
+def test_chunk_falls_back_to_hard_split_when_no_newline():
+    out = list(_chunk("a" * 25, limit=10))
+    # Three chunks: 0-10, 10-20, 20-25
+    assert [o for o, _ in out] == [0, 10, 20]
+    assert "".join(c for _, c in out) == "a" * 25
+
+
+def _make_transport(responses_per_text):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        results = responses_per_text.get(body["text"], [])
+        return httpx.Response(200, json=results)
+
+    return httpx.MockTransport(handler)
+
+
+def test_scan_files_cloud_translates_offsets(tmp_path: Path, monkeypatch):
+    file = tmp_path / "x.txt"
+    file.write_text("line1\n連絡先: 090-1234-5678\n")
+    text = file.read_text()
+    # Server says "PHONE_NUMBER" at offset 11..24 (位置に意味は無い、テキスト内のbyte位置).
+    phone_start = text.index("090-1234-5678")
+    server_response = [
+        {
+            "entity_type": "PHONE_NUMBER",
+            "start": phone_start,
+            "end": phone_start + len("090-1234-5678"),
+            "score": 0.9,
+            "text": "090-1234-5678",
+        }
+    ]
+    transport = _make_transport({text: server_response})
+
+    # Patch httpx.AsyncClient to use our transport.
+    real_init = httpx.AsyncClient.__init__
+
+    def fake_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", fake_init)
+
+    cfg = CloudConfig(base_url="https://example.invalid", concurrency=1)
+    findings = scan_files_cloud(
+        [(Path("x.txt"), file)], {"x.txt": text}, cfg
+    )
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.entity == "PHONE_NUMBER"
+    assert f.line == 2  # 1-indexed; phone is on second line
+    assert f.matched == "090-1234-5678"
+    assert f.pattern_name == "cloud"
+
+
+def test_scan_files_cloud_handles_http_error(tmp_path: Path, monkeypatch):
+    file = tmp_path / "x.txt"
+    file.write_text("hello world")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    transport = httpx.MockTransport(handler)
+    real_init = httpx.AsyncClient.__init__
+
+    def fake_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", fake_init)
+
+    cfg = CloudConfig(base_url="https://example.invalid", concurrency=1)
+    findings = scan_files_cloud(
+        [(Path("x.txt"), file)], {"x.txt": "hello world"}, cfg
+    )
+    # 500 errors are swallowed and produce no findings (per-file resilience).
+    assert findings == []
+
+
+def test_scan_files_cloud_empty_files_short_circuits():
+    cfg = CloudConfig(base_url="https://example.invalid")
+    assert scan_files_cloud([], {}, cfg) == []

--- a/uv.lock
+++ b/uv.lock
@@ -2653,14 +2653,12 @@ version = "0.1.0"
 source = { editable = "packages/scanner" }
 dependencies = [
     { name = "click" },
+    { name = "httpx" },
     { name = "pathspec" },
     { name = "pleno-recognizers" },
 ]
 
 [package.optional-dependencies]
-ai = [
-    { name = "httpx" },
-]
 deep = [
     { name = "pleno-anonymize-server" },
 ]
@@ -2673,12 +2671,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
-    { name = "httpx", marker = "extra == 'ai'", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pathspec", specifier = ">=0.12" },
     { name = "pleno-anonymize-server", marker = "extra == 'deep'", editable = "server" },
     { name = "pleno-recognizers", editable = "packages/recognizers" },
 ]
-provides-extras = ["deep", "ai"]
+provides-extras = ["deep"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## What

Add a `--base-url` flag (and `PLENO_BASE_URL` env var) that switches `pleno-scan` from local-only regex to cloud-backed analysis via the pleno-anonymize HTTP API.

```sh
# Default unchanged: local regex
pleno-scan dir ./repo

# Cloud: server-side Presidio + spaCy NER + regex
pleno-scan dir ./repo --base-url https://pleno-anonymize.fly.dev
```

## Why

Local regex catches structured PII (phone, email, My Number, etc.) but cannot detect free-text PII like `PERSON`/`ADDRESS`/`ORGANIZATION` — those need NER. Spinning up spaCy locally would balloon the scanner's footprint (200MB+ of models). Letting users opt in to a hosted endpoint keeps the default scanner light while giving teams that already run pleno-anonymize a way to get higher recall.

## How

New `pleno_scan.cloud_pass` module:
- `CloudConfig` dataclass holds endpoint settings.
- Async `httpx` client with semaphore-bounded concurrency (`--concurrency`, default 8).
- Per-file chunking under the server's 100k-char request cap, splitting on newline boundaries when possible.
- Server-returned (start, end) translated back to (line, col) via cumulative line offsets.
- HTTP errors per file are swallowed so one bad file doesn't fail the whole scan.

Local checksum verification (Luhn / My Number / 法人番号) still runs on cloud findings, so values the server accepts but fail checksum are still flagged.

History pass (`pleno-scan git`) intentionally remains local — per-line cloud calls would be chatty for short diff lines.

## Verification

- 32 unit tests pass (6 new for cloud mode using `httpx.MockTransport`, no network).
- Smoke test against `https://pleno-anonymize.fly.dev`:
  - Local: 14 findings (regex only) in 2ms
  - Cloud: 19 findings including PERSON × 2 in 1145ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)