### PR TITLE
feat(scanner): make NER (ja_ner_ja) the default scan path

### DIFF
--- a/packages/scanner/README.md
+++ b/packages/scanner/README.md
@@ -36,18 +36,20 @@ uv run pleno-scan protect
 uv run pleno-scan baseline ./my-repo --out .plenoignore-baseline.json
 ```
 
-### Local vs cloud mode
+### Local (default) vs cloud offload
 
-By default, `pleno-scan` runs **locally** with the regex pass only. Pass `--base-url` (or set `PLENO_BASE_URL`) to delegate analysis to a pleno-anonymize HTTP API — this enables NER-based entities (`PERSON`, `ADDRESS`, `ORGANIZATION`) that the local regex pass cannot detect.
+By default, `pleno-scan` runs **locally** with the same Presidio + spaCy NER (`ja_ner_ja`) + regex pipeline that powers the pleno-anonymize server. The ML model is required: it ships as a workspace dependency and `uv sync` installs it automatically. Local scans detect free-text PII (`PERSON`, `ADDRESS`, `ORGANIZATION`) in addition to all the regex-backed entities.
+
+Pass `--base-url` (or set `PLENO_BASE_URL`) to **offload** the same pipeline to a remote pleno-anonymize endpoint — useful when you don't want to load the model locally (e.g. lightweight CI runners) or when scanning a huge repo from a workstation.
 
 ```sh
-# Local (default): regex only, multiprocess, no network
+# Local (default): NER + regex, single-process, model loaded once
 uv run pleno-scan dir ./my-repo
 
-# Cloud: server-side analysis (Presidio + spaCy NER + regex)
+# Offload to a hosted endpoint
 uv run pleno-scan dir ./my-repo --base-url https://pleno-anonymize.fly.dev
 
-# Or via env var (CI-friendly)
+# CI-friendly env var
 PLENO_BASE_URL=https://pleno-anonymize.fly.dev pleno-scan dir ./my-repo
 
 # Auth (if your endpoint requires it)
@@ -55,14 +57,16 @@ uv run pleno-scan dir ./my-repo \
     --base-url https://internal.example.com \
     --api-key "$PLENO_API_KEY"
 
-# Throttle parallel HTTP requests
+# Throttle parallel HTTP requests in offload mode
 uv run pleno-scan dir ./my-repo --base-url ... --concurrency 4
 ```
 
-| Mode | Entities | Latency | Network | Use when |
+| Mode | Where compute runs | Network | Memory | Use when |
 |---|---|---|---|---|
-| Local | 13 regex-based JA patterns | ~ms / file | none | CI, pre-commit, offline |
-| Cloud | regex + NER (PERSON / ADDRESS / ORGANIZATION / etc.) | ~100s ms / file | required | one-off audits, higher recall |
+| Local (default) | This machine | none | model loaded once (~200MB) | normal use |
+| Cloud (`--base-url`) | Remote pleno-anonymize | required | none | thin CI runners, very large scans |
+
+Both modes return the same entity set; the only difference is *where* the model runs. Git history scanning always uses regex-only matching (per-line NER is wasteful for short diff lines).
 
 ### Output formats
 

--- a/packages/scanner/pyproject.toml
+++ b/packages/scanner/pyproject.toml
@@ -8,10 +8,12 @@ dependencies = [
     "click>=8.1",
     "pathspec>=0.12",
     "httpx>=0.27.0",
+    # Default scan path uses Presidio + spaCy NER (ja_ner_ja). Cloud mode
+    # (--base-url) is an offload, not a substitute.
+    "spacy[ja]>=3.8",
+    "presidio-analyzer>=2.2",
+    "ja-ner-ja",
 ]
-
-[project.optional-dependencies]
-deep = ["pleno-anonymize-server"]
 
 [project.scripts]
 pleno-scan = "pleno_scan.cli:main"
@@ -21,7 +23,7 @@ dev = ["pytest>=8.0"]
 
 [tool.uv.sources]
 pleno-recognizers = { workspace = true }
-pleno-anonymize-server = { workspace = true }
+ja-ner-ja = { url = "https://huggingface.co/0xhikae/ja-ner-ja/resolve/main/ja_ner_ja-0.2.0-py3-none-any.whl" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/scanner/src/pleno_scan/cli.py
+++ b/packages/scanner/src/pleno_scan/cli.py
@@ -16,7 +16,8 @@ from pleno_scan.git_history import scan_history as _scan_history
 from pleno_scan.github import list_org_repos, shallow_clone
 from pleno_scan.ignore import IgnoreSet, filter_findings, load_baseline, write_baseline
 from pleno_scan.models import Finding, ScanStats
-from pleno_scan.regex_pass import compile_patterns, scan_files
+from pleno_scan.ner_pass import scan_files as scan_files_ner
+from pleno_scan.regex_pass import compile_patterns
 from pleno_scan.report import render_human, render_json, render_sarif
 from pleno_scan.verify import verify
 from pleno_scan.walker import walk
@@ -27,8 +28,8 @@ def _common_options(f):
     f = click.option("--language", default="ja", show_default=True, help="Analysis language (ja|en). Cloud mode only.")(f)
     f = click.option("--base-url", "base_url", default=None,
                      envvar="PLENO_BASE_URL",
-                     help="Use cloud analysis at this URL (e.g. https://pleno-anonymize.fly.dev). "
-                          "When omitted, scans run locally with the regex pass only.")(f)
+                     help="Offload analysis to a remote pleno-anonymize at this URL. "
+                          "When omitted, NER + regex run locally (the default).")(f)
     f = click.option("--api-key", default=None, envvar="PLENO_API_KEY",
                      help="Bearer token for the cloud API. Cloud mode only.")(f)
     f = click.option("--concurrency", type=int, default=8, show_default=True,
@@ -40,34 +41,51 @@ def _common_options(f):
     f = click.option("--max-file-size", type=int, default=1024 * 1024, show_default=True)(f)
     f = click.option("--include", multiple=True, help="Glob to include (gitignore syntax).")(f)
     f = click.option("--exclude", multiple=True, help="Glob to exclude (gitignore syntax).")(f)
-    f = click.option("--workers", type=int, default=None, help="Parallel local-mode workers (default: CPU count).")(f)
+    f = click.option("--workers", type=int, default=None, help="Reserved for the regex-only history pass (default: CPU count).")(f)
     f = click.option("--only-verified", is_flag=True, help="Suppress unverified/failed findings.")(f)
     f = click.option("--no-color", is_flag=True, help="Disable ANSI colors.")(f)
     f = click.option("--exit-zero", is_flag=True, help="Always exit 0 even when findings exist.")(f)
     return f
 
 
+# Noisy patterns excluded from the default profile. Use --entities ALL to include them.
+_NOISY_ENTITIES = frozenset({"URL", "HEALTH_INSURANCE", "DRIVER_LICENSE"})
+
+# NER entities (ML-only) added to the default profile alongside non-noisy regex entities.
+_NER_ENTITIES = ("PERSON", "ADDRESS", "ORGANIZATION", "DATE_OF_BIRTH", "BANK_ACCOUNT")
+
+
+def _resolve_entities(entities_csv: str | None) -> tuple[str, ...] | None:
+    """Return the entity filter to send to NER/cloud, or None for no filter (--entities ALL)."""
+    if not entities_csv:
+        regex_default = tuple(
+            r.entity for r in ALL_JA_RECOGNIZERS if r.entity not in _NOISY_ENTITIES
+        )
+        return regex_default + _NER_ENTITIES
+    if entities_csv.strip().upper() == "ALL":
+        return None
+    wanted = tuple(e.strip() for e in entities_csv.split(",") if e.strip())
+    if not wanted:
+        raise click.UsageError("--entities was empty")
+    return wanted
+
+
 def _cloud_config(base_url: str | None, api_key: str | None, language: str,
-                  concurrency: int, entities_csv: str | None) -> CloudConfig | None:
+                  concurrency: int, entities: tuple[str, ...] | None) -> CloudConfig | None:
     if not base_url:
         return None
-    ents: tuple[str, ...] | None = None
-    if entities_csv and entities_csv.strip().upper() != "ALL":
-        ents = tuple(e.strip() for e in entities_csv.split(",") if e.strip())
     return CloudConfig(
         base_url=base_url,
         language=language,
         api_key=api_key,
         concurrency=concurrency,
-        entities=ents,
+        entities=entities,
     )
 
 
-# Default profile: excludes high-noise patterns. Use --entities ALL to enable everything.
-_NOISY_ENTITIES = frozenset({"URL", "HEALTH_INSURANCE", "DRIVER_LICENSE"})
-
-
 def _select_recognizers(entities_csv: str | None):
+    """Recognizers used for verification (checksum + context) — separate from the
+    entity filter that drives NER/cloud."""
     if not entities_csv:
         return tuple(r for r in ALL_JA_RECOGNIZERS if r.entity not in _NOISY_ENTITIES)
     if entities_csv.strip().upper() == "ALL":
@@ -75,10 +93,10 @@ def _select_recognizers(entities_csv: str | None):
     wanted = {e.strip() for e in entities_csv.split(",") if e.strip()}
     selected = tuple(r for r in ALL_JA_RECOGNIZERS if r.entity in wanted)
     if not selected:
-        raise click.UsageError(
-            f"No recognizers match {sorted(wanted)}. "
-            f"Known entities: {sorted({r.entity for r in ALL_JA_RECOGNIZERS})}"
-        )
+        # Wanted set may be NER-only (PERSON, ADDRESS, ...). Fall back to the
+        # full recognizer list for verification — verify() is no-op when no
+        # validator matches the entity.
+        return ALL_JA_RECOGNIZERS
     return selected
 
 
@@ -142,13 +160,15 @@ def _scan_directory(
         file_lines[rel_str] = text.splitlines()
         bytes_total += len(text.encode("utf-8", errors="ignore"))
 
+    entity_filter = _resolve_entities(entities)
     if cloud is not None:
-        # Cloud mode: server-side analysis (NER + regex + Presidio context).
+        # Cloud offload: same Presidio + NER + regex pipeline, just remote.
         findings = scan_files_cloud(file_pairs, file_text, cloud)
     else:
-        # Local mode: regex-only multiprocess pass.
-        patterns = compile_patterns(recognizers)
-        findings = scan_files(file_pairs, patterns, workers=workers)
+        # Default: local Presidio + spaCy NER (ja_ner_ja) + regex recognizers.
+        findings = scan_files_ner(
+            file_pairs, file_text, language="ja", entities=entity_filter
+        )
 
     # Verification (checksum + context) runs in both modes — the local
     # checksum can still flag obviously-fake values the server accepted.
@@ -195,7 +215,7 @@ def cmd_dir(path: Path, entities, language, base_url, api_key, concurrency,
     """Scan a directory tree."""
     ignore_set = _resolve_ignore(ignore_file, path)
     baseline = load_baseline(baseline_path) if baseline_path else set()
-    cloud = _cloud_config(base_url, api_key, language, concurrency, entities)
+    cloud = _cloud_config(base_url, api_key, language, concurrency, _resolve_entities(entities))
     stats = _scan_directory(
         path.resolve(),
         entities=entities,
@@ -229,7 +249,7 @@ def cmd_git(path: Path, no_history, max_commits, entities, language, base_url, a
     """
     ignore_set = _resolve_ignore(ignore_file, path)
     baseline = load_baseline(baseline_path) if baseline_path else set()
-    cloud = _cloud_config(base_url, api_key, language, concurrency, entities)
+    cloud = _cloud_config(base_url, api_key, language, concurrency, _resolve_entities(entities))
     recognizers = _select_recognizers(entities)
     patterns = compile_patterns(recognizers)
 
@@ -278,7 +298,7 @@ def cmd_github(target, org, full, include_history, entities, language, base_url,
     targets = list_org_repos(target) if org else [target]
 
     aggregate = ScanStats()
-    cloud = _cloud_config(base_url, api_key, language, concurrency, entities)
+    cloud = _cloud_config(base_url, api_key, language, concurrency, _resolve_entities(entities))
     recognizers = _select_recognizers(entities)
     patterns = compile_patterns(recognizers)
 

--- a/packages/scanner/src/pleno_scan/ner_pass.py
+++ b/packages/scanner/src/pleno_scan/ner_pass.py
@@ -1,0 +1,152 @@
+"""Default scan path: Presidio + spaCy NER (ja_ner_ja) + regex recognizers.
+
+Mirrors the server's analyzer initialization so a local scan produces the
+same set of entities as POST /api/analyze. This is the **default** scan
+path — the regex-only fast path lives in regex_pass.py and is reserved
+for git-history per-line scanning where NER overhead per short line is
+not worth it.
+
+The analyzer is heavy to construct (loads spaCy + Presidio). We init
+lazily and cache process-globally.
+"""
+
+from __future__ import annotations
+
+import bisect
+from pathlib import Path
+from typing import Iterable
+
+from pleno_scan.models import Finding
+
+
+_analyzer = None
+
+
+def _init_analyzer():
+    global _analyzer
+    if _analyzer is not None:
+        return _analyzer
+
+    import spacy
+    from presidio_analyzer import AnalyzerEngine
+    from presidio_analyzer.nlp_engine import SpacyNlpEngine
+
+    from pleno_recognizers.presidio_adapter import all_ja_presidio
+
+    class _MultiLangSpacyNlpEngine(SpacyNlpEngine):
+        def __init__(self, models: dict):
+            super().__init__()
+            self.nlp = models
+
+    nlp_ja = spacy.load("ja_ner_ja")
+    models = {"ja": nlp_ja}
+
+    # Optional: en model if installed in the venv (used when --language en).
+    try:
+        models["en"] = spacy.load("en_ner_en")
+    except OSError:
+        try:
+            models["en"] = spacy.load("en_core_web_sm")
+        except OSError:
+            pass
+
+    engine = _MultiLangSpacyNlpEngine(models)
+    analyzer = AnalyzerEngine(
+        nlp_engine=engine,
+        supported_languages=list(models.keys()),
+    )
+    for r in all_ja_presidio():
+        analyzer.registry.add_recognizer(r)
+    if "en" in models:
+        analyzer.registry.load_predefined_recognizers(languages=["en"])
+
+    _analyzer = analyzer
+    return _analyzer
+
+
+def _line_offsets(text: str) -> list[int]:
+    offsets = [0]
+    pos = 0
+    while True:
+        idx = text.find("\n", pos)
+        if idx == -1:
+            break
+        offsets.append(idx + 1)
+        pos = idx + 1
+    return offsets
+
+
+def _line_col(line_starts: list[int], offset: int) -> tuple[int, int]:
+    line_idx = bisect.bisect_right(line_starts, offset) - 1
+    return line_idx + 1, offset - line_starts[line_idx] + 1
+
+
+def scan_text(
+    text: str,
+    file: str,
+    *,
+    language: str = "ja",
+    entities: tuple[str, ...] | None = None,
+) -> list[Finding]:
+    if not text:
+        return []
+    analyzer = _init_analyzer()
+    results = analyzer.analyze(
+        text=text,
+        language=language,
+        entities=list(entities) if entities else None,
+    )
+    line_starts = _line_offsets(text)
+    findings: list[Finding] = []
+    for r in results:
+        start = int(r.start)
+        end = int(r.end)
+        line, col = _line_col(line_starts, start)
+        line_end_idx = bisect.bisect_right(line_starts, start)
+        line_end = (
+            line_starts[line_end_idx]
+            if line_end_idx < len(line_starts)
+            else len(text)
+        )
+        snippet = text[line_starts[line - 1] : line_end].rstrip("\n")
+        if len(snippet) > 240:
+            rel = start - line_starts[line - 1]
+            snippet = snippet[max(0, rel - 80) : rel + 160]
+        findings.append(
+            Finding(
+                entity=str(r.entity_type),
+                file=file,
+                line=line,
+                col=col,
+                score=float(r.score),
+                snippet=snippet,
+                matched=text[start:end],
+                pattern_name="presidio",
+            )
+        )
+    return findings
+
+
+def scan_files(
+    files: list[tuple[Path, Path]],
+    file_text: dict[str, str],
+    *,
+    language: str = "ja",
+    entities: tuple[str, ...] | None = None,
+) -> list[Finding]:
+    """Sequential per-file analyze. Single process so the loaded model is reused.
+
+    Throughput is bounded by spaCy NER (~10–100k chars/sec). For very large
+    repos prefer the cloud offload (`--base-url`) which can run on a beefier
+    machine, or restrict scope with --include / --exclude.
+    """
+    if not files:
+        return []
+    findings: list[Finding] = []
+    for rel, _ in files:
+        rel_str = rel.as_posix()
+        text = file_text.get(rel_str, "")
+        findings.extend(
+            scan_text(text, rel_str, language=language, entities=entities)
+        )
+    return findings

--- a/packages/scanner/tests/test_ner_pass.py
+++ b/packages/scanner/tests/test_ner_pass.py
@@ -1,0 +1,65 @@
+"""Verifies the local NER pass actually loads ja_ner_ja and detects PERSON.
+
+This test loads the spaCy model so it's slow on first run. When the model
+isn't installed the test is skipped with a clear message rather than
+failing — useful for environments where the wheel can't be downloaded
+(air-gapped CI, etc.).
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _model_available() -> bool:
+    try:
+        import spacy
+
+        spacy.load("ja_ner_ja")
+        return True
+    except (ImportError, OSError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _model_available(),
+    reason="ja_ner_ja model not installed in venv",
+)
+
+
+def test_ner_detects_person_in_japanese_text():
+    from pleno_scan.ner_pass import scan_text
+
+    findings = scan_text(
+        "山田太郎さんに連絡してください。電話: 090-1234-5678",
+        "x.txt",
+        language="ja",
+    )
+    entities = {f.entity for f in findings}
+    assert "PERSON" in entities, f"expected PERSON in {entities}"
+    assert "PHONE_NUMBER" in entities, f"expected PHONE_NUMBER in {entities}"
+
+
+def test_ner_returns_line_col():
+    from pleno_scan.ner_pass import scan_text
+
+    text = "header\n名前: 山田太郎\n"
+    findings = scan_text(text, "x.txt", language="ja")
+    persons = [f for f in findings if f.entity == "PERSON"]
+    assert persons, "expected at least one PERSON finding"
+    assert persons[0].line == 2
+
+
+def test_ner_pass_scan_files_reuses_model(tmp_path: Path):
+    from pleno_scan.ner_pass import scan_files
+
+    f1 = tmp_path / "a.txt"
+    f1.write_text("山田太郎")
+    f2 = tmp_path / "b.txt"
+    f2.write_text("佐藤花子")
+
+    files = [(Path(p.name), p) for p in (f1, f2)]
+    file_text = {p.name: p.read_text() for p in (f1, f2)}
+    findings = scan_files(files, file_text, language="ja")
+    assert any(f.entity == "PERSON" and f.file == "a.txt" for f in findings)
+    assert any(f.entity == "PERSON" and f.file == "b.txt" for f in findings)

--- a/uv.lock
+++ b/uv.lock
@@ -1170,6 +1170,20 @@ wheels = [
 ]
 
 [[package]]
+name = "ja-ner-ja"
+version = "0.2.0"
+source = { url = "https://huggingface.co/0xhikae/ja-ner-ja/resolve/main/ja_ner_ja-0.2.0-py3-none-any.whl" }
+dependencies = [
+    { name = "spacy" },
+]
+wheels = [
+    { url = "https://huggingface.co/0xhikae/ja-ner-ja/resolve/main/ja_ner_ja-0.2.0-py3-none-any.whl", hash = "sha256:3ca9ad0e619a0133cb05d9d92787428998f4e4a94234589d05edde50b5ba0b9a" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "spacy", specifier = ">=3.8.13,<3.9.0" }]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.flatt.tech/simple/" }
@@ -2516,7 +2530,7 @@ wheels = [
 [[package]]
 name = "pleno-anonymize-server"
 version = "0.1.0"
-source = { editable = "server" }
+source = { virtual = "server" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -2654,13 +2668,11 @@ source = { editable = "packages/scanner" }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
+    { name = "ja-ner-ja" },
     { name = "pathspec" },
     { name = "pleno-recognizers" },
-]
-
-[package.optional-dependencies]
-deep = [
-    { name = "pleno-anonymize-server" },
+    { name = "presidio-analyzer" },
+    { name = "spacy", extra = ["ja"] },
 ]
 
 [package.dev-dependencies]
@@ -2672,11 +2684,12 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "ja-ner-ja", url = "https://huggingface.co/0xhikae/ja-ner-ja/resolve/main/ja_ner_ja-0.2.0-py3-none-any.whl" },
     { name = "pathspec", specifier = ">=0.12" },
-    { name = "pleno-anonymize-server", marker = "extra == 'deep'", editable = "server" },
     { name = "pleno-recognizers", editable = "packages/recognizers" },
+    { name = "presidio-analyzer", specifier = ">=2.2" },
+    { name = "spacy", extras = ["ja"], specifier = ">=3.8" },
 ]
-provides-extras = ["deep"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## What

Make the spaCy NER model (`ja_ner_ja`) a required dependency of `pleno-scan` and use it by default. Reverts the regex-only default introduced in #91.

```sh
# Default: NER + regex (Presidio + spaCy ja_ner_ja, same as server)
pleno-scan dir ./repo

# Offload to a remote endpoint (same pipeline, runs there)
pleno-scan dir ./repo --base-url https://pleno-anonymize.fly.dev
```

## Why

User feedback: ML model is mandatory for pleno-scan, not opt-in. The point of pleno-scan is to find PII — including free-text PII (`PERSON`, `ADDRESS`, `ORGANIZATION`) that no regex can detect — so shipping a regex-only default was wrong. The cloud (`--base-url`) should be an offload option, not the only way to access ML.

## How

- New `pleno_scan.ner_pass` module: lazy Presidio init mirroring `server._init_presidio` — `MultiLangSpacyNlpEngine` with `ja_ner_ja`, optional en model, all_ja_presidio recognizers.
- Scanner pyproject deps: `spacy[ja]>=3.8`, `presidio-analyzer>=2.2`, and `ja-ner-ja` pinned to the HF wheel via `[tool.uv.sources]` (same wheel server's Dockerfile uses).
- CLI default scan path: `regex_pass.scan_files` -> `ner_pass.scan_files`. `regex_pass` kept for git-history per-line scanning where NER overhead per short line is wasteful.
- Default entity profile expanded: previous regex non-noisy set + PERSON / ADDRESS / ORGANIZATION / DATE_OF_BIRTH / BANK_ACCOUNT.
- Local checksum verification (Luhn / My Number / corp number) still runs in both local and cloud paths.

## Verification

- 35/35 tests pass (3 new `test_ner_pass.py` tests, with skip-if-model-missing guard for air-gapped CI).
- Smoke test on fixtures/positive: PERSON 山田太郎 detected at customers.csv:2 by the local default — same coverage as cloud mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)