### PR TITLE
feat(training): wire augmented + external hardneg into HF dataset for #48

### DIFF
--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -418,6 +418,22 @@ json.dump(a+b,open('data/raw/ja-v02/generated_with_external.json','w',encoding='
 		--tokenizer ku-nlp/deberta-v2-tiny-japanese \
 		--include-negatives
 
+# v02-tiny + augmented (ORG diverse #80) + external Wikipedia hardneg (#64).
+# Uses augmented.json (which folds in org_diverse seeds via augment-ja) instead
+# of raw generated.json, so the trained model sees the full ORG vocabulary mix
+# (公益/学校/略称/カタカナ) plus FP-pressure hardneg from Wikipedia. Required
+# for #48 Phase 2 to drive adversarial precision past the 70% AC.
+convert-hf-v02-tiny-aug-ext: augment-ja mine-external-hardneg-ja
+	uv run python -c "import json,sys; \
+a=json.load(open('data/raw/ja-v02/augmented.json',encoding='utf-8')); \
+b=json.load(open('data/raw/ja-v02/external_hardneg.json',encoding='utf-8')); \
+json.dump(a+b,open('data/raw/ja-v02/augmented_with_external.json','w',encoding='utf-8'),ensure_ascii=False)"
+	uv run python -m pleno_ner_training.convert_to_hf_dataset \
+		--input data/raw/ja-v02/augmented_with_external.json \
+		--output data/hf/ja-v02-tiny-aug-ext \
+		--tokenizer ku-nlp/deberta-v2-tiny-japanese \
+		--include-negatives
+
 # Train counterpart (RunPod). Mirrors `train-hf-v02-tiny-hardneg` shape so
 # evaluate_benchmark auto-derives the entry key `hf_v02_tiny_hardneg_ext`.
 train-hf-v02-tiny-hardneg-ext:
@@ -425,6 +441,16 @@ train-hf-v02-tiny-hardneg-ext:
 		--dataset data/hf/ja-v02-tiny-hardneg-ext \
 		--model ku-nlp/deberta-v2-tiny-japanese \
 		--output output/hf-ja-v02-tiny-hardneg-ext \
+		--fp16 --num-epochs 20 --batch-size 16 \
+		--learning-rate 3e-5 --warmup-ratio 0.15
+
+# Train counterpart for the augmented + hardneg-ext dataset (#48 Phase 2).
+# Same hyperparameters as hardneg-ext so deltas isolate the dataset variable.
+train-hf-v02-tiny-aug-ext:
+	uv run python -m pleno_ner_training.train_hf \
+		--dataset data/hf/ja-v02-tiny-aug-ext \
+		--model ku-nlp/deberta-v2-tiny-japanese \
+		--output output/hf-ja-v02-tiny-aug-ext \
 		--fp16 --num-epochs 20 --batch-size 16 \
 		--learning-rate 3e-5 --warmup-ratio 0.15
 


### PR DESCRIPTION
## Phase A complete (issue #48 prep)

### What
2 new Makefile targets that produce the training dataset that #48 Phase 2 needs:

| Target | Inputs | Output |
|---|---|---|
| `convert-hf-v02-tiny-aug-ext` | augmented.json (17565) + external_hardneg.json (4000) | data/hf/ja-v02-tiny-aug-ext (train=16554, dev=2069, test=2070) |
| `train-hf-v02-tiny-aug-ext` | data/hf/ja-v02-tiny-aug-ext | output/hf-ja-v02-tiny-aug-ext |

### Why
The existing `hardneg-ext` target uses raw `generated.json` and misses the #80 ORG diverse seeds (公益/学校/略称/カタカナ) that get folded into `augmented.json` via `augment-ja`. For Phase 2 to drive adversarial precision past 70%, the trained model must see all three Wave 1 improvements together:
- #80 ORG positive vocabulary diversity → `augment-ja`
- #64 external Wikipedia FP-pressure hardneg → `mine-external-hardneg-ja`  
- #83 PII heuristic filter (already inside `convert_to_hf_dataset`)

### Verified locally
```
augmented: 17565, external: 4000, total: 21565
Split: train=16554, dev=2069, test=2070
Saved to data/hf/ja-v02-tiny-aug-ext
```

### Not in this PR
- Actual GPU training run + scores.json update — blocked on RunPod proxy SSH auth (pubkey `SHA256:w3PqR0mN5g40AgnUrg5XWf+QuuGpgkrI1NjDPfv0Jik` not authenticating against ssh.runpod.io as of this attempt; 2 pods × 3-5 min retry each, both reject)
- Phase B-H of #48 will run once SSH unblocks. PR #79's `model/v0.13.0` tag-push pipeline will fire afterwards.

Refs #48 #80 #64