### PR TITLE
docs(readme): rewrite as current-facts only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,65 @@
 # pleno-anonymize
 
-Japanese-first PII anonymization service — **Dev F1 95.8% (ja, in-domain held-out) · Adversarial F1 49.0% (ja, v0.12.0 FP-pressure)**[^adv]
+日本語に強い PII 匿名化基盤。2 つの使い方で同じ NER + Presidio パイプラインを共有する。
 
-Purpose-built for Japanese PII that generic NER models miss: My Number, full-width phone numbers, Japanese-style addresses. Also provides transparent LLM API proxies with automatic PII redaction.
+- **`pleno-anonymize` server** — `/api/analyze` `/api/redact` と OpenAI/Anthropic/Gemini プロキシを公開する HTTP サービス
+- **`pleno-scan` CLI** — リポジトリやコミット履歴を走査して PII を検出する gitleaks/trufflehog 風スキャナー
 
-- **Playground:** https://plenoai.com/pleno-anonymize/playground
-- **Benchmark:** https://plenoai.com/pleno-anonymize/benchmark
-- **API Docs:** https://anonymize.plenoai.com/docs
+エンドポイント: https://pleno-anonymize.fly.dev (`/docs` で API リファレンス)
+プレイグラウンド: https://plenoai.com/pleno-anonymize/playground
 
-## Use Cases
-
-- **PII protection for LLM calls** — Auto-mask PII before sending to OpenAI/Anthropic/Gemini, restore in response
-- **Log & data cleaning** — Anonymize internal logs and customer data
-- **Compliance** — Pre-process data for APPI (Japan) and GDPR compliance
-
-## Model Performance
-
-Two complementary metrics are tracked. See [Methodology — Dev F1 vs Adversarial F1](#methodology--dev-f1-vs-adversarial-f1) for why they diverge.
-
-| Language | Dev F1 | Dev Precision | Dev Recall | Adversarial F1 (latest) |
-|---|---|---|---|---|
-| ja (CNN) | 95.8% | 96.0% | 95.6% | **49.0%** (v0.12.0)[^adv] |
-| en (Transformer) | 97.9% | 97.3% | 98.6% | 72.5% (v0.4.0) |
-
-### Benchmark Progress (ja, adversarial strict-span F1)
-
-| Benchmark | v0.4.0 | v0.5.0 | v0.12.0 | v0.13.0 |
-|---|---|---|---|---|
-| Overall F1 | **86.9%** | **86.7%** | 49.0% | _pending #48_ |
-| Overall Precision | — | — | 33.0% | _pending #48_ |
-| Overall Recall | — | — | 95.2% | _pending #48_ |
-| PERSON F1 | 88.5% | 89.6% | 83.7% | _pending #48_ |
-| ADDRESS F1 | 84.0% | 89.2% | 88.4% | _pending #48_ |
-| ORGANIZATION F1 | 84.5% | 89.5% | 21.6% | _pending #48_ |
-| DATE_OF_BIRTH F1 | 91.2% | 71.5% | 46.2% | _pending #48_ |
-| BANK_ACCOUNT F1 | 86.9% | 86.1% | 49.0% | _pending #48_ |
-
-### Per-entity Adversarial Precision / Recall (ja, v0.12.0)[^adv]
-
-| Entity | Precision | Recall | F1 |
-|---|---|---|---|
-| PERSON | 72.0% | 100.0% | 83.7% |
-| ADDRESS | 84.0% | 93.3% | 88.4% |
-| ORGANIZATION | 12.3% | 89.2% | 21.6% |
-| DATE_OF_BIRTH | 30.9% | 91.3% | 46.2% |
-| BANK_ACCOUNT | 32.4% | 100.0% | 49.0% |
-
-> spaCy's built-in model (`ja_core_news_lg`) achieves ~60-70% F1 on Japanese PII detection on similar adversarial corpora.
-
-## Methodology — Dev F1 vs Adversarial F1
-
-- **Dev F1** measures performance on a held-out portion of `generated.json` — the same synthetic distribution the model is trained on. It captures upper-bound capacity on in-domain templates.
-- **Adversarial F1** (v0.12.0 FP-pressure suite) measures strict-span micro F1 on a curated DLP corpus that mimics real-world docs: OCR/key-value collapse, dense negative documents (88% negative-only), and lexically diverse organization names. It is the production-honest number.
-- The two diverge because the FP-pressure suite stresses **precision** under heavy negatives — recall stays high (95%+) while precision collapses on `ORGANIZATION` and `BANK_ACCOUNT` (12% / 32%). Dev F1 cannot surface this because its negative density and entity diversity are far lower.
-- Adversarial scores are emitted by `pleno_ner_training.evaluate_benchmark` and persisted at [`packages/training/data/benchmark/v0.12.0/ja/scores.json`](packages/training/data/benchmark/v0.12.0/ja/scores.json) (`pleno_ner` entry). Treat this file as the canonical source of truth; Dev F1 lives in the spaCy training meta and is reported for capacity tracking only.
-
-[^adv]: Source: [`packages/training/data/benchmark/v0.12.0/ja/scores.json`](packages/training/data/benchmark/v0.12.0/ja/scores.json) — `pleno_ner` entry, strict-span micro F1, 500 docs (440 negative). v0.13.0 row is reserved for the post-#48 retrain.
-
-## Quick Start
+## サービスを使う (HTTP)
 
 ```bash
-curl -X POST https://anonymize.plenoai.com/api/analyze \
-  -H "Content-Type: application/json" \
-  -d '{"text": "John Doe lives at 123 Main St. Email: john@example.com", "language": "en"}'
+curl -X POST https://pleno-anonymize.fly.dev/api/analyze \
+  -H "content-type: application/json" \
+  -d '{"text":"連絡先 山田太郎 090-1234-5678","language":"ja"}'
 ```
 
-Or try the [Playground](https://plenoai.com/pleno-anonymize/playground) in your browser.
+LLM プロキシ経由で送ると、プロバイダに到達する前に PII をマスクし、レスポンスで元の値に復元する。
 
-## Supported Entities
-
-### NER Model (ja/en)
-| Entity | Description |
+| エンドポイント | 上流 |
 |---|---|
-| `PERSON` | Person names |
-| `ADDRESS` | Addresses |
-| `ORGANIZATION` | Organization names |
-| `DATE_OF_BIRTH` | Date of birth |
-| `BANK_ACCOUNT` | Bank account info |
+| `POST /api/openai/*` | OpenAI Chat Completions / Responses |
+| `POST /api/anthropic/*` | Anthropic Messages |
+| `POST /api/gemini/*` | Google Gemini |
 
-### Pattern-based
-| Entity | Description |
-|---|---|
-| `EMAIL_ADDRESS` | Email addresses |
-| `PHONE_NUMBER` | Phone numbers (full-width/half-width) |
-| `MY_NUMBER` | My Number (Japanese individual number) |
-| `MY_NUMBER_CORPORATE` | Corporate number |
-| `CREDIT_CARD` | Credit card numbers |
-| `PASSPORT` | Passport numbers |
-| `DRIVER_LICENSE` | Driver license numbers |
-| `HEALTH_INSURANCE` | Health insurance card numbers |
-| `RESIDENCE_CARD` | Residence card numbers |
-| `POSTAL_CODE` | Postal codes |
-| `IP_ADDRESS` | IP addresses |
-| `URL` | URLs |
-
-## API
-
-### `POST /api/analyze` — PII Detection
+## リポジトリをスキャンする (CLI)
 
 ```bash
-curl -X POST https://anonymize.plenoai.com/api/analyze \
-  -H "Content-Type: application/json" \
-  -d '{"text": "John Doe, phone: 090-1234-5678", "language": "en"}'
+uv sync                                   # ja_ner_ja モデル含めてセットアップ
+uv run pleno-scan dir ./my-repo           # ディレクトリ
+uv run pleno-scan git ./my-repo           # working tree + commit 履歴
+uv run pleno-scan github owner/repo       # clone してスキャン
+uv run pleno-scan protect                 # pre-commit (staged hunks のみ)
 ```
 
-### `POST /api/redact` — PII Redaction
+サーバを別マシンで動かしている場合は `--base-url` でオフロードできる:
 
 ```bash
-curl -X POST https://anonymize.plenoai.com/api/redact \
-  -H "Content-Type: application/json" \
-  -d '{"text": "John Doe, phone: 090-1234-5678", "language": "en"}'
+uv run pleno-scan dir ./my-repo --base-url https://pleno-anonymize.fly.dev
 ```
 
-### LLM API Proxy
+詳細は [`packages/scanner/README.md`](packages/scanner/README.md)。
 
-Automatically masks PII in requests before forwarding to LLM APIs, then restores original values in responses.
+## 検出できる PII
 
-| Endpoint | Upstream API |
-|---|---|
-| `POST /api/openai/*` | OpenAI (Chat Completions & Responses API) |
-| `POST /api/anthropic/*` | Anthropic Messages API |
-| `POST /api/gemini/*` | Google Gemini API |
+| 種別 | 検出方法 | エンティティ |
+|---|---|---|
+| 自由文 | spaCy NER (`ja_ner_ja`) + Presidio | `PERSON` `ADDRESS` `ORGANIZATION` `DATE_OF_BIRTH` `BANK_ACCOUNT` |
+| 構造化 | 正規表現 + checksum (Luhn / マイナンバー / 法人番号) | `PHONE_NUMBER` `MY_NUMBER` `MY_NUMBER_CORPORATE` `CREDIT_CARD` `PASSPORT` `DRIVER_LICENSE` `HEALTH_INSURANCE` `RESIDENCE_CARD` `POSTAL_CODE` `EMAIL_ADDRESS` `IP_ADDRESS` `URL` |
 
-```bash
-curl -X POST https://anonymize.plenoai.com/api/openai/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $OPENAI_API_KEY" \
-  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Tell me about John Doe"}]}'
-```
+サーバ・CLI どちらも同じレジストリを読み込むため、同じ入力に対して同じエンティティ集合を返す。
 
-## Self-hosting
+## セルフホスト
 
 ```bash
 docker build -t pleno-anonymize .
 docker run -p 8080:8080 pleno-anonymize
 ```
 
-## License
+`fly.toml` 同梱。`flyctl deploy --local-only` でそのまま fly.io に上がる。
 
-[AGPL-3.0](LICENSE) / [Privacy Policy](docs/PRIVACY.md) / [DPIA](docs/DPIA.md)
+## ライセンス
+
+[AGPL-3.0](LICENSE) · [Privacy Policy](docs/PRIVACY.md) · [DPIA](docs/DPIA.md)

--- a/packages/scanner/README.md
+++ b/packages/scanner/README.md
@@ -1,127 +1,98 @@
 # pleno-scan
 
-PII scanner for source repositories. Japanese-first. gitleaks/trufflehog UX.
+リポジトリ・コミット履歴・staged hunk から日本語 PII を検出する CLI。
 
-## Why
-
-`pleno-anonymize` redacts PII at request time via a proxy. `pleno-scan`
-catches PII **before** it reaches a remote repo or LLM — running locally,
-in CI, or as a pre-commit hook.
-
-## Install (within this monorepo)
+## セットアップ
 
 ```sh
 uv sync
 ```
 
-## Usage
+`ja_ner_ja` モデルも依存に含まれているので追加手順は不要。
+
+## サブコマンド
 
 ```sh
-# Scan a directory
-uv run pleno-scan dir ./my-repo
-
-# Scan local git repo, including history
-uv run pleno-scan git ./my-repo
-
-# Clone-and-scan a public GitHub repo (shallow)
-uv run pleno-scan github octocat/Hello-World
-
-# Scan every repo in an org (requires gh CLI)
-uv run pleno-scan github --org my-company
-
-# Pre-commit guard (in .git/hooks/pre-commit or lefthook config)
-uv run pleno-scan protect
-
-# Capture current findings as a baseline so they stop appearing
-uv run pleno-scan baseline ./my-repo --out .plenoignore-baseline.json
+pleno-scan dir <path>           # ディレクトリを走査
+pleno-scan git <path>           # working tree + commit 履歴
+pleno-scan github <owner>/<repo>  # shallow clone して走査
+pleno-scan github --org <org>     # gh CLI で org の全 repo を列挙して走査
+pleno-scan baseline <path>      # 現状の検出を suppression list として保存
+pleno-scan protect              # staged hunks だけ走査 (pre-commit hook 用)
 ```
 
-### Local (default) vs cloud offload
+## ローカル / オフロード
 
-By default, `pleno-scan` runs **locally** with the same Presidio + spaCy NER (`ja_ner_ja`) + regex pipeline that powers the pleno-anonymize server. The ML model is required: it ships as a workspace dependency and `uv sync` installs it automatically. Local scans detect free-text PII (`PERSON`, `ADDRESS`, `ORGANIZATION`) in addition to all the regex-backed entities.
-
-Pass `--base-url` (or set `PLENO_BASE_URL`) to **offload** the same pipeline to a remote pleno-anonymize endpoint — useful when you don't want to load the model locally (e.g. lightweight CI runners) or when scanning a huge repo from a workstation.
+デフォルトはローカルで Presidio + spaCy NER (`ja_ner_ja`) + 正規表現を実行。
 
 ```sh
-# Local (default): NER + regex, single-process, model loaded once
-uv run pleno-scan dir ./my-repo
-
-# Offload to a hosted endpoint
-uv run pleno-scan dir ./my-repo --base-url https://pleno-anonymize.fly.dev
-
-# CI-friendly env var
-PLENO_BASE_URL=https://pleno-anonymize.fly.dev pleno-scan dir ./my-repo
-
-# Auth (if your endpoint requires it)
-uv run pleno-scan dir ./my-repo \
-    --base-url https://internal.example.com \
-    --api-key "$PLENO_API_KEY"
-
-# Throttle parallel HTTP requests in offload mode
-uv run pleno-scan dir ./my-repo --base-url ... --concurrency 4
+pleno-scan dir ./my-repo --base-url https://pleno-anonymize.fly.dev
+PLENO_BASE_URL=... pleno-scan dir ./my-repo
+pleno-scan dir ./my-repo --base-url ... --api-key "$PLENO_API_KEY"
 ```
 
-| Mode | Where compute runs | Network | Memory | Use when |
-|---|---|---|---|---|
-| Local (default) | This machine | none | model loaded once (~200MB) | normal use |
-| Cloud (`--base-url`) | Remote pleno-anonymize | required | none | thin CI runners, very large scans |
+両モードとも返ってくるエンティティ集合は同じ。git 履歴のスキャンは行単位の NER オーバーヘッドが見合わないため常に正規表現のみ。
 
-Both modes return the same entity set; the only difference is *where* the model runs. Git history scanning always uses regex-only matching (per-line NER is wasteful for short diff lines).
+## 検出エンティティ
 
-### Output formats
+NER (`ja_ner_ja` + Presidio): `PERSON` `ADDRESS` `ORGANIZATION` `DATE_OF_BIRTH` `BANK_ACCOUNT`
 
-- `--report-format human` (default) — colorized table
-- `--report-format json` — machine-readable
-- `--report-format sarif` — upload to GitHub Code Scanning
+正規表現 + checksum: `PHONE_NUMBER` `MY_NUMBER` `MY_NUMBER_CORPORATE` `CREDIT_CARD` `PASSPORT` `DRIVER_LICENSE` `HEALTH_INSURANCE` `RESIDENCE_CARD` `POSTAL_CODE` `EMAIL_ADDRESS` `IP_ADDRESS` `URL`
 
-### Verification
+`URL` `HEALTH_INSURANCE` `DRIVER_LICENSE` はソースコード上で誤検出が多いためデフォルトプロファイルから除外。`--entities ALL` で全部、`--entities PHONE_NUMBER,EMAIL_ADDRESS` で個別指定。
 
-Each finding is annotated with one of:
+## Verification
 
-- `passed` — checksum-validated (Luhn / My Number / corp number) **or**
-  contextual keyword nearby
-- `failed` — checksum failed (likely false positive)
-- `unverified` — no validator and no context boost
+各 finding には `passed` / `failed` / `unverified` のラベルが付く。
 
-Use `--only-verified` to suppress unverified/failed findings (trufflehog-style).
+- `passed` — checksum (Luhn / マイナンバー / 法人番号) を通過、または同行近傍に文脈キーワード
+- `failed` — checksum 失敗 (誤検出の可能性が高い)
+- `unverified` — 該当する validator が無く文脈ヒットも無い
 
-### Suppressing findings
+`--only-verified` で `passed` のみに絞れる。
 
-`.plenoignore` (gitleaks-style):
+## 出力
+
+| `--report-format` | 用途 |
+|---|---|
+| `human` (既定) | カラー付きテーブル |
+| `json` | 機械可読 |
+| `sarif` | GitHub Code Scanning 投入可能な SARIF 2.1.0 |
+
+`--report-path FILE` でファイル出力。終了コードは `0`(検出なし) / `1`(検出あり) / `2`(usage error)。
+
+## 抑制
+
+リポルートに `.plenoignore` を置くと自動で読まれる:
 
 ```
-docs/samples/**         # path glob
-PHONE_NUMBER            # entity-wide
-finding:7a3b8c9d        # specific finding fingerprint
+docs/samples/**          # path glob (gitignore syntax)
+PHONE_NUMBER             # entity 全体
+finding:7a3b8c9d         # 特定 finding の fingerprint
 ```
 
-Inline:
+行内ディレクティブ:
 
 ```py
 SUPPORT_PHONE = "0120-123-456"  # pleno:ignore PHONE_NUMBER
-EXAMPLE_EMAIL = "noreply@example.com"  # pleno:ignore
+EXAMPLE_EMAIL = "user@example.com"  # pleno:ignore
 ```
 
-### Exit codes
+`pleno-scan baseline` で現状の検出を fingerprint 一覧として吐き出し、`--baseline FILE` で適用すれば既知の finding をまとめて無視できる。
 
-- `0` — no findings (or `--exit-zero`)
-- `1` — findings present
-- `2` — usage error
+## 主なフラグ
 
-## Detected entities
+| フラグ | 既定 | 役割 |
+|---|---|---|
+| `--entities` | デフォルトプロファイル | 検出対象を絞る (`PHONE,EMAIL` / `ALL`) |
+| `--language` | `ja` | 解析言語 (`ja` / `en`) |
+| `--base-url` | (なし) | リモート pleno-anonymize へオフロード |
+| `--api-key` | (なし) | オフロード時の Bearer token |
+| `--concurrency` | 8 | オフロード時の並列リクエスト数 |
+| `--include` / `--exclude` | (なし) | gitignore 風 glob でファイル絞り込み |
+| `--max-file-size` | 1 MB | これを超えるファイルは skip |
+| `--only-verified` | off | `passed` 以外を抑制 |
+| `--report-format` | `human` | `human` / `json` / `sarif` |
+| `--baseline` | (なし) | 既知 finding を抑制する fingerprint JSON |
 
-Japanese: `PHONE_NUMBER`, `MY_NUMBER`, `CREDIT_CARD`, `PASSPORT`,
-`DRIVER_LICENSE`, `IP_ADDRESS`, `EMAIL_ADDRESS`, `MY_NUMBER_CORPORATE`,
-`HEALTH_INSURANCE`, `RESIDENCE_CARD`, `POSTAL_CODE`, `URL`, `BANK_ACCOUNT`.
-
-NER-based entities (`PERSON`, `ADDRESS`, `ORGANIZATION`) require the deep
-mode (planned).
-
-## How it stays fast
-
-- Multiprocess regex pass (one worker per CPU core).
-- Built-in skip list for noisy directories (`node_modules`, `.git`, etc.).
-- `.gitignore`-aware.
-- Binary file detection (NUL byte probe).
-- 1 MB per-file size cap by default.
-- Git history pass uses `--unified=0` and only scans **added** lines.
+`--gitignore` と built-in skip リスト (`.git`, `node_modules`, `.venv`, `dist`, `build`, `vendor`, …) と NUL byte によるバイナリ判定はデフォルトで効いている。


### PR DESCRIPTION
## What

Rebuild root README and packages/scanner/README to contain only currently-true information. Strip:

- Benchmark history tables (v0.4.0 / v0.5.0 / v0.12.0 / v0.13.0 columns)
- Per-version per-entity precision/recall breakdowns
- Methodology long-form explanation about Dev F1 vs Adversarial F1
- Footnote pointers to scores.json
- 'planned' / 'requires deep mode' aspirational text
- Multiprocess regex-pass description (no longer accurate after #92)

## Why

User feedback: too much noise. README should describe what the project is right now, how to use it, and what to expect — not its benchmark archaeology. Detailed methodology and per-version benchmark numbers belong in docs/ or scores.json, not on the front page.

## Result

- Root: 141 -> 65 lines. Two products (server + scanner) sharing the same NER + Presidio pipeline, HTTP usage, CLI usage, one entity table, self-host one-liner.
- Scanner: 127 -> 98 lines. Subcommand list, local vs --base-url offload, entity table with default-profile carve-out, verification labels, output formats, .plenoignore syntax, flag table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)