### PR TITLE
feat(training): close en gap to v0.13.0 (held-out + manifest + HF tiny pipeline)

### DIFF
--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -11,7 +11,11 @@
        convert-hf-v02 train-hf-v02 export-onnx-v02 push-hf-v02 all-hf-ja-v02 \
        convert-hf-v02-tiny train-hf-v02-tiny export-onnx-v02-tiny push-hf-v02-tiny all-hf-ja-v02-tiny \
        mine-external-hardneg-ja mine-external-hardneg-ja-dry-run \
-       convert-hf-v02-tiny-hardneg-ext train-hf-v02-tiny-hardneg-ext
+       convert-hf-v02-tiny-hardneg-ext train-hf-v02-tiny-hardneg-ext \
+       mine-external-hardneg-en mine-external-hardneg-en-dry-run \
+       convert-hf-en-v01-tiny convert-hf-en-v01-tiny-hardneg-ext \
+       train-hf-en-v01-tiny train-hf-en-v01-tiny-hardneg-ext \
+       export-onnx-en-v01-tiny push-hf-en-v01-tiny all-hf-en-v01-tiny
 
 MODEL ?= gpt-5.4-nano
 DOCS_PER_TEMPLATE ?= 20
@@ -593,6 +597,96 @@ sweep-threshold-org-v12: predict-scores-v12-aug-ext
 		--thresholds 0.0 0.5 0.7 0.8 0.85 0.9 0.95 0.99 \
 		--output-md data/benchmark/v0.12.0/ja/threshold_sweep_org.md \
 		--output-json data/benchmark/v0.12.0/ja/threshold_sweep_org.json
+
+# === HuggingFace Pipeline (en, tiny, browser-optimized) ===
+# Mirrors the ja v02-tiny pipeline (#48) for English. The en side has only
+# data/raw/en/generated.json (4818 docs) today vs ja's ~64.5k docs across
+# generated + augmented + address_extra + ja-v02-extra; this scaffolding lets
+# subsequent runs grow the en training set incrementally without bespoke
+# Makefile edits each time.
+#
+# Tokenizer / model: microsoft/deberta-v3-xsmall (~22M params), the en
+# analogue of ku-nlp/deberta-v2-tiny-japanese. Fast tokenizer, ONNX-friendly,
+# small enough for browser inference via optimum onnxruntime-web.
+
+# Mine PII-free hard-negative docs from English Wikipedia (CC-BY-SA 4.0) for
+# ORG / person-name / address FP pressure. Same generated.json schema as the
+# ja flow so it can be merged before convert.
+mine-external-hardneg-en:
+	uv run python -m pleno_ner_training.mine_external_hardneg \
+		--dataset wikimedia/wikipedia \
+		--config 20231101.en \
+		--output data/raw/en/external_hardneg.json \
+		--max-docs 4000
+
+# Network-free smoke test for CI / local dev.
+mine-external-hardneg-en-dry-run:
+	uv run python -m pleno_ner_training.mine_external_hardneg \
+		--output data/raw/en/external_hardneg.json \
+		--max-docs 5 --dry-run
+
+# en-v01-tiny: convert raw/en/generated.json → HF dataset (BIO labels, fast
+# tokenizer alignment). PII_HINT_RE in convert_to_hf_dataset.py is a strict
+# superset of ja patterns; en text simply does not match the ja-only regexes
+# so they degrade to no-ops, keeping en zero-entity docs as-is (true negatives,
+# not silently dropped).
+convert-hf-en-v01-tiny:
+	uv run python -m pleno_ner_training.convert_to_hf_dataset \
+		--input data/raw/en/generated.json \
+		--output data/hf/en-v01-tiny \
+		--tokenizer microsoft/deberta-v3-xsmall
+
+# en-v01-tiny + Wikipedia hardneg merged (ORG-FP pressure analogue of #64).
+# Pre-merges generated.json + external_hardneg.json into a single tmp file
+# so the converter sees one input. Inline python avoids adding a stand-alone
+# merge module for a 6-line operation (mirrors convert-hf-v02-tiny-hardneg-ext).
+convert-hf-en-v01-tiny-hardneg-ext: mine-external-hardneg-en
+	uv run python -c "import json; \
+a=json.load(open('data/raw/en/generated.json',encoding='utf-8')); \
+b=json.load(open('data/raw/en/external_hardneg.json',encoding='utf-8')); \
+json.dump(a+b,open('data/raw/en/generated_with_external.json','w',encoding='utf-8'),ensure_ascii=False)"
+	uv run python -m pleno_ner_training.convert_to_hf_dataset \
+		--input data/raw/en/generated_with_external.json \
+		--output data/hf/en-v01-tiny-hardneg-ext \
+		--tokenizer microsoft/deberta-v3-xsmall \
+		--include-negatives
+
+# Train deberta-v3-xsmall fine-tune. RunPod GPU expected (CLAUDE.md: do not
+# train on local machine). Hyperparameters mirror ja-v02-tiny so deltas
+# isolate the data variable, not the optimizer.
+train-hf-en-v01-tiny:
+	uv run python -m pleno_ner_training.train_hf \
+		--dataset data/hf/en-v01-tiny \
+		--model microsoft/deberta-v3-xsmall \
+		--output output/hf-en-v01-tiny \
+		--fp16 --num-epochs 20 --batch-size 16 \
+		--learning-rate 3e-5 --warmup-ratio 0.15
+
+train-hf-en-v01-tiny-hardneg-ext:
+	uv run python -m pleno_ner_training.train_hf \
+		--dataset data/hf/en-v01-tiny-hardneg-ext \
+		--model microsoft/deberta-v3-xsmall \
+		--output output/hf-en-v01-tiny-hardneg-ext \
+		--fp16 --num-epochs 20 --batch-size 16 \
+		--learning-rate 3e-5 --warmup-ratio 0.15
+
+export-onnx-en-v01-tiny:
+	uv run python -m pleno_ner_training.export_onnx \
+		--model output/hf-en-v01-tiny \
+		--output output/hf-en-v01-tiny-onnx
+
+# Push to HF Hub. Repo `0xhikae/en-ner-onnx` is the en analogue of
+# `0xhikae/ja-ner-onnx@v0.13.0` consumed by pleno-pii-scanner's HF backend.
+push-hf-en-v01-tiny:
+	uv run python -m pleno_ner_training.export_onnx \
+		--model output/hf-en-v01-tiny \
+		--output output/hf-en-v01-tiny-onnx \
+		--push-to 0xhikae/en-ner-onnx
+
+# End-to-end (assumes en raw + RunPod GPU). The `mine-external-hardneg-en`
+# step in convert-hf-en-v01-tiny-hardneg-ext makes this network-dependent;
+# split into two runs for offline reproducibility.
+all-hf-en-v01-tiny: convert-hf-en-v01-tiny train-hf-en-v01-tiny export-onnx-en-v01-tiny push-hf-en-v01-tiny
 
 # === 共通 ===
 

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -7,6 +7,7 @@
        benchmark-v10-generate benchmark-v10-evaluate benchmark-v10-generate-en benchmark-v10-evaluate-en \
        benchmark-v11-generate benchmark-v11-evaluate benchmark-v11-generate-en benchmark-v11-evaluate-en \
        benchmark-v12-generate benchmark-v12-evaluate benchmark-v12-generate-en benchmark-v12-evaluate-en \
+       benchmark-v13-held-out-evaluate benchmark-v13-held-out-evaluate-en \
        verify-leakage-v12 pin-noise-floor-v12 compare-baselines-v12 runpod-gpu-compare-v12 \
        convert-hf-v02 train-hf-v02 export-onnx-v02 push-hf-v02 all-hf-ja-v02 \
        convert-hf-v02-tiny train-hf-v02-tiny export-onnx-v02-tiny push-hf-v02-tiny all-hf-ja-v02-tiny \
@@ -393,6 +394,20 @@ benchmark-v12-evaluate-en:
 	uv run python -m pleno_ner_training.evaluate_benchmark \
 		--model $(EN_MODEL) \
 		--language en --version v0.12.0
+
+# v0.13.0-held-out: pre-built raw.json under data/benchmark/v0.13.0-held-out/<lang>/
+# (no generate target — held-out is the *test* partition kept disjoint from
+# training data; rebuilding it from prompts would defeat that). Convert the
+# raw.json once to test.spacy via convert_to_docs, then evaluate.
+benchmark-v13-held-out-evaluate:
+	uv run python -m pleno_ner_training.evaluate_benchmark \
+		--model $(OUTPUT_DIR)/model-best \
+		--language ja --version v0.13.0-held-out
+
+benchmark-v13-held-out-evaluate-en:
+	uv run python -m pleno_ner_training.evaluate_benchmark \
+		--model $(EN_MODEL) \
+		--language en --version v0.13.0-held-out
 
 # === HuggingFace Pipeline ===
 

--- a/packages/training/data/benchmark/v0.12.0/en/training_corpus_manifest.json
+++ b/packages/training/data/benchmark/v0.12.0/en/training_corpus_manifest.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "SHA256-NFC",
+  "generated_at": "2026-05-04T09:41:59.973770+00:00",
+  "language": "en",
+  "manifest_hash": "2835dee5c6b64d38199a4e0e5f55506f6a0a712daeb3f310c7b19350457ae7c7",
+  "note": "doc_hashes recomputed at runtime from source files (paths under git tracking).",
+  "schema_version": "1.1",
+  "sources": [
+    {
+      "doc_count": 4818,
+      "doc_hashes_first5": [
+        "c2d616811682938eb3ce83f6841e82c7143d24ca83bd214bcba11ef9b8d2e763",
+        "e4ff04332364511c57dc60a868f79313dd53a9c2ce4ae63ef1543746d3730618",
+        "94b2447a9889f6fd7838b3ab5a6a48a639d8ee8b4f506cb548b272d306fe4055",
+        "9ff16a007d96686a851b180364964399cfe12e9bf7a5d1b9a8e55af174a68f66",
+        "fab81cbff954960cd0e5d47cf5468c4111e9d86900ef43ae8f1c215e2f401c81"
+      ],
+      "file_sha256": "b51757216d883b83c036c4c44822540856dd235eb36827133be32702279b6d95",
+      "name": "raw_en_generated",
+      "path": "packages/training/data/raw/en/generated.json"
+    }
+  ]
+}

--- a/packages/training/data/benchmark/v0.12.1-leak-fixed/en/training_corpus_manifest.json
+++ b/packages/training/data/benchmark/v0.12.1-leak-fixed/en/training_corpus_manifest.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "SHA256-NFC",
+  "generated_at": "2026-05-04T09:41:59.973770+00:00",
+  "language": "en",
+  "manifest_hash": "2835dee5c6b64d38199a4e0e5f55506f6a0a712daeb3f310c7b19350457ae7c7",
+  "note": "doc_hashes recomputed at runtime from source files (paths under git tracking).",
+  "schema_version": "1.1",
+  "sources": [
+    {
+      "doc_count": 4818,
+      "doc_hashes_first5": [
+        "c2d616811682938eb3ce83f6841e82c7143d24ca83bd214bcba11ef9b8d2e763",
+        "e4ff04332364511c57dc60a868f79313dd53a9c2ce4ae63ef1543746d3730618",
+        "94b2447a9889f6fd7838b3ab5a6a48a639d8ee8b4f506cb548b272d306fe4055",
+        "9ff16a007d96686a851b180364964399cfe12e9bf7a5d1b9a8e55af174a68f66",
+        "fab81cbff954960cd0e5d47cf5468c4111e9d86900ef43ae8f1c215e2f401c81"
+      ],
+      "file_sha256": "b51757216d883b83c036c4c44822540856dd235eb36827133be32702279b6d95",
+      "name": "raw_en_generated",
+      "path": "packages/training/data/raw/en/generated.json"
+    }
+  ]
+}

--- a/packages/training/data/benchmark/v0.13.0-held-out/en/raw.json
+++ b/packages/training/data/benchmark/v0.13.0-held-out/en/raw.json
@@ -1,0 +1,1446 @@
+[
+  {
+    "text": "The logistics policy page mostly discusses delivery windows and temperature ranges, but the edge of an OCR scan still shows `John A. Smith` and `234 Harbor Way, Boston, MA 02110`, with sender `Shibuya Branch Business Support Inc.` left visible.",
+    "entities": [
+      {
+        "start": 125,
+        "end": 138,
+        "label": "PERSON",
+        "text": "John A. Smith"
+      },
+      {
+        "start": 145,
+        "end": 177,
+        "label": "ADDRESS",
+        "text": "234 Harbor Way, Boston, MA 02110"
+      },
+      {
+        "start": 193,
+        "end": 229,
+        "label": "ORGANIZATION",
+        "text": "Shibuya Branch Business Support Inc."
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 0
+    }
+  },
+  {
+    "text": "Warehouse signage diagrams display only shelf numbers and work dates, yet the lower-right slip reads `Hannah Sato`, return address `488 Broadway, Apt 6B, New York, NY 10013`, refund account `Bank of America Routing 026009593 Account 5566778`.",
+    "entities": [
+      {
+        "start": 102,
+        "end": 113,
+        "label": "PERSON",
+        "text": "Hannah Sato"
+      },
+      {
+        "start": 132,
+        "end": 172,
+        "label": "ADDRESS",
+        "text": "488 Broadway, Apt 6B, New York, NY 10013"
+      },
+      {
+        "start": 191,
+        "end": 240,
+        "label": "BANK_ACCOUNT",
+        "text": "Bank of America Routing 026009593 Account 5566778"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 1
+    }
+  },
+  {
+    "text": "The shipping FAQ body covers parcel sizing and ETA boilerplate, but a footnote thumbnail embeds `Priya Iyer`, `17 Rue de Lisbonne, Paris 75008`, and `May 10, 1965`.",
+    "entities": [
+      {
+        "start": 97,
+        "end": 107,
+        "label": "PERSON",
+        "text": "Priya Iyer"
+      },
+      {
+        "start": 111,
+        "end": 142,
+        "label": "ADDRESS",
+        "text": "17 Rue de Lisbonne, Paris 75008"
+      },
+      {
+        "start": 150,
+        "end": 162,
+        "label": "DATE_OF_BIRTH",
+        "text": "May 10, 1965"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 2
+    }
+  },
+  {
+    "text": "The venue guide carries only maps and timetables, yet an attached scan slips in `Olivia Bennett`, `742 Evergreen Terrace, Springfield, IL 62701`, and `Aoyagi Bridge Development Co.` on a delivery slip.",
+    "entities": [
+      {
+        "start": 81,
+        "end": 95,
+        "label": "PERSON",
+        "text": "Olivia Bennett"
+      },
+      {
+        "start": 99,
+        "end": 143,
+        "label": "ADDRESS",
+        "text": "742 Evergreen Terrace, Springfield, IL 62701"
+      },
+      {
+        "start": 151,
+        "end": 180,
+        "label": "ORGANIZATION",
+        "text": "Aoyagi Bridge Development Co."
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 3
+    }
+  },
+  {
+    "text": "The delivery policy explainer page only discusses receiving conditions, yet a stray label image prints `Marcus DeLuca`, `88 Market Street, Suite 410, San Francisco, CA 94103`, and `1991/03/28`.",
+    "entities": [
+      {
+        "start": 104,
+        "end": 117,
+        "label": "PERSON",
+        "text": "Marcus DeLuca"
+      },
+      {
+        "start": 121,
+        "end": 173,
+        "label": "ADDRESS",
+        "text": "88 Market Street, Suite 410, San Francisco, CA 94103"
+      },
+      {
+        "start": 181,
+        "end": 191,
+        "label": "DATE_OF_BIRTH",
+        "text": "1991/03/28"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 4
+    }
+  },
+  {
+    "text": "The logistics report body sticks to generic KPIs and dates, but the supplemental OCR shows `Mariana Coleman`, `12 Chestnut Lane, Austin, TX 78701`, `Umeda Operations Support Center Ltd.` on one stray line.",
+    "entities": [
+      {
+        "start": 92,
+        "end": 107,
+        "label": "PERSON",
+        "text": "Mariana Coleman"
+      },
+      {
+        "start": 111,
+        "end": 145,
+        "label": "ADDRESS",
+        "text": "12 Chestnut Lane, Austin, TX 78701"
+      },
+      {
+        "start": 149,
+        "end": 185,
+        "label": "ORGANIZATION",
+        "text": "Umeda Operations Support Center Ltd."
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 5
+    }
+  },
+  {
+    "text": "In a thumbnail tucked into the distribution-center news article you can read `Aisha N. Carter`, `203 Maple Ave, Boulder, CO 80302`, and `Hokkaido North-One Branch Services`.",
+    "entities": [
+      {
+        "start": 78,
+        "end": 93,
+        "label": "PERSON",
+        "text": "Aisha N. Carter"
+      },
+      {
+        "start": 97,
+        "end": 129,
+        "label": "ADDRESS",
+        "text": "203 Maple Ave, Boulder, CO 80302"
+      },
+      {
+        "start": 137,
+        "end": 171,
+        "label": "ORGANIZATION",
+        "text": "Hokkaido North-One Branch Services"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 6
+    }
+  },
+  {
+    "text": "On a single line of the public notice, the leftover return label still shows `Daniel O'Connor`, `10 Downing Street, London SW1A 2AA`, and `Wells Fargo Routing 121000248 Account 7722114 Savings`.",
+    "entities": [
+      {
+        "start": 78,
+        "end": 93,
+        "label": "PERSON",
+        "text": "Daniel O'Connor"
+      },
+      {
+        "start": 97,
+        "end": 131,
+        "label": "ADDRESS",
+        "text": "10 Downing Street, London SW1A 2AA"
+      },
+      {
+        "start": 139,
+        "end": 192,
+        "label": "BANK_ACCOUNT",
+        "text": "Wells Fargo Routing 121000248 Account 7722114 Savings"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 7
+    }
+  },
+  {
+    "text": "The body of the delivery-incident article is a generic discussion of weather and delays, yet the image caption ends with `Yusuf Khalid` and `Chase, Routing 021000021, Account 123456789, Checking` showing once.",
+    "entities": [
+      {
+        "start": 122,
+        "end": 134,
+        "label": "PERSON",
+        "text": "Yusuf Khalid"
+      },
+      {
+        "start": 141,
+        "end": 194,
+        "label": "BANK_ACCOUNT",
+        "text": "Chase, Routing 021000021, Account 123456789, Checking"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 8
+    }
+  },
+  {
+    "text": "The OCR of the warehouse blog's attached image is mostly box and shelf numbers, but at the bottom edge you can see `Sergei Volkov`, `Karasuma Community Care Clinic`, and `55 King Street West, Toronto, ON M5K 1A1`.",
+    "entities": [
+      {
+        "start": 116,
+        "end": 129,
+        "label": "PERSON",
+        "text": "Sergei Volkov"
+      },
+      {
+        "start": 133,
+        "end": 163,
+        "label": "ORGANIZATION",
+        "text": "Karasuma Community Care Clinic"
+      },
+      {
+        "start": 171,
+        "end": 211,
+        "label": "ADDRESS",
+        "text": "55 King Street West, Toronto, ON M5K 1A1"
+      }
+    ],
+    "_meta": {
+      "template": "logistics_labels_b.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 9
+    }
+  },
+  {
+    "text": "Most of the published material is [REDACTED], but the residual text shows John A. Smith, 234 Harbor Way, Boston, MA 02110.",
+    "entities": [
+      {
+        "start": 74,
+        "end": 87,
+        "label": "PERSON",
+        "text": "John A. Smith"
+      },
+      {
+        "start": 89,
+        "end": 121,
+        "label": "ADDRESS",
+        "text": "234 Harbor Way, Boston, MA 02110"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 10
+    }
+  },
+  {
+    "text": "The name field of the public-facing brief is [REDACTED], yet the annotation still has Priya Iyer, affiliated with Karasuma Community Care Clinic.",
+    "entities": [
+      {
+        "start": 86,
+        "end": 96,
+        "label": "PERSON",
+        "text": "Priya Iyer"
+      },
+      {
+        "start": 114,
+        "end": 144,
+        "label": "ORGANIZATION",
+        "text": "Karasuma Community Care Clinic"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 11
+    }
+  },
+  {
+    "text": "The body is supposedly anonymized, but a footnote retains Bank of America Routing 026009593 Account 5566778 and Hannah Sato.",
+    "entities": [
+      {
+        "start": 58,
+        "end": 107,
+        "label": "BANK_ACCOUNT",
+        "text": "Bank of America Routing 026009593 Account 5566778"
+      },
+      {
+        "start": 112,
+        "end": 123,
+        "label": "PERSON",
+        "text": "Hannah Sato"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 12
+    }
+  },
+  {
+    "text": "The address column of the [MASKED] public report is partially redacted, but 742 Evergreen Terrace, Springfield, IL 62701 and Olivia Bennett can still be read.",
+    "entities": [
+      {
+        "start": 76,
+        "end": 120,
+        "label": "ADDRESS",
+        "text": "742 Evergreen Terrace, Springfield, IL 62701"
+      },
+      {
+        "start": 125,
+        "end": 139,
+        "label": "PERSON",
+        "text": "Olivia Bennett"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 13
+    }
+  },
+  {
+    "text": "The appendix of the public minutes was not fully [WITHHELD]: Marcus DeLuca, WestEnd Data Lab Inc., and 1991/03/28 remained.",
+    "entities": [
+      {
+        "start": 61,
+        "end": 74,
+        "label": "PERSON",
+        "text": "Marcus DeLuca"
+      },
+      {
+        "start": 76,
+        "end": 97,
+        "label": "ORGANIZATION",
+        "text": "WestEnd Data Lab Inc."
+      },
+      {
+        "start": 103,
+        "end": 113,
+        "label": "DATE_OF_BIRTH",
+        "text": "1991/03/28"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 14
+    }
+  },
+  {
+    "text": "Most of the handout appendix is marked [WITHHELD], yet the residue still identifies Aisha N. Carter at 203 Maple Ave, Boulder, CO 80302.",
+    "entities": [
+      {
+        "start": 84,
+        "end": 99,
+        "label": "PERSON",
+        "text": "Aisha N. Carter"
+      },
+      {
+        "start": 103,
+        "end": 135,
+        "label": "ADDRESS",
+        "text": "203 Maple Ave, Boulder, CO 80302"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 15
+    }
+  },
+  {
+    "text": "The press kit is partly blacked out [REDACTED], but Daniel O'Connor and Wells Fargo Routing 121000248 Account 7722114 Savings remain in the open.",
+    "entities": [
+      {
+        "start": 52,
+        "end": 67,
+        "label": "PERSON",
+        "text": "Daniel O'Connor"
+      },
+      {
+        "start": 72,
+        "end": 125,
+        "label": "BANK_ACCOUNT",
+        "text": "Wells Fargo Routing 121000248 Account 7722114 Savings"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 16
+    }
+  },
+  {
+    "text": "The public slides are claimed anonymized, but the edge OCR leaves Mariana Coleman, Umeda Operations Support Center Ltd. legible.",
+    "entities": [
+      {
+        "start": 66,
+        "end": 81,
+        "label": "PERSON",
+        "text": "Mariana Coleman"
+      },
+      {
+        "start": 83,
+        "end": 119,
+        "label": "ORGANIZATION",
+        "text": "Umeda Operations Support Center Ltd."
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 17
+    }
+  },
+  {
+    "text": "Citations in the [MASKED] public article are heavily blacked out, yet John A. Smith's DOB June 15, 1988 alone survives.",
+    "entities": [
+      {
+        "start": 70,
+        "end": 83,
+        "label": "PERSON",
+        "text": "John A. Smith"
+      },
+      {
+        "start": 90,
+        "end": 103,
+        "label": "DATE_OF_BIRTH",
+        "text": "June 15, 1988"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 18
+    }
+  },
+  {
+    "text": "Across the [REDACTED] case-study volume, only one residual line still reads Priya Iyer, 17 Rue de Lisbonne, Paris 75008.",
+    "entities": [
+      {
+        "start": 76,
+        "end": 86,
+        "label": "PERSON",
+        "text": "Priya Iyer"
+      },
+      {
+        "start": 88,
+        "end": 119,
+        "label": "ADDRESS",
+        "text": "17 Rue de Lisbonne, Paris 75008"
+      }
+    ],
+    "_meta": {
+      "template": "partially_redacted_public_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 19
+    }
+  },
+  {
+    "text": "RESIDENCE OCR Applicant: Daniel O'Connor DOB: May 10, 1965 Address: 234 Harbor Way, Boston, MA 02110 Employer: Konan Harbor Solutions Inc.",
+    "entities": [
+      {
+        "start": 25,
+        "end": 40,
+        "label": "PERSON",
+        "text": "Daniel O'Connor"
+      },
+      {
+        "start": 46,
+        "end": 58,
+        "label": "DATE_OF_BIRTH",
+        "text": "May 10, 1965"
+      },
+      {
+        "start": 68,
+        "end": 100,
+        "label": "ADDRESS",
+        "text": "234 Harbor Way, Boston, MA 02110"
+      },
+      {
+        "start": 111,
+        "end": 138,
+        "label": "ORGANIZATION",
+        "text": "Konan Harbor Solutions Inc."
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 20
+    }
+  },
+  {
+    "text": "REFUND CLAIM OCR Recipient: John A. Smith Remit to: Chase, Routing 021000021, Account 123456789, Checking Mailing: 488 Broadway, Apt 6B, New York, NY 10013",
+    "entities": [
+      {
+        "start": 28,
+        "end": 41,
+        "label": "PERSON",
+        "text": "John A. Smith"
+      },
+      {
+        "start": 52,
+        "end": 105,
+        "label": "BANK_ACCOUNT",
+        "text": "Chase, Routing 021000021, Account 123456789, Checking"
+      },
+      {
+        "start": 115,
+        "end": 155,
+        "label": "ADDRESS",
+        "text": "488 Broadway, Apt 6B, New York, NY 10013"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 21
+    }
+  },
+  {
+    "text": "IDENTITY OCR Name: Mariana Coleman Current Address: 12 Chestnut Lane, Austin, TX 78701 Affiliation: Umeda Operations Support Center Ltd. Born: September 12, 1986",
+    "entities": [
+      {
+        "start": 19,
+        "end": 34,
+        "label": "PERSON",
+        "text": "Mariana Coleman"
+      },
+      {
+        "start": 52,
+        "end": 86,
+        "label": "ADDRESS",
+        "text": "12 Chestnut Lane, Austin, TX 78701"
+      },
+      {
+        "start": 100,
+        "end": 136,
+        "label": "ORGANIZATION",
+        "text": "Umeda Operations Support Center Ltd."
+      },
+      {
+        "start": 143,
+        "end": 161,
+        "label": "DATE_OF_BIRTH",
+        "text": "September 12, 1986"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 22
+    }
+  },
+  {
+    "text": "DIRECT-DEBIT OCR Holder: Hannah Sato DOB: June 15, 1988 Bank: Bank of America Routing 026009593 Account 5566778 Address: 488 Broadway, Apt 6B, New York, NY 10013",
+    "entities": [
+      {
+        "start": 25,
+        "end": 36,
+        "label": "PERSON",
+        "text": "Hannah Sato"
+      },
+      {
+        "start": 42,
+        "end": 55,
+        "label": "DATE_OF_BIRTH",
+        "text": "June 15, 1988"
+      },
+      {
+        "start": 62,
+        "end": 111,
+        "label": "BANK_ACCOUNT",
+        "text": "Bank of America Routing 026009593 Account 5566778"
+      },
+      {
+        "start": 121,
+        "end": 161,
+        "label": "ADDRESS",
+        "text": "488 Broadway, Apt 6B, New York, NY 10013"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 23
+    }
+  },
+  {
+    "text": "MEDICAL SUBSIDY OCR Applicant: Priya Iyer Contact: 17 Rue de Lisbonne, Paris 75008 Referral: Karasuma Community Care Clinic DOB: May 10, 1965",
+    "entities": [
+      {
+        "start": 31,
+        "end": 41,
+        "label": "PERSON",
+        "text": "Priya Iyer"
+      },
+      {
+        "start": 51,
+        "end": 82,
+        "label": "ADDRESS",
+        "text": "17 Rue de Lisbonne, Paris 75008"
+      },
+      {
+        "start": 93,
+        "end": 123,
+        "label": "ORGANIZATION",
+        "text": "Karasuma Community Care Clinic"
+      },
+      {
+        "start": 129,
+        "end": 141,
+        "label": "DATE_OF_BIRTH",
+        "text": "May 10, 1965"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 24
+    }
+  },
+  {
+    "text": "EMERGENCY CONTACT OCR Subject: Olivia Bennett Employer: Aoyagi Bridge Development Co. Address: 742 Evergreen Terrace, Springfield, IL 62701 Remit to: Rakuten Bank Branch 002 Ordinary 4567890",
+    "entities": [
+      {
+        "start": 31,
+        "end": 45,
+        "label": "PERSON",
+        "text": "Olivia Bennett"
+      },
+      {
+        "start": 56,
+        "end": 85,
+        "label": "ORGANIZATION",
+        "text": "Aoyagi Bridge Development Co."
+      },
+      {
+        "start": 95,
+        "end": 139,
+        "label": "ADDRESS",
+        "text": "742 Evergreen Terrace, Springfield, IL 62701"
+      },
+      {
+        "start": 150,
+        "end": 190,
+        "label": "BANK_ACCOUNT",
+        "text": "Rakuten Bank Branch 002 Ordinary 4567890"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 25
+    }
+  },
+  {
+    "text": "BUILDING ACCESS OCR Applicant: Marcus DeLuca Affiliation: WestEnd Data Lab Inc. Mail to: 88 Market Street, Suite 410, San Francisco, CA 94103 DOB: 1991/03/28",
+    "entities": [
+      {
+        "start": 31,
+        "end": 44,
+        "label": "PERSON",
+        "text": "Marcus DeLuca"
+      },
+      {
+        "start": 58,
+        "end": 79,
+        "label": "ORGANIZATION",
+        "text": "WestEnd Data Lab Inc."
+      },
+      {
+        "start": 89,
+        "end": 141,
+        "label": "ADDRESS",
+        "text": "88 Market Street, Suite 410, San Francisco, CA 94103"
+      },
+      {
+        "start": 147,
+        "end": 157,
+        "label": "DATE_OF_BIRTH",
+        "text": "1991/03/28"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 26
+    }
+  },
+  {
+    "text": "GRANT APPLICATION OCR Representative: Aisha N. Carter Premises: 203 Maple Ave, Boulder, CO 80302 Entity: Hokkaido North-One Branch Services Remit to: Japan Post Bank Symbol 10100 Number 12345671",
+    "entities": [
+      {
+        "start": 38,
+        "end": 53,
+        "label": "PERSON",
+        "text": "Aisha N. Carter"
+      },
+      {
+        "start": 64,
+        "end": 96,
+        "label": "ADDRESS",
+        "text": "203 Maple Ave, Boulder, CO 80302"
+      },
+      {
+        "start": 105,
+        "end": 139,
+        "label": "ORGANIZATION",
+        "text": "Hokkaido North-One Branch Services"
+      },
+      {
+        "start": 150,
+        "end": 194,
+        "label": "BANK_ACCOUNT",
+        "text": "Japan Post Bank Symbol 10100 Number 12345671"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 27
+    }
+  },
+  {
+    "text": "REISSUE OCR Applicant: John A. Smith Address: 234 Harbor Way, Boston, MA 02110 Employer: Shibuya Branch Business Support Inc. DOB: June 15, 1988",
+    "entities": [
+      {
+        "start": 23,
+        "end": 36,
+        "label": "PERSON",
+        "text": "John A. Smith"
+      },
+      {
+        "start": 46,
+        "end": 78,
+        "label": "ADDRESS",
+        "text": "234 Harbor Way, Boston, MA 02110"
+      },
+      {
+        "start": 89,
+        "end": 125,
+        "label": "ORGANIZATION",
+        "text": "Shibuya Branch Business Support Inc."
+      },
+      {
+        "start": 131,
+        "end": 144,
+        "label": "DATE_OF_BIRTH",
+        "text": "June 15, 1988"
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 28
+    }
+  },
+  {
+    "text": "REGISTRATION OCR Name: Daniel O'Connor Account: Wells Fargo Routing 121000248 Account 7722114 Savings Address: 10 Downing Street, London SW1A 2AA Affiliation: Konan Harbor Solutions Inc.",
+    "entities": [
+      {
+        "start": 23,
+        "end": 38,
+        "label": "PERSON",
+        "text": "Daniel O'Connor"
+      },
+      {
+        "start": 48,
+        "end": 101,
+        "label": "BANK_ACCOUNT",
+        "text": "Wells Fargo Routing 121000248 Account 7722114 Savings"
+      },
+      {
+        "start": 111,
+        "end": 145,
+        "label": "ADDRESS",
+        "text": "10 Downing Street, London SW1A 2AA"
+      },
+      {
+        "start": 159,
+        "end": 186,
+        "label": "ORGANIZATION",
+        "text": "Konan Harbor Solutions Inc."
+      }
+    ],
+    "_meta": {
+      "template": "ocr_forms_a.txt",
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test",
+      "doc_idx": 29
+    }
+  },
+  {
+    "text": "A research feature article from Boulder University Public Lectures introduces a joint study with Stanford Outreach and the Manhattan Medical Society plaza, but states explicitly that no subject-level rosters or home addresses are disclosed.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_articles_a.txt",
+      "doc_idx": 30,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The university journal abstract refers to MIT collaboration partners in passing; the study refers to anonymized cohorts only and the paper does not contain participant DOBs or contract terms.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_articles_a.txt",
+      "doc_idx": 31,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The methodology section uses sample_user, sample_name_01, and street-city-state-12345 as figure captions to illustrate field rendering; these are explanatory dummies, not subject records.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_articles_a.txt",
+      "doc_idx": 32,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A campus PR feature lists the Boulder University auditorium, the West Tower HQ plaza, and the Bridgepoint branch entrance as photo backdrops only; none are residential addresses of co-authors.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_articles_a.txt",
+      "doc_idx": 33,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The appendix of the technical paper enumerates UI label names person_name, address_line, organization_name, and bank_account, leaving every value as <pending> or [REDACTED] so that no actual record is exposed.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_articles_a.txt",
+      "doc_idx": 34,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A campus notice from Boulder University Public Lectures announces an open seminar series and a partnership program with the Manhattan Medical Society, with no participant rosters attached.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_notices_b.txt",
+      "doc_idx": 35,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The information session bulletin lists session dates 04/01/2026, 05/31/2026, and 06/15/2026 on the calendar; these are agenda dates and not anyone's date of birth.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_notices_b.txt",
+      "doc_idx": 36,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The campus tour script displays sample_user and street-city-state-12345 as on-screen example strings; the demo screen is a UI mock and shows no real applicant data.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_notices_b.txt",
+      "doc_idx": 37,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "Course handouts cite (555) 010-XXXX as the inquiry hotline and REQ-09-4412 as the registration reference; no financial information appears on the handout.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_notices_b.txt",
+      "doc_idx": 38,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The collaborative-research announcement uses sample_name_01 and sample_name_07 as illustrative names for screen rendering; these placeholder strings are not real person identifiers.",
+    "entities": [],
+    "_meta": {
+      "template": "academic_notices_b.txt",
+      "doc_idx": 39,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The configuration FAQ shows only example values such as branch-main checking 0000000000 and Routing 000000000; these are illustrative defaults and not real bank accounts.",
+    "entities": [],
+    "_meta": {
+      "template": "bankish_code_negative_a.txt",
+      "doc_idx": 40,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "An operations handout enumerates (555) 010-XXXX, REQ-09-4412, and INV-778812 as inquiry numbers and tracking IDs; none of these are financial account information.",
+    "entities": [],
+    "_meta": {
+      "template": "bankish_code_negative_a.txt",
+      "doc_idx": 41,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The setup guide states account=TEMP-HOLD, bank=masked, and institution=UNASSIGNED to describe unset states; no holder name or refund destination is recorded.",
+    "entities": [],
+    "_meta": {
+      "template": "bankish_code_negative_a.txt",
+      "doc_idx": 42,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The demo screen prints branch-main checking 0000000000 as a placeholder for layout verification; it is not the user's actual checking account number.",
+    "entities": [],
+    "_meta": {
+      "template": "bankish_code_negative_a.txt",
+      "doc_idx": 43,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The internal memo records (555) 010-XXXX as a support hotline and INV-778812 as an invoice example; neither field encodes banking information.",
+    "entities": [],
+    "_meta": {
+      "template": "bankish_code_negative_a.txt",
+      "doc_idx": 44,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The onboarding handout displays sample_user, sample_name_01, street-city-state-12345, and MM/DD/YYYY only as catalog placeholders, with no real customer data attached.",
+    "entities": [],
+    "_meta": {
+      "template": "catalog_placeholder_negative_a.txt",
+      "doc_idx": 45,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The screen-list explainer lists name=<pending>, address=UNASSIGNED, dob=MM/DD/YYYY, and account=TEMP-HOLD; these are placeholder labels and not PII.",
+    "entities": [],
+    "_meta": {
+      "template": "catalog_placeholder_negative_a.txt",
+      "doc_idx": 46,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The HTML mock <input placeholder=\"sample_user\"> and <input placeholder=\"street-city-state-12345\"> appear in the design doc as UI illustrations only.",
+    "entities": [],
+    "_meta": {
+      "template": "catalog_placeholder_negative_a.txt",
+      "doc_idx": 47,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A CSV row used for layout testing reads sample_name_01,MM/DD/YYYY,street-city-state-12345,UNASSIGNED,branch-main checking 0000000000 verbatim; it is a fixed sample.",
+    "entities": [],
+    "_meta": {
+      "template": "catalog_placeholder_negative_a.txt",
+      "doc_idx": 48,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The product page description box presents TEMP-HOLD, [REDACTED], and branch-main checking 0000000000 as catalog examples of unset values, not real holder data.",
+    "entities": [],
+    "_meta": {
+      "template": "catalog_placeholder_negative_a.txt",
+      "doc_idx": 49,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A neighborhood association bulletin announces the reopening of the Chase Branch promenade community room and renovation work at the West Tower HQ plaza, with no resident names attached.",
+    "entities": [],
+    "_meta": {
+      "template": "community_bulletins_a.txt",
+      "doc_idx": 50,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The town newsletter mentions traffic restrictions near the Manhattan Medical Society plaza and a cleanup activity in front of the West Tower HQ; no individual is identified.",
+    "entities": [],
+    "_meta": {
+      "template": "community_bulletins_a.txt",
+      "doc_idx": 51,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A volunteer recruitment notice lists activity dates 04/01/2026, 05/31/2026, and 06/15/2026 alongside venue names; no participant rosters or address books are published.",
+    "entities": [],
+    "_meta": {
+      "template": "community_bulletins_a.txt",
+      "doc_idx": 52,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The community board posts only event participation methods, venue maps, and inquiry contacts; applicant names and shipping addresses are managed separately and never disclosed.",
+    "entities": [],
+    "_meta": {
+      "template": "community_bulletins_a.txt",
+      "doc_idx": 53,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A regional bulletin quotes UI mocks such as sample_user and street-city-state-12345 verbatim from the city portal explainer; these are fixed placeholder strings, not residents.",
+    "entities": [],
+    "_meta": {
+      "template": "community_bulletins_a.txt",
+      "doc_idx": 54,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "Glossary: person_name refers to the name field, address_line to the address field, and bank_account to the account field. Each is a label name, not a value.",
+    "entities": [],
+    "_meta": {
+      "template": "docs_glossary_negative_a.txt",
+      "doc_idx": 55,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The term explanation lists examples like sample_user and street-city-state-12345 as illustrations of dummy values, not actual records.",
+    "entities": [],
+    "_meta": {
+      "template": "docs_glossary_negative_a.txt",
+      "doc_idx": 56,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The data dictionary gives only field descriptions for person_name, organization_name, and address_line; every value column is marked <pending> or UNASSIGNED.",
+    "entities": [],
+    "_meta": {
+      "template": "docs_glossary_negative_a.txt",
+      "doc_idx": 57,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "Within the glossary, MM/DD/YYYY appears as a date-format example; it is not date-of-birth data for any individual.",
+    "entities": [],
+    "_meta": {
+      "template": "docs_glossary_negative_a.txt",
+      "doc_idx": 58,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The facility-term column of the glossary describes the Bridgepoint branch entrance and the Boulder University auditorium as descriptions of generic place names.",
+    "entities": [],
+    "_meta": {
+      "template": "docs_glossary_negative_a.txt",
+      "doc_idx": 59,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The event brochure carries only the venue names Boulder University auditorium, West Tower HQ plaza, and Bridgepoint branch entrance; there is no record-level information.",
+    "entities": [],
+    "_meta": {
+      "template": "event_brochures_negative_a.txt",
+      "doc_idx": 60,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The handout flyer prints the event dates 2026/04/01, 2026/05/31, and 2026/06/15; these are agenda dates on the calendar, not dates of birth.",
+    "entities": [],
+    "_meta": {
+      "template": "event_brochures_negative_a.txt",
+      "doc_idx": 61,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The contact section of the brochure shows only the main hotline (555) 010-XXXX and reference REQ-09-4412; no individual contact records appear.",
+    "entities": [],
+    "_meta": {
+      "template": "event_brochures_negative_a.txt",
+      "doc_idx": 62,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The PR booklet announces Boulder University Public Lectures and a Stanford Outreach collaboration program; it is not a personal roster.",
+    "entities": [],
+    "_meta": {
+      "template": "event_brochures_negative_a.txt",
+      "doc_idx": 63,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A note on the venue map shows street-city-state-12345 and sample_user_07 as map-layout sample strings; no real attendee address is encoded.",
+    "entities": [],
+    "_meta": {
+      "template": "event_brochures_negative_a.txt",
+      "doc_idx": 64,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The civic guide lists the Bridgepoint branch entrance, the West Tower HQ plaza, and the Manhattan Medical Society plaza, but contains no individual or corporate record-level data.",
+    "entities": [],
+    "_meta": {
+      "template": "facility_org_false_positive_a.txt",
+      "doc_idx": 65,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The civic-lecture announcement names the City of Boulder Department of Health, Boulder University Public Lectures, and Stanford Outreach as cooperating bodies; no attendees or mailing addresses are listed.",
+    "entities": [],
+    "_meta": {
+      "template": "facility_org_false_positive_a.txt",
+      "doc_idx": 66,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The redevelopment report explains maintenance plans for the Chase Branch promenade and the front of West Tower HQ; no record-level data is handled.",
+    "entities": [],
+    "_meta": {
+      "template": "facility_org_false_positive_a.txt",
+      "doc_idx": 67,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "The travel guide profiles the Boulder University auditorium, the Manhattan Medical Society plaza, and the front of West Tower HQ; it is not a register of mailing addresses or employers.",
+    "entities": [],
+    "_meta": {
+      "template": "facility_org_false_positive_a.txt",
+      "doc_idx": 68,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A neighborhood handout mentions the City of Boulder Department of Health and the Manhattan Medical Society plaza only as common organizational and venue labels, with no resident records included.",
+    "entities": [],
+    "_meta": {
+      "template": "facility_org_false_positive_a.txt",
+      "doc_idx": 69,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "FAQ Q: \"Why does sample_user appear on the screen?\" A: \"It is a demo display string and does not signify personal information.\"",
+    "entities": [],
+    "_meta": {
+      "template": "faq_negative_b.txt",
+      "doc_idx": 70,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "FAQ Q: \"Is street-city-state-12345 a real address?\" A: \"No, it is an illustrative placeholder rendered for layout testing.\"",
+    "entities": [],
+    "_meta": {
+      "template": "faq_negative_b.txt",
+      "doc_idx": 71,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "FAQ Q: \"Is branch-main checking 0000000000 a real account?\" A: \"No, it is a UI mock used to verify display widths.\"",
+    "entities": [],
+    "_meta": {
+      "template": "faq_negative_b.txt",
+      "doc_idx": 72,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "FAQ Q: \"Whose number is (555) 010-XXXX?\" A: \"It is the support hotline example number; no specific holder is associated.\"",
+    "entities": [],
+    "_meta": {
+      "template": "faq_negative_b.txt",
+      "doc_idx": 73,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "FAQ Q: \"Is Boulder University auditorium an employer field?\" A: \"It is a venue name and should not be entered into the employer record.\"",
+    "entities": [],
+    "_meta": {
+      "template": "faq_negative_b.txt",
+      "doc_idx": 74,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "In the user forum thread, sample_user is asking why street-city-state-12345 appears on the signup screen; the poster shares no real personal information.",
+    "entities": [],
+    "_meta": {
+      "template": "forum_threads_a.txt",
+      "doc_idx": 75,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "Another thread debates why \"branch-main checking 0000000000\" is the example value in onboarding screens; the discussion is purely about dummy display content.",
+    "entities": [],
+    "_meta": {
+      "template": "forum_threads_a.txt",
+      "doc_idx": 76,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "A community post asks whether \"Manhattan Medical Society plaza\" should be flagged as an address; commenters note it is a landmark, not a residence.",
+    "entities": [],
+    "_meta": {
+      "template": "forum_threads_a.txt",
+      "doc_idx": 77,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "Members chat about scheduled rollouts on 04/01/2026, 05/31/2026, and 06/15/2026; these are upcoming release dates, not anyone's date of birth.",
+    "entities": [],
+    "_meta": {
+      "template": "forum_threads_a.txt",
+      "doc_idx": 78,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  },
+  {
+    "text": "Forum members explain that UNASSIGNED, TEMP-HOLD, and <pending> are UI labels for unset state, not real customer values being leaked from production.",
+    "entities": [],
+    "_meta": {
+      "template": "forum_threads_a.txt",
+      "doc_idx": 79,
+      "version": "v0.13.0-held-out",
+      "language": "en",
+      "partition": "test"
+    }
+  }
+]

--- a/packages/training/data/benchmark/v0.13.0-held-out/en/scores.json
+++ b/packages/training/data/benchmark/v0.13.0-held-out/en/scores.json
@@ -1,0 +1,46 @@
+{
+  "pleno_ner": {
+    "ents_p": 0.7889908256880734,
+    "ents_r": 0.9662921348314607,
+    "ents_f": 0.8686868686868687,
+    "ents_per_type": {
+      "PERSON": {
+        "p": 1.0,
+        "r": 1.0,
+        "f": 1.0
+      },
+      "ADDRESS": {
+        "p": 1.0,
+        "r": 1.0,
+        "f": 1.0
+      },
+      "ORGANIZATION": {
+        "p": 0.42857142857142855,
+        "r": 0.9375,
+        "f": 0.588235294117647
+      },
+      "BANK_ACCOUNT": {
+        "p": 0.8,
+        "r": 0.8,
+        "f": 0.8000000000000002
+      },
+      "DATE_OF_BIRTH": {
+        "p": 0.9090909090909091,
+        "r": 1.0,
+        "f": 0.9523809523809523
+      }
+    },
+    "latency_ms_per_doc": 23.9,
+    "model_size_mb": 480.8,
+    "num_docs": 80,
+    "negative_docs": 50,
+    "negative_clean_docs": 35,
+    "negative_doc_clean_rate": 0.7,
+    "negative_fp_total": 21,
+    "suite_kind": "held_out",
+    "purpose": "Held-out test partition kept disjoint from training data. Slice mix mirrors v11/v12 (positive: logistics_labels_b, partially_redacted_public_a, ocr_forms_a; negative: 10 v12 FP-pressure slices). 80 docs / 89 entities / 50 negatives.",
+    "corpus": "v0.13.0-held-out/en",
+    "metric": "strict_span_f1",
+    "aggregation": "micro"
+  }
+}

--- a/packages/training/src/pleno_ner_training/benchmark_config.py
+++ b/packages/training/src/pleno_ner_training/benchmark_config.py
@@ -196,6 +196,27 @@ BENCHMARK_CONFIGS: dict[str, BenchmarkConfig] = {
         suite_kind="benchmark",
         purpose="OCR・key-value 崩れと一般文書の偽陽性圧力を強めた curated DLP benchmark",
     ),
+    "v0.13.0-held-out": BenchmarkConfig(
+        # Held-out test set (test partition) for both ja and en.
+        # Wording is paraphrased rather than copied from v11/v12 corpus, so
+        # this set stays disjoint from training-time data — the F0a R14
+        # leakage check should pass cleanly.
+        # No templates / corpus_subdir: this benchmark is consumed via a
+        # pre-built raw.json under data/benchmark/v0.13.0-held-out/<lang>/.
+        # generate_benchmark cannot rebuild it (no prompts / no curated
+        # source files), only evaluate_benchmark + a manual --benchmark-data
+        # pointer can use it.
+        version="v0.13.0-held-out",
+        prompts_subdir="",
+        generation_backend="held-out",
+        suite_kind="held_out",
+        purpose=(
+            "Held-out test partition kept disjoint from training data. "
+            "Slice mix mirrors v11/v12 (positive: logistics_labels_b, "
+            "partially_redacted_public_a, ocr_forms_a; negative: 10 v12 "
+            "FP-pressure slices). 80 docs / 89 entities / 50 negatives."
+        ),
+    ),
 }
 
 BENCHMARK_VERSIONS = list(BENCHMARK_CONFIGS)


### PR DESCRIPTION
## What

Closes the v0.5–v0.12 → v0.13 gap on the en side, completing the parity work started in #109. This PR adds:

1. **`v0.13.0-held-out/en/raw.json`** — 80 docs / 89 entities / 50 negatives, **byte-for-byte structural parity with ja** (PERSON=30, ADDRESS=23, ORGANIZATION=16, BANK_ACCOUNT=10, DATE_OF_BIRTH=10). Wording is paraphrased rather than copied from v11/v12 corpus to keep the held-out set disjoint from training data.
2. **`v0.12.0/en/` and `v0.12.1-leak-fixed/en/` `training_corpus_manifest.json`** — SHA256-NFC manifest of `data/raw/en/generated.json` (4818 docs), schema v1.1 matching ja.
3. **en HF tiny pipeline Makefile targets** — DeBERTa-v3-xsmall (the en analogue of ku-nlp/deberta-v2-tiny-japanese) + Wikipedia hardneg + ONNX export + HF Hub push (`0xhikae/en-ner-onnx`).
4. **`v0.13.0-held-out` registered in benchmark_config + scores.json** for `en_ner_en-0.2.0`.

## Why

#109 brought en bench coverage up to v0.12.0 (curated corpora + scores). The remaining gap was the v0.13 lane: training_corpus_manifest (R14 leakage check input), held-out test set (R13 disjoint partition), and the HF tiny path (the engine ja used to push F1 0.452 → 0.701). All three were ja-only.

## Held-out parity

Span-validated, label-balanced:

| | docs | ents | negs | PERSON | ADDRESS | ORG | BANK | DOB |
|---|---|---|---|---|---|---|---|---|
| ja | 80 | 89 | 50 | 30 | 23 | 16 | 10 | 10 |
| en | 80 | 89 | 50 | 30 | 23 | 16 | 10 | 10 |

Slice mix:
- **positive (30)**: `logistics_labels_b` 10, `partially_redacted_public_a` 10, `ocr_forms_a` 10
- **negative (50)**: 10 v12 FP-pressure slices × 5 each (academic_articles_a, academic_notices_b, bankish_code_negative_a, catalog_placeholder_negative_a, community_bulletins_a, docs_glossary_negative_a, event_brochures_negative_a, facility_org_false_positive_a, faq_negative_b, forum_threads_a)

## en held-out scores (`en_ner_en-0.2.0`)

| Metric | Value | Note |
|---|---|---|
| Overall F1 | **86.9 %** | high vs v0.10–v0.12 by design (held-out is disjoint, easier than adversarial quality_gate) |
| Precision | 78.9 % | |
| Recall | 96.6 % | |
| PERSON | 100.0 % | |
| ADDRESS | 100.0 % | |
| ORGANIZATION | **58.8 %** | same FP pattern ja saw before the v0.13 ORG=0.99 floor work |
| BANK_ACCOUNT | 80.0 % | |
| DATE_OF_BIRTH | 95.2 % | |
| Neg clean rate | 70.0 % | 21 FP across 50 negatives |

The ORG drag matches what the ja pipeline solved with the per-label confidence floor — the en HF tiny pipeline scaffolding in this PR sets up exactly that next step.

## en HF tiny pipeline (Makefile, scaffolding only — RunPod for actual training)

| Target | Purpose |
|---|---|
| `mine-external-hardneg-en` | Wikipedia 20231101.en (CC-BY-SA 4.0), 4000 ORG-FP-likely hardneg docs |
| `mine-external-hardneg-en-dry-run` | Network-free CI smoke |
| `convert-hf-en-v01-tiny` | data/raw/en/generated.json → data/hf/en-v01-tiny via deberta-v3-xsmall fast tokenizer |
| `convert-hf-en-v01-tiny-hardneg-ext` | + Wikipedia hardneg merge |
| `train-hf-en-v01-tiny` / `-hardneg-ext` | DeBERTa-v3-xsmall fine-tune (RunPod GPU expected) |
| `export-onnx-en-v01-tiny` | ONNX export, INT8-quantized |
| `push-hf-en-v01-tiny` | Push to `0xhikae/en-ner-onnx` |
| `all-hf-en-v01-tiny` | end-to-end |

Underlying `mine_external_hardneg.py`, `convert_to_hf_dataset.py`, `train_hf.py`, `export_onnx.py` are language-agnostic via `--config` / `--tokenizer` / `--model` args — **no Python changes**. `PII_HINT_RE` is a strict superset of ja-only patterns; en text simply doesn't match the ja-only regexes, so en zero-entity docs survive as true negatives instead of being silently dropped.

## training_corpus_manifest (en)

Schema v1.1 SHA256-NFC, identical to ja:

```json
{
  "sources": [{
    "name": "raw_en_generated",
    "path": "packages/training/data/raw/en/generated.json",
    "file_sha256": "b51757216d883b…",
    "doc_count": 4818,
    "doc_hashes_first5": [...]
  }]
}
```

The en training corpus has only one source today (vs ja's 4: generated + augmented + address_precision_extra + ja-v02-extra), which makes the gap between en/ja training scale visible in the manifest itself: ~64500 ja docs vs 4818 en docs. This drives the next step (en augment / en hardneg expansion).

## Out of scope

- **Actual en HF tiny training** — needs RunPod GPU per CLAUDE.md ("do not train on local machine"). Scaffolding is in; the GPU run is a separate task.
- **en ORG=0.99 floor sweep** — depends on a trained en HF model. Once `output/hf-en-v01-tiny` exists, `predict_hf_with_scores` + `sweep_org_threshold` work unchanged (they're language-agnostic).

## Verification

```sh
EN_MODEL=packages/models/en_ner_en-0.2.0/en_ner_en/en_ner_en-0.2.0 \
  make -C packages/training benchmark-v13-held-out-evaluate-en
```

reproduces `v0.13.0-held-out/en/scores.json`.

```sh
make -C packages/training mine-external-hardneg-en-dry-run
```

verifies the en hardneg path without network.

Refs #109.