### PR TITLE
feat(pii-scanner-notion): block tree → Markdown + database query (#29, ADR §13)

### DIFF
--- a/packages/pii-scanner-notion/README.md
+++ b/packages/pii-scanner-notion/README.md
@@ -1,0 +1,62 @@
+# pleno-pii-scanner-notion
+
+Notion `SourceConnector` wheel for `pleno-pii-scanner`.
+
+Scans every page, database, and block content the integration has been
+explicitly shared with. Ships behind the registry entry-point group
+`pleno_pii_scanner.connectors` (kind `notion`), routed by the unified CLI
+as `pleno-pii-scanner scan notion ...`.
+
+## Auth
+
+**Internal Integration Token only** (Bearer). The token must come from a
+workspace-internal integration that has been shared with the pages /
+databases you want to scan. OAuth public integrations are out of scope
+for v1 — the connector deliberately rejects every prefix other than the
+`secret_*` / `ntn_*` Notion uses for internal integration tokens.
+
+## Discovery modes
+
+| Mode | Config | Behavior |
+|---|---|---|
+| Search | (default) | `POST /v1/search` with empty query — every page + database the integration was shared with |
+| Explicit pages | `pages: ["<id>", ...]` | scan only those pages and their descendants |
+| Database query | `databases: ["<id>", ...]` | enumerate rows of each database via `/v1/databases/{id}/query` |
+
+The three modes are independent and can be combined; results dedupe on
+`(object_type, id)`.
+
+## Block tree → Markdown
+
+Every page or row's block tree is materialized to Markdown so the
+existing detector stack (regex + NER) sees the same surface text a
+Notion reader would. Supported block types:
+
+`paragraph`, `heading_1`, `heading_2`, `heading_3`, `bulleted_list_item`,
+`numbered_list_item`, `to_do`, `toggle`, `code` (preserves language fence),
+`quote`, `callout`, `divider`, `table`, `table_row`, `equation`, `embed`,
+`bookmark`, `link_to_page`, `child_page`, `child_database`.
+
+Unknown block types emit `<!-- unsupported: {type} -->` so a future
+Notion API change cannot crash a scan.
+
+## Database row → Markdown
+
+Properties are serialized one per line as `prop_name: value`. Supported
+property types: `title`, `rich_text`, `number`, `select`, `multi_select`,
+`status`, `date`, `email`, `phone_number`, `url`, `people`, `files`,
+`checkbox`, `relation`, `formula`, `rollup`. Low-signal metadata
+(`created_time`, `last_edited_time`, `created_by`, `last_edited_by`) is
+skipped.
+
+## Rate limiting
+
+Notion returns `429` with a `Retry-After` header. The connector raises
+`RateLimited` on 429 so the scheduler's AIMD bucket can shrink the
+per-tenant rate; concurrency defaults to 3 (Notion's published limit is
+~3 RPS averaged).
+
+## Archived
+
+Archived pages / blocks are skipped by default; pass `include_archived=True`
+to keep them.

--- a/packages/pii-scanner-notion/pyproject.toml
+++ b/packages/pii-scanner-notion/pyproject.toml
@@ -1,0 +1,74 @@
+[project]
+name = "pleno-pii-scanner-notion"
+version = "0.1.0"
+description = "Notion SourceConnector wheel for pleno-pii-scanner — workspace pages, databases, block tree → Markdown"
+readme = "README.md"
+license = { text = "AGPL-3.0-or-later" }
+requires-python = ">=3.12"
+authors = [{ name = "pleno", email = "ai@egahika.dev" }]
+keywords = ["pii", "notion", "scanner", "dlp", "knowledge-base"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+    "Topic :: Office/Business",
+]
+dependencies = [
+    # Core protocol + scheduler primitives (RateLimited, Capabilities, ...).
+    # Workspace-pinned so this wheel inherits whatever the core repo currently
+    # ships and we don't have to chase compatible version ranges in-tree.
+    "pleno-pii-scanner",
+    # Direct httpx access — we deliberately do NOT take notion-client as a
+    # dependency. notion-client is sync only, has no transport-injection seam
+    # for hermetic tests, and would force us to bridge between sync and async.
+    # httpx + the documented Notion REST shape is small enough that owning the
+    # surface area is cheaper than fighting an SDK that pre-dates async Notion
+    # use cases.
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/plenoai/pleno-anonymize"
+Source = "https://github.com/plenoai/pleno-anonymize"
+Issues = "https://github.com/plenoai/pleno-anonymize/issues"
+
+# WHY entry-point only (no [project.scripts]): per ADR-0007 §13, this wheel
+# must NOT add a `pleno-pii-scanner-notion` CLI; routing happens via the core
+# registry (`pleno-pii-scanner scan notion ...`). Adding a script would shadow
+# the registry path and confuse operators about which entry is canonical.
+[project.entry-points."pleno_pii_scanner.connectors"]
+notion = "pleno_pii_scanner_notion:SPEC"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
+]
+
+[tool.uv.sources]
+pleno-pii-scanner = { workspace = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+branch = true
+source = ["pleno_pii_scanner_notion"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+fail_under = 99
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pleno_pii_scanner_notion"]

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/__init__.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/__init__.py
@@ -1,0 +1,46 @@
+"""Notion SourceConnector wheel for pleno-pii-scanner.
+
+Workspace-internal integration token (Bearer) → search-based discovery
++ explicit page list + database query. The block tree is materialized
+to Markdown so detectors see the same surface text a Notion reader
+would, and database row properties are emitted as `key: value` lines so
+structured columns (email / phone / URL) stay scannable.
+
+Registered in the core registry via the entry-point group
+`pleno_pii_scanner.connectors`; route via `pleno-pii-scanner scan notion ...`.
+"""
+
+from .api import (
+    DEFAULT_BASE_URL,
+    NOTION_VERSION,
+    PAGE_SIZE,
+    NotionApi,
+    NotionApiError,
+)
+from .connector import KIND, SPEC, NotionConfig, NotionConnector
+from .markdown import (
+    DEPTH_TRUNCATED_MARKER,
+    MAX_DEPTH,
+    render_blocks,
+    render_database_row,
+    render_rich_text,
+)
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "DEPTH_TRUNCATED_MARKER",
+    "KIND",
+    "MAX_DEPTH",
+    "NOTION_VERSION",
+    "PAGE_SIZE",
+    "SPEC",
+    "NotionApi",
+    "NotionApiError",
+    "NotionConfig",
+    "NotionConnector",
+    "render_blocks",
+    "render_database_row",
+    "render_rich_text",
+]
+
+__version__ = "0.1.0"

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/api.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/api.py
@@ -1,0 +1,165 @@
+"""Minimal httpx wrapper for the Notion REST API.
+
+Notion's official `notion-client` SDK is sync only and exposes no
+transport-injection seam, so we cannot drive it under
+`httpx.MockTransport` for hermetic testing. The endpoint surface we use
+is small (5 paths) — owning a thin async wrapper is cheaper than
+bridging sync→async and writing parallel test infrastructure.
+
+Rate-limit handling lives here so every endpoint surfaces `RateLimited`
+to the scheduler's AIMD bucket on `429 Too Many Requests`. The
+`Notion-Version` header is pinned to a specific date — Notion breaks
+response shape across versions and an unpinned client will silently
+start failing one morning when they roll a new schema.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from pleno_pii_scanner.scheduler.rate_limit import RateLimited
+
+
+# Public REST host. There is no GHES-equivalent self-hosted Notion, so we
+# don't expose `base_url` as a connector option — only the constructor
+# accepts it for tests that want to point at a captive mock.
+DEFAULT_BASE_URL = "https://api.notion.com/v1"
+
+# Pinned API version. Bumping requires re-validating every block / property
+# parser in `markdown.py`; do NOT silently track upstream's "latest".
+# 2022-06-28 is Notion's GA version and the schema we parse against.
+NOTION_VERSION = "2022-06-28"
+
+_USER_AGENT = "pleno-pii-scanner-notion"
+
+# Notion's `page_size` ceiling on every paginated endpoint. Hard-coded
+# instead of exposed because going below 100 multiplies request count
+# (= rate-limit pressure) for no benefit, and >100 is rejected by Notion.
+PAGE_SIZE = 100
+
+
+class NotionApiError(Exception):
+    """Non-retryable upstream failure (4xx other than 401/403/429)."""
+
+
+class NotionApi:
+    """Thin async wrapper around `httpx.AsyncClient`.
+
+    Owns one HTTP client for the connector's lifetime. Tests inject a
+    mock transport; production callers pass `transport=None` for the
+    default. The bearer token is immutable per-instance — Notion
+    integration tokens never expire so there is no refresh seam.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        base_url: str = DEFAULT_BASE_URL,
+        notion_version: str = NOTION_VERSION,
+        transport: httpx.AsyncBaseTransport | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        if not token:
+            raise ValueError("notion api requires a non-empty integration token")
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+        self._notion_version = notion_version
+        kwargs: dict[str, Any] = {"timeout": timeout}
+        if transport is not None:
+            kwargs["transport"] = transport
+        self._client = httpx.AsyncClient(**kwargs)
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def notion_version(self) -> str:
+        return self._notion_version
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    def _headers(self) -> dict[str, str]:
+        # Authorization MUST come from the constructor token; Notion-Version
+        # is pinned because response shape is version-coupled (e.g. the
+        # `properties` schema for databases changed between 2021-08-16 and
+        # 2022-06-28). Content-Type only matters for POST bodies but we
+        # set it unconditionally — Notion ignores it on GET.
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Notion-Version": self._notion_version,
+            "User-Agent": _USER_AGENT,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    async def get(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = path if path.startswith("http") else f"{self._base_url}{path}"
+        response = await self._client.get(url, params=params, headers=self._headers())
+        return self._handle(response)
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = path if path.startswith("http") else f"{self._base_url}{path}"
+        response = await self._client.post(
+            url, json=dict(json or {}), headers=self._headers()
+        )
+        return self._handle(response)
+
+    def _handle(self, response: httpx.Response) -> dict[str, Any]:
+        """Translate HTTP status into either a parsed body or an exception."""
+        _raise_for_rate_limit(response)
+        status = response.status_code
+        if status == 404:
+            # Notion returns 404 for "this integration cannot see this object"
+            # *and* for "this object does not exist". The two are
+            # indistinguishable from the API; both must be treated as a
+            # silent skip by the connector, not a fatal error. We surface
+            # an empty dict so callers can `if not body: return`.
+            return {}
+        if status >= 400:
+            raise NotionApiError(
+                f"notion {status} {response.request.method} {response.request.url.path}: "
+                f"{response.text[:200]}"
+            )
+        # Notion always responds with JSON for 2xx; .json() raising means
+        # the upstream sent a corrupt body and we want the loud failure.
+        return response.json()
+
+
+def _raise_for_rate_limit(response: httpx.Response) -> None:
+    """Convert Notion's 429 signal into `RateLimited`.
+
+    Notion documents only one rate-limit shape: `429 Too Many Requests`
+    with a `Retry-After` integer header in seconds. Unlike GitHub there
+    is no "secondary" 403; primary 401 means the token is bad and is a
+    fatal NotionApiError handled by the generic >=400 branch.
+    """
+    if response.status_code == 429:
+        retry_after = response.headers.get("Retry-After")
+        raise RateLimited(
+            f"notion 429; retry_after={retry_after!r}"
+        )
+
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "NOTION_VERSION",
+    "PAGE_SIZE",
+    "NotionApi",
+    "NotionApiError",
+]

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/connector.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/connector.py
@@ -1,0 +1,524 @@
+"""NotionConnector — main SourceConnector for Notion workspaces.
+
+Three independent discovery modes:
+
+* **Search** — `POST /v1/search` with empty query yields every page +
+  database the integration has been shared with. Default when no
+  `pages` / `databases` is configured.
+* **Explicit pages** — `pages=["<page-id>", ...]` scans the given pages
+  and their descendant blocks.
+* **Database query** — `databases=["<db-id>", ...]` enumerates rows of
+  each database via `/v1/databases/{id}/query`.
+
+The three modes are not mutually exclusive; the connector merges
+results and yields one `DocumentRef` per page or database row. `fetch`
+materializes the block tree (or the row's properties + child blocks)
+into Markdown for the detector pipeline.
+
+Concurrency defaults to 3 (`max_concurrent_fetches=3`) — Notion's
+published cap is ~3 RPS averaged and 429 ramps up quickly past it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from pleno_pii_scanner.scheduler.rate_limit import BucketKey, RateLimited
+from pleno_pii_scanner.sources.base import (
+    Capabilities,
+    Cursor,
+    Document,
+    DocumentChunk,  # noqa: F401  re-exported in fetch annotation
+    DocumentRef,
+    SourceConnector,
+    SourceFilter,
+)
+from pleno_pii_scanner.sources.registry import ConnectorSpec
+
+from .api import DEFAULT_BASE_URL, NOTION_VERSION, PAGE_SIZE, NotionApi, NotionApiError
+from .markdown import MAX_DEPTH, render_blocks, render_database_row
+
+
+# Connector kind — entry-point key.
+KIND = "notion"
+
+
+@dataclass(frozen=True, slots=True)
+class NotionConfig:
+    """Construction config for `NotionConnector`.
+
+    `token` is required and must be a Notion internal-integration token
+    (Bearer). `pages` / `databases` switch on the explicit modes; if
+    both are empty, the connector falls back to search-based discovery.
+    """
+
+    token: str
+    id: str | None = None
+    pages: tuple[str, ...] = ()
+    databases: tuple[str, ...] = ()
+    include_archived: bool = False
+    base_url: str = DEFAULT_BASE_URL
+    notion_version: str = NOTION_VERSION
+    max_concurrent_fetches: int = 3
+    request_timeout: float = 30.0
+    workspace_id: str | None = None
+
+    def resolved_id(self) -> str:
+        if self.id is not None:
+            return self.id
+        # Token is never embedded in the id — derive a stable scope from
+        # the optional workspace_id if the operator supplied one.
+        scope = self.workspace_id or "default"
+        return f"notion:{scope}"
+
+
+class NotionConnector:
+    """`SourceConnector` implementation backed by the Notion REST API.
+
+    Owns one `NotionApi` for the connector's lifetime. The HTTP client is
+    closed in `close()`; tests that pass `transport=...` get the same
+    cleanup path so there are no leaked sessions on shutdown.
+    """
+
+    kind = KIND
+
+    def __init__(
+        self,
+        config: NotionConfig,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._config = config
+        self.id = config.resolved_id()
+        self._api = NotionApi(
+            token=config.token,
+            base_url=config.base_url,
+            notion_version=config.notion_version,
+            transport=transport,
+            timeout=config.request_timeout,
+        )
+        # `(object_type, object_id)` set used to deduplicate discoveries
+        # when search + pages + databases are combined. Kept on the
+        # instance because `discover` is an async generator and each
+        # discovery invocation wants a fresh dedup horizon.
+        self._discover_seen: set[tuple[str, str]] = set()
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(
+            incremental=True,
+            binary=False,
+            content_hash_delta=False,
+            max_concurrent_fetches=self._config.max_concurrent_fetches,
+            streaming=False,
+        )
+
+    def bucket_key(self) -> BucketKey:
+        """BucketKey for the global rate limiter.
+
+        Notion's rate limit is per-integration-token — every endpoint
+        shares the same ~3 RPS budget. We expose a single bucket per
+        connector instance so the scheduler doesn't double-throttle.
+        """
+        return BucketKey(
+            connector_kind=self.kind,
+            tenant_id=self._config.workspace_id or self.id,
+        )
+
+    async def close(self) -> None:
+        await self._api.aclose()
+
+    # ------------------------------------------------------------------
+    # discover
+    # ------------------------------------------------------------------
+
+    async def discover(
+        self,
+        filter: SourceFilter,  # noqa: ARG002 — Notion has no native include/exclude
+        cursor: Cursor | None,
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield one DocumentRef per page or database row.
+
+        Modes are evaluated in order — explicit pages first (so an
+        operator pinning a small list gets fast results), then explicit
+        databases, then the catch-all search. `cursor` is currently
+        only honored by the search path; the explicit modes are bounded
+        and always restart from scratch.
+        """
+        self._discover_seen = set()
+        if self._config.pages:
+            for page_id in self._config.pages:
+                async for ref in self._discover_page(page_id):
+                    yield ref
+        if self._config.databases:
+            for db_id in self._config.databases:
+                async for ref in self._discover_database(db_id):
+                    yield ref
+        if not self._config.pages and not self._config.databases:
+            async for ref in self._discover_search(cursor):
+                yield ref
+
+    async def _discover_page(self, page_id: str) -> AsyncIterator[DocumentRef]:
+        page = await self._api.get(f"/pages/{page_id}")
+        ref = self._page_to_ref(page)
+        if ref is not None:
+            yield ref
+
+    async def _discover_database(self, database_id: str) -> AsyncIterator[DocumentRef]:
+        cursor: str | None = None
+        while True:
+            body: dict[str, Any] = {"page_size": PAGE_SIZE}
+            if cursor:
+                body["start_cursor"] = cursor
+            payload = await self._api.post(
+                f"/databases/{database_id}/query", json=body
+            )
+            for row in payload.get("results", []):
+                ref = self._page_to_ref(row, parent_database_id=database_id)
+                if ref is not None:
+                    yield ref
+            if not payload.get("has_more"):
+                return
+            cursor = payload.get("next_cursor")
+            if not cursor:
+                return
+
+    async def _discover_search(self, cursor: str | None) -> AsyncIterator[DocumentRef]:
+        next_cursor: str | None = cursor
+        while True:
+            body: dict[str, Any] = {"page_size": PAGE_SIZE}
+            if next_cursor:
+                body["start_cursor"] = next_cursor
+            payload = await self._api.post("/search", json=body)
+            for obj in payload.get("results", []):
+                ref = self._page_to_ref(obj)
+                if ref is not None:
+                    # Round-trip the search cursor on every ref so the
+                    # scheduler can checkpoint mid-search.
+                    yield self._with_cursor(ref, payload.get("next_cursor"))
+            if not payload.get("has_more"):
+                return
+            next_cursor = payload.get("next_cursor")
+            if not next_cursor:
+                return
+
+    def _page_to_ref(
+        self,
+        obj: Mapping[str, Any] | None,
+        *,
+        parent_database_id: str | None = None,
+    ) -> DocumentRef | None:
+        if not isinstance(obj, Mapping) or not obj:
+            return None
+        object_type = obj.get("object")
+        object_id = obj.get("id")
+        if not isinstance(object_id, str) or object_type not in {"page", "database"}:
+            return None
+        if not self._config.include_archived and obj.get("archived"):
+            return None
+        key = (object_type, object_id)
+        if key in self._discover_seen:
+            return None
+        self._discover_seen.add(key)
+        last_modified = _parse_iso(obj.get("last_edited_time"))
+        native_url = obj.get("url") if isinstance(obj.get("url"), str) else None
+        # Path encodes the object kind so a finding's location renders as
+        # `notion://page/<id>` or `notion://database-row/<id>` — the
+        # parent_database_id qualifier disambiguates rows from standalone
+        # pages.
+        path_kind = (
+            "database-row" if parent_database_id else object_type
+        )
+        path = f"notion://{path_kind}/{object_id}"
+        parent_chain: tuple[str, ...] = ()
+        if parent_database_id:
+            parent_chain = (f"notion://database/{parent_database_id}",)
+        elif isinstance(obj.get("parent"), Mapping):
+            parent_id = _parent_id(obj["parent"])
+            if parent_id is not None:
+                parent_chain = (parent_id,)
+        metadata: dict[str, str] = {
+            "object_type": str(object_type),
+            "object_id": object_id,
+        }
+        if parent_database_id:
+            metadata["database_id"] = parent_database_id
+        return DocumentRef(
+            source_id=self.id,
+            source_kind=self.kind,
+            path=path,
+            native_url=native_url,
+            parent_chain=parent_chain,
+            content_type="text/markdown",
+            last_modified=last_modified,
+            metadata=metadata,
+        )
+
+    def _with_cursor(self, ref: DocumentRef, cursor: str | None) -> DocumentRef:
+        if not cursor:
+            return ref
+        # DocumentRef is frozen; build a fresh metadata dict and rebind.
+        new_meta = dict(ref.metadata)
+        new_meta["_cursor"] = cursor
+        return DocumentRef(
+            source_id=ref.source_id,
+            source_kind=ref.source_kind,
+            path=ref.path,
+            native_url=ref.native_url,
+            parent_chain=ref.parent_chain,
+            content_type=ref.content_type,
+            size=ref.size,
+            etag=ref.etag,
+            last_modified=ref.last_modified,
+            metadata=new_meta,
+        )
+
+    # ------------------------------------------------------------------
+    # fetch
+    # ------------------------------------------------------------------
+
+    async def fetch(
+        self,
+        ref: DocumentRef,
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        """Materialize a Markdown Document for `ref`.
+
+        For pages and database rows: walk the block tree and convert
+        every block to Markdown. For database rows the property map is
+        emitted first (one `name: value` line per property) so detectors
+        see the structured columns alongside the prose body.
+        """
+        meta = ref.metadata
+        object_id = meta.get("object_id")
+        object_type = meta.get("object_type")
+        if not object_id or not object_type:
+            return
+        page_or_row = await self._fetch_object(object_type, object_id)
+        if not page_or_row:
+            return
+        properties_md = ""
+        if object_type == "page":
+            # Database rows expose a `properties` map with rich-text
+            # columns; standalone pages only have a `title` we don't
+            # need to repeat (it appears in the block tree).
+            if meta.get("database_id"):
+                properties_md = render_database_row(page_or_row.get("properties"))
+        body_md = await self._fetch_block_tree(object_id)
+        text_parts = [p for p in (properties_md, body_md) if p]
+        text = "\n\n".join(text_parts) if text_parts else ""
+        if not text:
+            # Nothing to scan — yield nothing rather than emit an empty
+            # Document (which fails the text/binary XOR invariant).
+            return
+        yield Document(
+            ref=ref,
+            text=text,
+            fetched_at=datetime.now(UTC),
+        )
+
+    async def _fetch_object(
+        self, object_type: str, object_id: str
+    ) -> Mapping[str, Any] | None:
+        if object_type == "page":
+            obj = await self._api.get(f"/pages/{object_id}")
+        elif object_type == "database":
+            obj = await self._api.get(f"/databases/{object_id}")
+        else:
+            return None
+        return obj or None
+
+    async def _fetch_block_tree(self, root_id: str) -> str:
+        """Recursively pull a block's children and render them.
+
+        Children are fetched eagerly per nesting level; for each block
+        with `has_children=true` we issue another `/blocks/{id}/children`
+        call. The recursion is bounded by `markdown.MAX_DEPTH` so a
+        future API change that introduces a self-referential block can
+        not infinite-loop.
+        """
+        # Cache: block_id -> list[block]. Populated as we descend so
+        # `render_blocks` can resolve children synchronously via the
+        # callback seam.
+        children_cache: dict[str, list[Mapping[str, Any]]] = {}
+
+        async def _walk(block_id: str, depth: int) -> None:
+            if depth >= MAX_DEPTH:
+                return
+            children = await self._list_block_children(block_id)
+            children_cache[block_id] = children
+            for child in children:
+                if child.get("has_children"):
+                    child_id = child.get("id")
+                    if isinstance(child_id, str):
+                        await _walk(child_id, depth + 1)
+
+        await _walk(root_id, depth=0)
+
+        def lookup(block_id: str | None) -> list[Mapping[str, Any]]:
+            if not isinstance(block_id, str):
+                return []
+            return children_cache.get(block_id, [])
+
+        return render_blocks(
+            children_cache.get(root_id, []),
+            children_for=lookup,
+            include_archived=self._config.include_archived,
+        )
+
+    async def _list_block_children(
+        self, block_id: str
+    ) -> list[Mapping[str, Any]]:
+        """Page through `/blocks/{id}/children` and return every child block."""
+        out: list[Mapping[str, Any]] = []
+        cursor: str | None = None
+        while True:
+            params: dict[str, Any] = {"page_size": PAGE_SIZE}
+            if cursor:
+                params["start_cursor"] = cursor
+            payload = await self._api.get(
+                f"/blocks/{block_id}/children", params=params
+            )
+            for block in payload.get("results", []):
+                if not isinstance(block, Mapping):
+                    continue
+                if not self._config.include_archived and block.get("archived"):
+                    continue
+                out.append(block)
+            if not payload.get("has_more"):
+                return out
+            cursor = payload.get("next_cursor")
+            if not cursor:
+                return out
+
+
+# ---------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _parent_id(parent: Mapping[str, Any]) -> str | None:
+    """Render a Notion `parent` object as a `notion://...` URI."""
+    p_type = parent.get("type")
+    if p_type == "database_id":
+        return f"notion://database/{parent.get('database_id')}"
+    if p_type == "page_id":
+        return f"notion://page/{parent.get('page_id')}"
+    if p_type == "block_id":
+        return f"notion://block/{parent.get('block_id')}"
+    if p_type == "workspace":
+        return "notion://workspace"
+    return None
+
+
+# ---------------------------------------------------------------------
+# Factory + Spec
+# ---------------------------------------------------------------------
+
+
+def _factory(config: Mapping[str, Any]) -> SourceConnector:
+    """Registry factory: dict → NotionConnector.
+
+    Required key: `token`. Optional knobs match the `NotionConfig` fields.
+    """
+    if "token" not in config:
+        raise ValueError("notion connector config requires 'token'")
+    token = str(config["token"])
+    if not token:
+        raise ValueError("notion connector 'token' must be a non-empty string")
+    pages = _string_tuple(config.get("pages"))
+    databases = _string_tuple(config.get("databases"))
+    return NotionConnector(
+        NotionConfig(
+            token=token,
+            id=str(config["id"]) if config.get("id") is not None else None,
+            pages=pages,
+            databases=databases,
+            include_archived=bool(config.get("include_archived", False)),
+            base_url=str(config.get("base_url", DEFAULT_BASE_URL)),
+            notion_version=str(config.get("notion_version", NOTION_VERSION)),
+            max_concurrent_fetches=int(config.get("max_concurrent_fetches", 3)),
+            request_timeout=float(config.get("request_timeout", 30.0)),
+            workspace_id=(
+                str(config["workspace_id"])
+                if config.get("workspace_id") is not None
+                else None
+            ),
+        )
+    )
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    """Accept list/tuple of strings; reject everything else loudly."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        # A bare string is almost certainly an operator typo (one id
+        # instead of a list of ids); reject so they catch it before the
+        # scan launches.
+        raise ValueError(
+            "notion connector list-typed configs (pages, databases) "
+            "must be a list, not a bare string"
+        )
+    if not isinstance(value, Iterable):
+        raise ValueError(
+            "notion connector list-typed configs must be iterable"
+        )
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise ValueError(
+                "notion connector list-typed configs must contain "
+                "non-empty strings"
+            )
+        out.append(item)
+    return tuple(out)
+
+
+SPEC = ConnectorSpec(
+    kind=KIND,
+    version="0.1.0",
+    factory=_factory,
+    capabilities=Capabilities(
+        incremental=True,
+        binary=False,
+        max_concurrent_fetches=3,
+    ),
+    required_scopes=(
+        # Notion doesn't expose granular OAuth scopes for internal
+        # integrations; the integration's "Capabilities" UI gates
+        # read access. We document the practical scope set here so
+        # `connectors describe notion` shows what the operator must
+        # toggle on in Notion's integration settings.
+        "read_content",
+        "read_user_information",
+    ),
+    description=(
+        "Notion connector. Internal Integration Token (Bearer); search-based "
+        "discovery + explicit page list + database query. Fetch materializes "
+        "the block tree as Markdown so detectors see the same surface text a "
+        "Notion reader would. Concurrency capped at 3 to stay under Notion's "
+        "~3 RPS rate limit. ADR-0007 §13."
+    ),
+)
+
+
+__all__ = [
+    "KIND",
+    "SPEC",
+    "NotionConfig",
+    "NotionConnector",
+]

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/markdown.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/markdown.py
@@ -1,0 +1,659 @@
+"""Notion block tree + database property → Markdown converters.
+
+Detectors (regex + NER) downstream operate on plain text, so we
+flatten the Notion document model into Markdown before handing it
+off. Markdown is preferred over a custom AST because:
+
+* It preserves enough structure (lists, headings, code fences) that a
+  human reading a finding's context can still recognise the original
+  page.
+* Mention objects (`@user`, `@page`, `@date`) are rendered as
+  Markdown links so detectors can still match emails / dates that
+  appear inside the mention text.
+* Code fences keep language tags so a Python `password = "x"` inside
+  a `code` block stays distinguishable from the same string in prose.
+
+Defensive contract: an unknown block type emits
+`<!-- unsupported: {type} -->` and the recursion continues. A future
+Notion API change must never crash a scan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+
+# Hard cap on block-tree recursion depth. Notion's UI imposes ~50 levels
+# in practice; 100 leaves headroom while bounding the worst case if a
+# malformed response (or a future API bug) accidentally produces a cycle.
+MAX_DEPTH = 100
+
+# Sentinel emitted when recursion is truncated. Picked so an operator
+# grepping output can find truncated regions without ambiguity vs. real
+# document content.
+DEPTH_TRUNCATED_MARKER = "<!-- depth-truncated -->"
+
+# Property keys that carry no PII signal but are present on every database
+# row; serializing them would dilute the detector input with noise.
+_LOW_SIGNAL_PROPERTY_TYPES = frozenset(
+    {"created_time", "last_edited_time", "created_by", "last_edited_by"}
+)
+
+
+# ---------------------------------------------------------------------
+# rich text
+# ---------------------------------------------------------------------
+
+
+def render_rich_text(rich_text: Sequence[Mapping[str, Any]] | None) -> str:
+    """Concatenate a Notion rich-text array into Markdown.
+
+    Each rich-text element is one of:
+
+    * `{type: "text", text: {content, link}, annotations: {...}}`
+    * `{type: "mention", mention: {type: ...}, plain_text, href}`
+    * `{type: "equation", equation: {expression}, plain_text}`
+
+    Annotations (bold, italic, strikethrough, code) are wrapped with
+    Markdown markers in the order Markdown parsers accept them.
+    """
+    if not rich_text:
+        return ""
+    parts: list[str] = []
+    for element in rich_text:
+        if not isinstance(element, Mapping):
+            continue
+        rendered = _render_rich_text_element(element)
+        if rendered:
+            parts.append(rendered)
+    return "".join(parts)
+
+
+def _render_rich_text_element(element: Mapping[str, Any]) -> str:
+    el_type = element.get("type")
+    if el_type == "text":
+        return _render_text_element(element)
+    if el_type == "mention":
+        return _render_mention_element(element)
+    if el_type == "equation":
+        # Inline equations are wrapped in `$...$` so a downstream Markdown
+        # renderer still treats them as math, while detectors that read
+        # raw text see the LaTeX source verbatim.
+        equation = element.get("equation")
+        expression = (
+            equation.get("expression", "")
+            if isinstance(equation, Mapping)
+            else ""
+        )
+        return f"${expression}$" if expression else _plain(element)
+    # Unknown rich-text type: fall back to the `plain_text` field that
+    # Notion includes on every element for accessibility. This keeps the
+    # raw user-visible text reachable even if the type is one we haven't
+    # mapped.
+    return _plain(element)
+
+
+def _render_text_element(element: Mapping[str, Any]) -> str:
+    text_obj = element.get("text") or {}
+    content = text_obj.get("content", "") if isinstance(text_obj, Mapping) else ""
+    link = text_obj.get("link") if isinstance(text_obj, Mapping) else None
+    href = link.get("url") if isinstance(link, Mapping) else None
+    rendered = _apply_annotations(content, element.get("annotations") or {})
+    if href:
+        # Markdown link: link text already carries annotations.
+        return f"[{rendered}]({href})"
+    return rendered
+
+
+def _render_mention_element(element: Mapping[str, Any]) -> str:
+    mention = element.get("mention") or {}
+    plain_text = element.get("plain_text") or ""
+    href = element.get("href")
+    if not isinstance(mention, Mapping):
+        return _apply_annotations(plain_text, element.get("annotations") or {})
+    mention_type = mention.get("type")
+    # Build a `notion://` URL for mention types that don't carry an
+    # explicit href so detectors still see structured pointers (and so
+    # downstream finding rendering can resolve them later).
+    if not href:
+        if mention_type == "user":
+            user = mention.get("user") or {}
+            href = f"notion://user/{user.get('id', 'unknown')}" if isinstance(user, Mapping) else None
+        elif mention_type == "page":
+            page = mention.get("page") or {}
+            href = f"notion://page/{page.get('id', 'unknown')}" if isinstance(page, Mapping) else None
+        elif mention_type == "database":
+            db = mention.get("database") or {}
+            href = f"notion://database/{db.get('id', 'unknown')}" if isinstance(db, Mapping) else None
+        elif mention_type == "date":
+            date = mention.get("date") or {}
+            start = date.get("start", "") if isinstance(date, Mapping) else ""
+            href = f"notion://date/{start}"
+    rendered = _apply_annotations(plain_text, element.get("annotations") or {})
+    if href:
+        return f"[{rendered}]({href})"
+    return rendered
+
+
+def _apply_annotations(text: str, annotations: Mapping[str, Any]) -> str:
+    r"""Wrap `text` with Markdown markers for each truthy annotation.
+
+    Order: code (innermost) → strikethrough → italic → bold → output.
+    Wrapping `code` first keeps inline code legible inside other
+    decorations (`**\`x\`**`), and `bold` last is the convention every
+    Markdown parser tolerates.
+    """
+    if not text:
+        return text
+    if not isinstance(annotations, Mapping):
+        return text
+    if annotations.get("code"):
+        text = f"`{text}`"
+    if annotations.get("strikethrough"):
+        text = f"~~{text}~~"
+    if annotations.get("italic"):
+        text = f"*{text}*"
+    if annotations.get("bold"):
+        text = f"**{text}**"
+    return text
+
+
+def _plain(element: Mapping[str, Any]) -> str:
+    """Best-effort fallback to the `plain_text` Notion attaches everywhere."""
+    plain = element.get("plain_text")
+    return plain if isinstance(plain, str) else ""
+
+
+# ---------------------------------------------------------------------
+# blocks
+# ---------------------------------------------------------------------
+
+
+def render_blocks(
+    blocks: Sequence[Mapping[str, Any]] | None,
+    *,
+    children_for: "ChildrenLookup | None" = None,
+    include_archived: bool = False,
+    depth: int = 0,
+) -> str:
+    """Render a flat list of sibling blocks into Markdown.
+
+    `children_for(block_id) -> list[block]` is the recursion seam: the
+    connector's discover/fetch path hydrates child block lists with
+    real HTTP calls, while tests inject a dict-backed lookup so the
+    converter is fully exercised in isolation.
+
+    `depth` is the current recursion depth. Beyond `MAX_DEPTH` we emit a
+    sentinel and stop recursing — Notion's response model can't directly
+    express a cycle but a future API change or a malformed mock could.
+    """
+    if not blocks:
+        return ""
+    if depth >= MAX_DEPTH:
+        return DEPTH_TRUNCATED_MARKER
+    out: list[str] = []
+    # Numbered-list rendering needs a running counter scoped to the
+    # current sibling group, restarted whenever a non-list block breaks
+    # the run. Notion stores no list index — clients compute it.
+    numbered_counter = 0
+    for block in blocks:
+        if not isinstance(block, Mapping):
+            continue
+        if not include_archived and block.get("archived"):
+            continue
+        block_type = block.get("type")
+        if block_type == "numbered_list_item":
+            numbered_counter += 1
+        else:
+            numbered_counter = 0
+        rendered = _render_block(
+            block,
+            children_for=children_for,
+            include_archived=include_archived,
+            depth=depth,
+            numbered_index=numbered_counter,
+        )
+        if rendered:
+            out.append(rendered)
+    return "\n\n".join(p for p in out if p)
+
+
+# Type alias — kept as a string-quoted forward reference in the public
+# signature to avoid circular imports with the connector module.
+ChildrenLookup = Any
+
+
+def _render_block(
+    block: Mapping[str, Any],
+    *,
+    children_for: ChildrenLookup | None,
+    include_archived: bool,
+    depth: int,
+    numbered_index: int,
+) -> str:
+    block_type = block.get("type")
+    payload = block.get(block_type) if isinstance(block_type, str) else None
+    if not isinstance(payload, Mapping):
+        payload = {}
+    has_children = bool(block.get("has_children"))
+
+    handler = _BLOCK_HANDLERS.get(block_type or "")
+    if handler is None:
+        # Unknown / unsupported block type. Emit a comment so an operator
+        # reading raw output sees what was skipped, but never crash.
+        return f"<!-- unsupported: {block_type} -->"
+
+    body = handler(payload, numbered_index=numbered_index)
+
+    if has_children and children_for is not None and block_type not in {"table"}:
+        # `table` handles its own children (rows) inline; everything else
+        # appends nested children below the parent block, indented two
+        # spaces per nesting level so a Markdown renderer treats them as
+        # sub-list items where applicable.
+        children = children_for(block.get("id"))
+        if children:
+            child_md = render_blocks(
+                children,
+                children_for=children_for,
+                include_archived=include_archived,
+                depth=depth + 1,
+            )
+            if child_md:
+                body = f"{body}\n{_indent(child_md, '  ')}" if body else child_md
+    elif block_type == "table" and children_for is not None:
+        # Tables: children are `table_row` blocks. Render them inline
+        # using the table-specific formatter so the result is a single
+        # Markdown table block rather than a header followed by indented
+        # rows.
+        rows = children_for(block.get("id")) or []
+        body = _render_table(payload, rows)
+    return body
+
+
+def _render_paragraph(payload: Mapping[str, Any], **_: Any) -> str:
+    return render_rich_text(payload.get("rich_text"))
+
+
+def _render_heading(level: int):
+    prefix = "#" * level
+
+    def _h(payload: Mapping[str, Any], **_: Any) -> str:
+        text = render_rich_text(payload.get("rich_text"))
+        return f"{prefix} {text}" if text else prefix
+
+    return _h
+
+
+def _render_bulleted(payload: Mapping[str, Any], **_: Any) -> str:
+    return f"- {render_rich_text(payload.get('rich_text'))}"
+
+
+def _render_numbered(payload: Mapping[str, Any], *, numbered_index: int = 1, **_: Any) -> str:
+    return f"{numbered_index}. {render_rich_text(payload.get('rich_text'))}"
+
+
+def _render_to_do(payload: Mapping[str, Any], **_: Any) -> str:
+    box = "[x]" if payload.get("checked") else "[ ]"
+    return f"- {box} {render_rich_text(payload.get('rich_text'))}"
+
+
+def _render_toggle(payload: Mapping[str, Any], **_: Any) -> str:
+    # Notion toggles render as a `<details>` summary in their HTML
+    # export; we use the same so detectors still see the toggle title
+    # alongside the body when a renderer collapses the children.
+    return f"<details><summary>{render_rich_text(payload.get('rich_text'))}</summary></details>"
+
+
+def _render_code(payload: Mapping[str, Any], **_: Any) -> str:
+    language = payload.get("language") or ""
+    body = render_rich_text(payload.get("rich_text"))
+    return f"```{language}\n{body}\n```"
+
+
+def _render_quote(payload: Mapping[str, Any], **_: Any) -> str:
+    text = render_rich_text(payload.get("rich_text"))
+    return f"> {text}" if text else ">"
+
+
+def _render_callout(payload: Mapping[str, Any], **_: Any) -> str:
+    icon = payload.get("icon") or {}
+    emoji = icon.get("emoji") if isinstance(icon, Mapping) else None
+    body = render_rich_text(payload.get("rich_text"))
+    prefix = f"{emoji} " if emoji else ""
+    return f"> {prefix}{body}"
+
+
+def _render_divider(_: Mapping[str, Any], **__: Any) -> str:
+    return "---"
+
+
+def _render_table_placeholder(_: Mapping[str, Any], **__: Any) -> str:
+    # Real rendering happens in `_render_table`; without children we have
+    # nothing to emit.
+    return ""
+
+
+def _render_table_row(payload: Mapping[str, Any], **_: Any) -> str:
+    cells = payload.get("cells") or []
+    rendered_cells = [render_rich_text(cell) for cell in cells if isinstance(cell, Sequence)]
+    return "| " + " | ".join(rendered_cells) + " |"
+
+
+def _render_equation(payload: Mapping[str, Any], **_: Any) -> str:
+    expression = payload.get("expression", "")
+    return f"$$\n{expression}\n$$" if expression else ""
+
+
+def _render_embed(payload: Mapping[str, Any], **_: Any) -> str:
+    url = payload.get("url", "")
+    return f"[embed]({url})" if url else ""
+
+
+def _render_bookmark(payload: Mapping[str, Any], **_: Any) -> str:
+    url = payload.get("url", "")
+    caption = render_rich_text(payload.get("caption"))
+    if not url:
+        return ""
+    label = caption or url
+    return f"[{label}]({url})"
+
+
+def _render_link_to_page(payload: Mapping[str, Any], **_: Any) -> str:
+    target_type = payload.get("type")
+    target_id = payload.get(target_type) if isinstance(target_type, str) else None
+    if isinstance(target_id, str):
+        return f"[link]({_notion_uri(target_type, target_id)})"
+    return ""
+
+
+def _render_child_page(payload: Mapping[str, Any], **_: Any) -> str:
+    title = payload.get("title", "")
+    return f"## {title}" if title else ""
+
+
+def _render_child_database(payload: Mapping[str, Any], **_: Any) -> str:
+    title = payload.get("title", "")
+    return f"## {title} (database)" if title else "## (database)"
+
+
+def _render_table(payload: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> str:
+    """Materialize a Notion `table` block + its `table_row` children.
+
+    Notion stores `has_column_header` / `has_row_header` on the table
+    payload so we can emit the standard Markdown header separator only
+    when the source explicitly declared a header row. Without a header
+    row, every row is data — we still emit a separator row so the
+    output remains valid Markdown table syntax (some parsers reject
+    tables without a header).
+    """
+    if not rows:
+        return ""
+    table_width = int(payload.get("table_width") or 0) or _row_width(rows[0])
+    header_row, *body_rows = rows if payload.get("has_column_header") else (
+        [{"type": "table_row", "table_row": {"cells": [[] for _ in range(table_width)]}}]
+        + list(rows)
+    )
+    parts = [_render_one_row(header_row), "| " + " | ".join(["---"] * table_width) + " |"]
+    for r in body_rows:
+        parts.append(_render_one_row(r))
+    return "\n".join(parts)
+
+
+def _render_one_row(row: Mapping[str, Any]) -> str:
+    payload = row.get("table_row") or {}
+    if not isinstance(payload, Mapping):
+        return ""
+    return _render_table_row(payload)
+
+
+def _row_width(row: Mapping[str, Any]) -> int:
+    payload = row.get("table_row") or {}
+    if not isinstance(payload, Mapping):
+        return 0
+    cells = payload.get("cells") or []
+    return len(cells) if isinstance(cells, Sequence) else 0
+
+
+def _notion_uri(kind: str | None, ident: str) -> str:
+    return f"notion://{kind or 'object'}/{ident}"
+
+
+def _indent(text: str, prefix: str) -> str:
+    return "\n".join(prefix + line if line else line for line in text.splitlines())
+
+
+# Dispatch table — keyed by Notion `type` discriminator. Lookup miss →
+# unsupported-comment fallback in `_render_block`.
+_BLOCK_HANDLERS: dict[str, Any] = {
+    "paragraph": _render_paragraph,
+    "heading_1": _render_heading(1),
+    "heading_2": _render_heading(2),
+    "heading_3": _render_heading(3),
+    "bulleted_list_item": _render_bulleted,
+    "numbered_list_item": _render_numbered,
+    "to_do": _render_to_do,
+    "toggle": _render_toggle,
+    "code": _render_code,
+    "quote": _render_quote,
+    "callout": _render_callout,
+    "divider": _render_divider,
+    "table": _render_table_placeholder,
+    "table_row": _render_table_row,
+    "equation": _render_equation,
+    "embed": _render_embed,
+    "bookmark": _render_bookmark,
+    "link_to_page": _render_link_to_page,
+    "child_page": _render_child_page,
+    "child_database": _render_child_database,
+}
+
+
+# ---------------------------------------------------------------------
+# database properties
+# ---------------------------------------------------------------------
+
+
+def render_database_row(properties: Mapping[str, Any] | None) -> str:
+    """Serialize a database row's `properties` map to `key: value` lines.
+
+    Properties are emitted in the order Notion returned them so the
+    output mirrors the column ordering the workspace owner configured.
+    `created_time` / `last_edited_time` / `created_by` / `last_edited_by`
+    are skipped — they're high-volume metadata with no PII signal and
+    would dilute the detector input.
+    """
+    if not properties:
+        return ""
+    lines: list[str] = []
+    for name, prop in properties.items():
+        if not isinstance(prop, Mapping):
+            continue
+        prop_type = prop.get("type")
+        if prop_type in _LOW_SIGNAL_PROPERTY_TYPES:
+            continue
+        rendered = _render_property(prop, prop_type)
+        if rendered is None:
+            # Unknown property type — emit the name with a marker so an
+            # operator can spot which column dropped out without crashing.
+            lines.append(f"{name}: <!-- unsupported property: {prop_type} -->")
+            continue
+        lines.append(f"{name}: {rendered}")
+    return "\n".join(lines)
+
+
+def _render_property(prop: Mapping[str, Any], prop_type: str | None) -> str | None:
+    handler = _PROPERTY_HANDLERS.get(prop_type or "")
+    if handler is None:
+        return None
+    return handler(prop)
+
+
+def _prop_title(prop: Mapping[str, Any]) -> str:
+    return render_rich_text(prop.get("title"))
+
+
+def _prop_rich_text(prop: Mapping[str, Any]) -> str:
+    return render_rich_text(prop.get("rich_text"))
+
+
+def _prop_number(prop: Mapping[str, Any]) -> str:
+    value = prop.get("number")
+    return "" if value is None else str(value)
+
+
+def _prop_select(prop: Mapping[str, Any]) -> str:
+    select = prop.get("select")
+    if not isinstance(select, Mapping):
+        return ""
+    return str(select.get("name", ""))
+
+
+def _prop_multi_select(prop: Mapping[str, Any]) -> str:
+    items = prop.get("multi_select") or []
+    names = [
+        str(item.get("name", ""))
+        for item in items
+        if isinstance(item, Mapping)
+    ]
+    return ", ".join(n for n in names if n)
+
+
+def _prop_status(prop: Mapping[str, Any]) -> str:
+    status = prop.get("status")
+    if not isinstance(status, Mapping):
+        return ""
+    return str(status.get("name", ""))
+
+
+def _prop_date(prop: Mapping[str, Any]) -> str:
+    date = prop.get("date")
+    if not isinstance(date, Mapping):
+        return ""
+    start = date.get("start", "")
+    end = date.get("end")
+    return f"{start} → {end}" if end else str(start or "")
+
+
+def _prop_email(prop: Mapping[str, Any]) -> str:
+    return str(prop.get("email") or "")
+
+
+def _prop_phone(prop: Mapping[str, Any]) -> str:
+    return str(prop.get("phone_number") or "")
+
+
+def _prop_url(prop: Mapping[str, Any]) -> str:
+    return str(prop.get("url") or "")
+
+
+def _prop_people(prop: Mapping[str, Any]) -> str:
+    people = prop.get("people") or []
+    rendered: list[str] = []
+    for person in people:
+        if not isinstance(person, Mapping):
+            continue
+        name = person.get("name")
+        person_obj = person.get("person")
+        email = (
+            person_obj.get("email")
+            if isinstance(person_obj, Mapping)
+            else None
+        )
+        if name and email:
+            rendered.append(f"{name} <{email}>")
+        elif name:
+            rendered.append(str(name))
+        elif email:
+            rendered.append(str(email))
+        else:
+            rendered.append(str(person.get("id", "")))
+    return ", ".join(r for r in rendered if r)
+
+
+def _prop_files(prop: Mapping[str, Any]) -> str:
+    files = prop.get("files") or []
+    rendered: list[str] = []
+    for f in files:
+        if not isinstance(f, Mapping):
+            continue
+        name = f.get("name", "")
+        ftype = f.get("type")
+        body = f.get(ftype) if isinstance(ftype, str) else None
+        url = body.get("url", "") if isinstance(body, Mapping) else ""
+        rendered.append(f"[{name}]({url})" if url else str(name))
+    return ", ".join(r for r in rendered if r)
+
+
+def _prop_checkbox(prop: Mapping[str, Any]) -> str:
+    return "true" if prop.get("checkbox") else "false"
+
+
+def _prop_relation(prop: Mapping[str, Any]) -> str:
+    rels = prop.get("relation") or []
+    ids = [r.get("id") for r in rels if isinstance(r, Mapping) and r.get("id")]
+    return ", ".join(str(i) for i in ids)
+
+
+def _prop_formula(prop: Mapping[str, Any]) -> str:
+    formula = prop.get("formula")
+    if not isinstance(formula, Mapping):
+        return ""
+    f_type = formula.get("type")
+    value = formula.get(f_type) if isinstance(f_type, str) else None
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, Mapping):
+        # Date-typed formula has the same shape as a date property.
+        if "start" in value:
+            return _prop_date({"date": value})
+        return ""
+    return str(value)
+
+
+def _prop_rollup(prop: Mapping[str, Any]) -> str:
+    rollup = prop.get("rollup")
+    if not isinstance(rollup, Mapping):
+        return ""
+    r_type = rollup.get("type")
+    value = rollup.get(r_type) if isinstance(r_type, str) else None
+    if value is None:
+        return ""
+    if r_type == "array" and isinstance(value, list):
+        # Each array element is itself a typed property; recurse.
+        rendered = [_render_property(item, item.get("type")) for item in value if isinstance(item, Mapping)]
+        return ", ".join(r for r in rendered if r)
+    if isinstance(value, Mapping) and "start" in value:
+        return _prop_date({"date": value})
+    return str(value)
+
+
+_PROPERTY_HANDLERS: dict[str, Any] = {
+    "title": _prop_title,
+    "rich_text": _prop_rich_text,
+    "number": _prop_number,
+    "select": _prop_select,
+    "multi_select": _prop_multi_select,
+    "status": _prop_status,
+    "date": _prop_date,
+    "email": _prop_email,
+    "phone_number": _prop_phone,
+    "url": _prop_url,
+    "people": _prop_people,
+    "files": _prop_files,
+    "checkbox": _prop_checkbox,
+    "relation": _prop_relation,
+    "formula": _prop_formula,
+    "rollup": _prop_rollup,
+}
+
+
+__all__ = [
+    "DEPTH_TRUNCATED_MARKER",
+    "MAX_DEPTH",
+    "render_blocks",
+    "render_database_row",
+    "render_rich_text",
+]

--- a/packages/pii-scanner-notion/tests/conftest.py
+++ b/packages/pii-scanner-notion/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Shared hermetic-test fixtures for pleno-pii-scanner-notion.
+
+Tests never reach the real Notion API; every HTTP call is served by
+`httpx.MockTransport` with hand-written JSON fixtures. The
+`route_handler` helper builds a path-prefix dispatcher so a single test
+can register canned responses for `/v1/search`, `/v1/databases/.../query`,
+`/v1/blocks/.../children`, etc.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import httpx
+import pytest
+
+
+# Public re-export so tests can `from conftest import ...` if needed.
+ResponseFactory = Callable[[httpx.Request], httpx.Response]
+
+
+def make_handler(
+    routes: Iterable[tuple[str, ResponseFactory]],
+) -> ResponseFactory:
+    """Build a routing handler from `(path-suffix, response_fn)` tuples.
+
+    Routes are matched in order; the first containment match wins. An
+    unmatched path raises `AssertionError` so a test never silently
+    receives a 200 for a URL it forgot to mock — that's a sign the
+    connector is calling an endpoint the test isn't asserting on.
+    """
+    materialized = list(routes)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        for suffix, fn in materialized:
+            if suffix in url:
+                return fn(request)
+        raise AssertionError(
+            f"no route matches {request.method} {url}; "
+            f"routes={[r[0] for r in materialized]}"
+        )
+
+    return handler
+
+
+def queued(responses: Iterable[httpx.Response]) -> ResponseFactory:
+    """Pop the next pre-built response from `responses` per request.
+
+    Useful when a single endpoint must return different bodies on
+    successive calls (pagination chains, retry-then-succeed).
+    """
+    iterator = iter(responses)
+
+    def fn(_: httpx.Request) -> httpx.Response:
+        try:
+            return next(iterator)
+        except StopIteration as exc:
+            raise AssertionError("queued responses exhausted") from exc
+
+    return fn
+
+
+def json_response(payload: Any, *, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=payload)

--- a/packages/pii-scanner-notion/tests/test_api.py
+++ b/packages/pii-scanner-notion/tests/test_api.py
@@ -1,0 +1,157 @@
+"""Tests for `NotionApi` — header pinning, status handling, rate-limit propagation."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from pleno_pii_scanner.scheduler.rate_limit import RateLimited
+from pleno_pii_scanner_notion.api import (
+    DEFAULT_BASE_URL,
+    NOTION_VERSION,
+    NotionApi,
+    NotionApiError,
+)
+
+from .conftest import json_response, make_handler
+
+
+class TestConstruction:
+    def test_rejects_empty_token(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            NotionApi(token="")
+
+    def test_default_base_and_version(self) -> None:
+        api = NotionApi(token="secret_x")
+        assert api.base_url == DEFAULT_BASE_URL
+        assert api.notion_version == NOTION_VERSION
+
+
+class TestHeaders:
+    async def test_authorization_and_notion_version_pinned(self) -> None:
+        captured: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.update(dict(request.headers))
+            return json_response({"ok": True})
+
+        transport = httpx.MockTransport(handler)
+        api = NotionApi(token="secret_abc", transport=transport)
+        try:
+            body = await api.get("/users/me")
+            assert body == {"ok": True}
+            assert captured["authorization"] == "Bearer secret_abc"
+            assert captured["notion-version"] == NOTION_VERSION
+            assert captured["accept"] == "application/json"
+        finally:
+            await api.aclose()
+
+    async def test_post_sets_json_body_and_headers(self) -> None:
+        seen_body: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_body["text"] = request.content.decode()
+            seen_body["ct"] = request.headers["content-type"]
+            return json_response({"results": []})
+
+        transport = httpx.MockTransport(handler)
+        api = NotionApi(token="x", transport=transport)
+        try:
+            await api.post("/search", json={"query": ""})
+            assert "query" in seen_body["text"]
+            assert seen_body["ct"].startswith("application/json")
+        finally:
+            await api.aclose()
+
+    async def test_custom_notion_version_propagates(self) -> None:
+        captured: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["v"] = request.headers["notion-version"]
+            return json_response({})
+
+        api = NotionApi(
+            token="x",
+            transport=httpx.MockTransport(handler),
+            notion_version="2099-12-31",
+        )
+        try:
+            await api.get("/foo")
+            assert captured["v"] == "2099-12-31"
+        finally:
+            await api.aclose()
+
+
+class TestStatusHandling:
+    async def test_404_returns_empty_dict(self) -> None:
+        api = NotionApi(
+            token="x",
+            transport=httpx.MockTransport(lambda _: httpx.Response(404, text="not found")),
+        )
+        try:
+            assert await api.get("/pages/missing") == {}
+        finally:
+            await api.aclose()
+
+    async def test_500_raises_notion_api_error(self) -> None:
+        api = NotionApi(
+            token="x",
+            transport=httpx.MockTransport(lambda _: httpx.Response(500, text="boom")),
+        )
+        try:
+            with pytest.raises(NotionApiError):
+                await api.get("/pages/x")
+        finally:
+            await api.aclose()
+
+    async def test_429_raises_rate_limited_with_retry_after(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "3"}, text="slow")
+
+        api = NotionApi(token="x", transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(RateLimited, match="3"):
+                await api.get("/search")
+        finally:
+            await api.aclose()
+
+    async def test_post_propagates_rate_limit(self) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "1"})
+
+        api = NotionApi(token="x", transport=httpx.MockTransport(handler))
+        try:
+            with pytest.raises(RateLimited):
+                await api.post("/search")
+        finally:
+            await api.aclose()
+
+
+class TestUrls:
+    async def test_absolute_url_passes_through(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(str(request.url))
+            return json_response({})
+
+        api = NotionApi(token="x", transport=httpx.MockTransport(handler))
+        try:
+            await api.get("https://example.test/v1/whatever")
+            assert captured == ["https://example.test/v1/whatever"]
+        finally:
+            await api.aclose()
+
+    async def test_post_absolute_url_passes_through(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(str(request.url))
+            return json_response({})
+
+        api = NotionApi(token="x", transport=httpx.MockTransport(handler))
+        try:
+            await api.post("https://example.test/v1/post")
+            assert captured == ["https://example.test/v1/post"]
+        finally:
+            await api.aclose()

--- a/packages/pii-scanner-notion/tests/test_connector.py
+++ b/packages/pii-scanner-notion/tests/test_connector.py
@@ -1,0 +1,1070 @@
+"""Tests for `NotionConnector` — discover modes, fetch, factory, lifecycle."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from pleno_pii_scanner.scheduler.rate_limit import BucketKey, RateLimited
+from pleno_pii_scanner.sources.base import (
+    Capabilities,
+    Document,
+    DocumentRef,
+    SourceConnector,
+    SourceFilter,
+)
+from pleno_pii_scanner_notion.connector import (
+    KIND,
+    SPEC,
+    NotionConfig,
+    NotionConnector,
+    _factory,
+    _parent_id,
+    _parse_iso,
+    _string_tuple,
+)
+
+from .conftest import json_response, make_handler
+
+
+def page_object(
+    page_id: str,
+    *,
+    archived: bool = False,
+    parent: dict[str, Any] | None = None,
+    last_edited: str | None = "2026-05-04T00:00:00Z",
+    url: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "object": "page",
+        "id": page_id,
+        "archived": archived,
+        "parent": parent or {"type": "workspace", "workspace": True},
+        "last_edited_time": last_edited,
+        "url": url or f"https://notion.so/{page_id}",
+        "properties": {},
+    }
+
+
+def database_object(database_id: str) -> dict[str, Any]:
+    return {
+        "object": "database",
+        "id": database_id,
+        "archived": False,
+        "parent": {"type": "workspace", "workspace": True},
+        "last_edited_time": "2026-05-04T00:00:00Z",
+        "url": f"https://notion.so/{database_id}",
+    }
+
+
+def block_payload(text: str, *, block_type: str = "paragraph", block_id: str = "b") -> dict[str, Any]:
+    return {
+        "id": block_id,
+        "object": "block",
+        "type": block_type,
+        block_type: {"rich_text": [{"type": "text", "text": {"content": text, "link": None}, "annotations": {}, "plain_text": text}]},
+        "archived": False,
+        "has_children": False,
+    }
+
+
+async def drain(it: AsyncIterator[DocumentRef]) -> list[DocumentRef]:
+    return [r async for r in it]
+
+
+# ---------------------------------------------------------------------
+# config + construction
+# ---------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_resolved_id_default(self) -> None:
+        assert NotionConfig(token="secret_x").resolved_id() == "notion:default"
+
+    def test_resolved_id_with_workspace(self) -> None:
+        cfg = NotionConfig(token="t", workspace_id="acme")
+        assert cfg.resolved_id() == "notion:acme"
+
+    def test_explicit_id_wins(self) -> None:
+        assert NotionConfig(token="t", id="custom").resolved_id() == "custom"
+
+
+class TestConstruction:
+    def test_runtime_protocol_isinstance(self) -> None:
+        c = NotionConnector(NotionConfig(token="secret_x"))
+        assert isinstance(c, SourceConnector)
+        assert c.kind == KIND
+        assert c.id == "notion:default"
+
+    def test_capabilities(self) -> None:
+        c = NotionConnector(NotionConfig(token="t", max_concurrent_fetches=5))
+        caps = c.capabilities()
+        assert caps == Capabilities(
+            incremental=True,
+            binary=False,
+            content_hash_delta=False,
+            max_concurrent_fetches=5,
+            streaming=False,
+        )
+
+    def test_bucket_key(self) -> None:
+        c = NotionConnector(NotionConfig(token="t", workspace_id="acme"))
+        assert c.bucket_key() == BucketKey(connector_kind="notion", tenant_id="acme")
+
+    def test_bucket_key_falls_back_to_id(self) -> None:
+        c = NotionConnector(NotionConfig(token="t"))
+        assert c.bucket_key() == BucketKey(connector_kind="notion", tenant_id="notion:default")
+
+
+# ---------------------------------------------------------------------
+# discover — search mode
+# ---------------------------------------------------------------------
+
+
+class TestDiscoverSearch:
+    async def test_search_yields_pages_and_databases(self) -> None:
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [
+                        page_object("p1"),
+                        database_object("d1"),
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            paths = sorted(r.path for r in refs)
+            assert paths == ["notion://database/d1", "notion://page/p1"]
+            for r in refs:
+                assert r.source_kind == "notion"
+                assert r.content_type == "text/markdown"
+                assert r.metadata["object_id"] in {"p1", "d1"}
+                assert r.last_modified is not None
+        finally:
+            await c.close()
+
+    async def test_search_pagination_chains_cursor(self) -> None:
+        captured_bodies: list[bytes] = []
+
+        responses = iter(
+            [
+                {
+                    "results": [page_object("p1")],
+                    "has_more": True,
+                    "next_cursor": "cur-2",
+                },
+                {
+                    "results": [page_object("p2")],
+                    "has_more": False,
+                    "next_cursor": None,
+                },
+            ]
+        )
+
+        def search(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(request.content)
+            return json_response(next(responses))
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert [r.path for r in refs] == ["notion://page/p1", "notion://page/p2"]
+            # Second request must include start_cursor.
+            assert b"start_cursor" in captured_bodies[1]
+            assert b"cur-2" in captured_bodies[1]
+            # First ref carries the search _cursor in metadata.
+            assert refs[0].metadata.get("_cursor") == "cur-2"
+        finally:
+            await c.close()
+
+    async def test_search_seeded_cursor_is_used(self) -> None:
+        captured_bodies: list[bytes] = []
+
+        def search(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(request.content)
+            return json_response(
+                {"results": [], "has_more": False, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            await drain(c.discover(SourceFilter(), "cur-from-checkpoint"))
+            assert b"cur-from-checkpoint" in captured_bodies[0]
+        finally:
+            await c.close()
+
+    async def test_search_pagination_stops_when_next_cursor_missing(self) -> None:
+        # has_more=True but next_cursor=None must not infinite-loop.
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {"results": [page_object("p1")], "has_more": True, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert [r.path for r in refs] == ["notion://page/p1"]
+        finally:
+            await c.close()
+
+    async def test_search_skips_archived_by_default(self) -> None:
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [
+                        page_object("kept"),
+                        page_object("dropped", archived=True),
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert {r.metadata["object_id"] for r in refs} == {"kept"}
+        finally:
+            await c.close()
+
+    async def test_include_archived_keeps_them(self) -> None:
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [page_object("p1", archived=True)],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(
+            NotionConfig(token="t", include_archived=True), transport=transport
+        )
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert {r.metadata["object_id"] for r in refs} == {"p1"}
+        finally:
+            await c.close()
+
+    async def test_search_skips_unsupported_object_types(self) -> None:
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [
+                        {"object": "user", "id": "u1"},
+                        page_object("p1"),
+                        {"object": "page"},  # missing id
+                        "broken",
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert {r.metadata["object_id"] for r in refs} == {"p1"}
+        finally:
+            await c.close()
+
+    async def test_parent_chain_renders_for_known_parent_kinds(self) -> None:
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [
+                        page_object("p1", parent={"type": "page_id", "page_id": "parent-1"}),
+                        page_object("p2", parent={"type": "database_id", "database_id": "db-1"}),
+                        page_object("p3", parent={"type": "block_id", "block_id": "b-1"}),
+                        page_object("p4", parent={"type": "workspace", "workspace": True}),
+                        page_object("p5", parent={"type": "unknown_kind"}),
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = {r.metadata["object_id"]: r for r in await drain(c.discover(SourceFilter(), None))}
+            assert refs["p1"].parent_chain == ("notion://page/parent-1",)
+            assert refs["p2"].parent_chain == ("notion://database/db-1",)
+            assert refs["p3"].parent_chain == ("notion://block/b-1",)
+            assert refs["p4"].parent_chain == ("notion://workspace",)
+            assert refs["p5"].parent_chain == ()
+        finally:
+            await c.close()
+
+    async def test_search_dedupes_repeated_objects(self) -> None:
+        def search(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [page_object("p1"), page_object("p1")],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(make_handler([("/search", search)]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert len(refs) == 1
+        finally:
+            await c.close()
+
+
+# ---------------------------------------------------------------------
+# discover — explicit pages
+# ---------------------------------------------------------------------
+
+
+class TestDiscoverExplicitPages:
+    async def test_explicit_page_list_uses_pages_endpoint(self) -> None:
+        def page_handler(request: httpx.Request) -> httpx.Response:
+            page_id = str(request.url).rsplit("/", 1)[-1]
+            return json_response(page_object(page_id))
+
+        transport = httpx.MockTransport(make_handler([("/pages/", page_handler)]))
+        c = NotionConnector(
+            NotionConfig(token="t", pages=("p1", "p2")), transport=transport
+        )
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert sorted(r.metadata["object_id"] for r in refs) == ["p1", "p2"]
+        finally:
+            await c.close()
+
+    async def test_404_page_yields_nothing(self) -> None:
+        transport = httpx.MockTransport(make_handler([("/pages/", lambda _: httpx.Response(404))]))
+        c = NotionConnector(NotionConfig(token="t", pages=("missing",)), transport=transport)
+        try:
+            assert await drain(c.discover(SourceFilter(), None)) == []
+        finally:
+            await c.close()
+
+
+# ---------------------------------------------------------------------
+# discover — explicit database
+# ---------------------------------------------------------------------
+
+
+class TestDiscoverDatabase:
+    async def test_database_query_paginates(self) -> None:
+        responses = iter(
+            [
+                {
+                    "results": [page_object("r1"), page_object("r2")],
+                    "has_more": True,
+                    "next_cursor": "cur-2",
+                },
+                {
+                    "results": [page_object("r3")],
+                    "has_more": False,
+                    "next_cursor": None,
+                },
+            ]
+        )
+        captured: list[bytes] = []
+
+        def query(request: httpx.Request) -> httpx.Response:
+            captured.append(request.content)
+            return json_response(next(responses))
+
+        transport = httpx.MockTransport(
+            make_handler([("/databases/db-1/query", query)])
+        )
+        c = NotionConnector(
+            NotionConfig(token="t", databases=("db-1",)), transport=transport
+        )
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert [r.metadata["object_id"] for r in refs] == ["r1", "r2", "r3"]
+            for r in refs:
+                assert r.metadata["database_id"] == "db-1"
+                assert r.path.startswith("notion://database-row/")
+                assert r.parent_chain == ("notion://database/db-1",)
+            assert b"start_cursor" in captured[1]
+        finally:
+            await c.close()
+
+    async def test_database_query_stops_when_next_cursor_missing(self) -> None:
+        # has_more=True but next_cursor=None must terminate.
+        def query(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {"results": [page_object("r1")], "has_more": True, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(make_handler([("/databases/db-1/query", query)]))
+        c = NotionConnector(
+            NotionConfig(token="t", databases=("db-1",)), transport=transport
+        )
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            assert [r.metadata["object_id"] for r in refs] == ["r1"]
+        finally:
+            await c.close()
+
+
+# ---------------------------------------------------------------------
+# discover — combined modes
+# ---------------------------------------------------------------------
+
+
+class TestDiscoverCombined:
+    async def test_pages_and_databases_combined(self) -> None:
+        def page_handler(request: httpx.Request) -> httpx.Response:
+            page_id = str(request.url).rsplit("/", 1)[-1]
+            return json_response(page_object(page_id))
+
+        def query(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {"results": [page_object("row1")], "has_more": False, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/databases/db-1/query", query),
+                    ("/pages/", page_handler),
+                ]
+            )
+        )
+        c = NotionConnector(
+            NotionConfig(token="t", pages=("p1",), databases=("db-1",)),
+            transport=transport,
+        )
+        try:
+            refs = await drain(c.discover(SourceFilter(), None))
+            ids = sorted(r.metadata["object_id"] for r in refs)
+            assert ids == ["p1", "row1"]
+        finally:
+            await c.close()
+
+
+# ---------------------------------------------------------------------
+# fetch
+# ---------------------------------------------------------------------
+
+
+def _children_route(children_by_block: dict[str, list[dict[str, Any]]]) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # URL: /v1/blocks/<id>/children
+        path = request.url.path
+        block_id = path.rsplit("/", 2)[-2]
+        return json_response(
+            {
+                "results": children_by_block.get(block_id, []),
+                "has_more": False,
+                "next_cursor": None,
+            }
+        )
+
+    return handler
+
+
+class TestFetch:
+    async def test_fetch_page_renders_block_tree(self) -> None:
+        children = {
+            "p1": [block_payload("hello world", block_id="c1")],
+        }
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", _children_route(children)),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert len(docs) == 1
+            assert isinstance(docs[0], Document)
+            assert docs[0].text == "hello world"
+        finally:
+            await c.close()
+
+    async def test_fetch_database_row_includes_properties_and_body(self) -> None:
+        # The "page" object returned by /pages/<row_id> carries the row's
+        # property map; child blocks render below.
+        row = page_object("row1")
+        row["properties"] = {
+            "Name": {
+                "type": "title",
+                "title": [
+                    {"type": "text", "text": {"content": "alice", "link": None}, "annotations": {}, "plain_text": "alice"}
+                ],
+            },
+            "Email": {"type": "email", "email": "alice@x.test"},
+        }
+        children = {"row1": [block_payload("body text")]}
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/row1", lambda _: json_response(row)),
+                    ("/blocks/", _children_route(children)),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://database-row/row1",
+                metadata={"object_id": "row1", "object_type": "page", "database_id": "db1"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert len(docs) == 1
+            text = docs[0].text or ""
+            assert "Name: alice" in text
+            assert "Email: alice@x.test" in text
+            assert "body text" in text
+        finally:
+            await c.close()
+
+    async def test_fetch_database_object_renders_block_tree(self) -> None:
+        children = {"db1": [block_payload("description")]}
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/databases/db1", lambda _: json_response(database_object("db1"))),
+                    ("/blocks/", _children_route(children)),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://database/db1",
+                metadata={"object_id": "db1", "object_type": "database"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert len(docs) == 1
+            assert (docs[0].text or "").strip() == "description"
+        finally:
+            await c.close()
+
+    async def test_fetch_missing_metadata_yields_nothing(self) -> None:
+        transport = httpx.MockTransport(make_handler([]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ghost = DocumentRef(source_id=c.id, source_kind=c.kind, path="notion://page/x")
+            assert [d async for d in c.fetch(ghost)] == []
+        finally:
+            await c.close()
+
+    async def test_fetch_unsupported_object_type_yields_nothing(self) -> None:
+        transport = httpx.MockTransport(make_handler([]))
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://block/x",
+                metadata={"object_id": "x", "object_type": "block"},
+            )
+            assert [d async for d in c.fetch(ref)] == []
+        finally:
+            await c.close()
+
+    async def test_fetch_404_object_yields_nothing(self) -> None:
+        transport = httpx.MockTransport(
+            make_handler([("/pages/", lambda _: httpx.Response(404))])
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/x",
+                metadata={"object_id": "x", "object_type": "page"},
+            )
+            assert [d async for d in c.fetch(ref)] == []
+        finally:
+            await c.close()
+
+    async def test_fetch_empty_block_tree_yields_nothing(self) -> None:
+        # A page with no body and no row properties should not emit an
+        # empty Document (which would violate the text/binary XOR).
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", _children_route({})),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            assert [d async for d in c.fetch(ref)] == []
+        finally:
+            await c.close()
+
+    async def test_fetch_recurses_nested_children(self) -> None:
+        # Root child has has_children=True; second-level child carries the
+        # text we want to assert on.
+        nested_parent = block_payload("parent", block_id="np")
+        nested_parent["has_children"] = True
+        leaf = block_payload("leaf", block_id="leaf")
+        children = {
+            "p1": [nested_parent],
+            "np": [leaf],
+        }
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", _children_route(children)),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            text = docs[0].text or ""
+            assert "parent" in text
+            assert "leaf" in text
+        finally:
+            await c.close()
+
+    async def test_block_children_pagination(self) -> None:
+        responses = iter(
+            [
+                {
+                    "results": [block_payload("page1", block_id="b1")],
+                    "has_more": True,
+                    "next_cursor": "cur-2",
+                },
+                {
+                    "results": [block_payload("page2", block_id="b2")],
+                    "has_more": False,
+                    "next_cursor": None,
+                },
+            ]
+        )
+        captured: list[str] = []
+
+        def children(request: httpx.Request) -> httpx.Response:
+            captured.append(str(request.url))
+            return json_response(next(responses))
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", children),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            text = docs[0].text or ""
+            assert "page1" in text
+            assert "page2" in text
+            # second URL must contain start_cursor
+            assert "start_cursor" in captured[1]
+        finally:
+            await c.close()
+
+    async def test_block_children_pagination_stops_when_next_cursor_missing(self) -> None:
+        # has_more=True without next_cursor must terminate (defense in depth).
+        def children(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [block_payload("only", block_id="b1")],
+                    "has_more": True,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", children),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert "only" in (docs[0].text or "")
+        finally:
+            await c.close()
+
+    async def test_block_children_archived_filtered(self) -> None:
+        archived_block = block_payload("dropped", block_id="b1")
+        archived_block["archived"] = True
+        kept = block_payload("kept", block_id="b2")
+
+        def children(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {
+                    "results": [archived_block, kept, "broken"],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
+            )
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", children),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            text = docs[0].text or ""
+            assert "kept" in text
+            assert "dropped" not in text
+        finally:
+            await c.close()
+
+    async def test_block_children_archived_kept_with_flag(self) -> None:
+        archived_block = block_payload("kept-archived", block_id="b1")
+        archived_block["archived"] = True
+
+        def children(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {"results": [archived_block], "has_more": False, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", children),
+                ]
+            )
+        )
+        c = NotionConnector(
+            NotionConfig(token="t", include_archived=True), transport=transport
+        )
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert "kept-archived" in (docs[0].text or "")
+        finally:
+            await c.close()
+
+
+# ---------------------------------------------------------------------
+# rate-limit propagation
+# ---------------------------------------------------------------------
+
+
+class TestRateLimit:
+    async def test_429_during_search_surfaces_rate_limited(self) -> None:
+        transport = httpx.MockTransport(
+            make_handler(
+                [("/search", lambda _: httpx.Response(429, headers={"Retry-After": "1"}))]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            with pytest.raises(RateLimited):
+                await drain(c.discover(SourceFilter(), None))
+        finally:
+            await c.close()
+
+    async def test_429_during_block_fetch_surfaces_rate_limited(self) -> None:
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", lambda _: httpx.Response(429, headers={"Retry-After": "2"})),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            with pytest.raises(RateLimited):
+                [d async for d in c.fetch(ref)]
+        finally:
+            await c.close()
+
+
+# ---------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_parse_iso_handles_z_suffix(self) -> None:
+        ts = _parse_iso("2026-05-04T00:00:00Z")
+        assert ts is not None and ts.year == 2026
+
+    def test_parse_iso_returns_none_on_garbage(self) -> None:
+        assert _parse_iso("not-a-date") is None
+        assert _parse_iso(None) is None
+        assert _parse_iso(42) is None
+
+    def test_parent_id_workspace(self) -> None:
+        assert _parent_id({"type": "workspace"}) == "notion://workspace"
+
+    def test_parent_id_unknown(self) -> None:
+        assert _parent_id({"type": "future"}) is None
+
+    def test_string_tuple_accepts_lists(self) -> None:
+        assert _string_tuple(["a", "b"]) == ("a", "b")
+        assert _string_tuple(("a",)) == ("a",)
+        assert _string_tuple(None) == ()
+
+    def test_string_tuple_rejects_bare_string(self) -> None:
+        with pytest.raises(ValueError, match="bare string"):
+            _string_tuple("abc")
+
+    def test_string_tuple_rejects_non_iterable(self) -> None:
+        with pytest.raises(ValueError, match="iterable"):
+            _string_tuple(42)
+
+    def test_string_tuple_rejects_empty_or_non_string_items(self) -> None:
+        with pytest.raises(ValueError, match="non-empty strings"):
+            _string_tuple(["", "ok"])
+        with pytest.raises(ValueError, match="non-empty strings"):
+            _string_tuple([123])
+
+
+# ---------------------------------------------------------------------
+# factory + spec
+# ---------------------------------------------------------------------
+
+
+class TestFactoryAndSpec:
+    def test_spec_metadata(self) -> None:
+        assert SPEC.kind == "notion"
+        assert KIND == "notion"
+        assert SPEC.capabilities.incremental is True
+        assert SPEC.capabilities.max_concurrent_fetches == 3
+        assert "read_content" in SPEC.required_scopes
+
+    def test_factory_minimal(self) -> None:
+        c = SPEC.factory({"token": "secret_x"})
+        assert isinstance(c, NotionConnector)
+        assert c.id == "notion:default"
+
+    def test_factory_full_config(self) -> None:
+        c = _factory(
+            {
+                "token": "secret_x",
+                "id": "custom",
+                "pages": ["p1"],
+                "databases": ["d1"],
+                "include_archived": True,
+                "base_url": "https://api.example.test/v1",
+                "notion_version": "2099-12-31",
+                "max_concurrent_fetches": 5,
+                "request_timeout": 10.0,
+                "workspace_id": "acme",
+            }
+        )
+        assert c.id == "custom"
+        assert c._config.pages == ("p1",)
+        assert c._config.databases == ("d1",)
+        assert c._config.include_archived is True
+        assert c._config.notion_version == "2099-12-31"
+
+    def test_factory_missing_token(self) -> None:
+        with pytest.raises(ValueError, match="token"):
+            _factory({})
+
+    def test_factory_empty_token(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            _factory({"token": ""})
+
+    def test_factory_rejects_bare_string_pages(self) -> None:
+        with pytest.raises(ValueError, match="bare string"):
+            _factory({"token": "t", "pages": "p1"})
+
+    def test_factory_rejects_non_string_database_entries(self) -> None:
+        with pytest.raises(ValueError, match="non-empty strings"):
+            _factory({"token": "t", "databases": [42]})
+
+
+# ---------------------------------------------------------------------
+# package init re-exports
+# ---------------------------------------------------------------------
+
+
+class TestPackageInit:
+    def test_top_level_exports(self) -> None:
+        import pleno_pii_scanner_notion as pkg
+
+        assert pkg.SPEC is SPEC
+        assert pkg.KIND == "notion"
+        assert pkg.NotionConnector is NotionConnector
+        assert pkg.NotionConfig is NotionConfig
+        assert pkg.__version__ == "0.1.0"
+
+
+# ---------------------------------------------------------------------
+# lifecycle
+# ---------------------------------------------------------------------
+
+
+class TestRecursion:
+    async def test_block_walk_stops_at_max_depth(self) -> None:
+        """`_fetch_block_tree`'s `_walk` short-circuits when depth >= MAX_DEPTH.
+
+        We instrument the connector with a children map that always
+        returns one block-with-children, then patch MAX_DEPTH down to a
+        tiny value via the connector's import so the test runs in
+        bounded time. Verifies the defense-in-depth recursion cap.
+        """
+        from pleno_pii_scanner_notion import connector as conn_module
+
+        # Each call returns one nested-children block; without a depth cap
+        # this loops forever.
+        def children(_: httpx.Request) -> httpx.Response:
+            child = block_payload("deep", block_id="loop")
+            child["has_children"] = True
+            return json_response(
+                {"results": [child], "has_more": False, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", children),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        original_max_depth = conn_module.MAX_DEPTH
+        conn_module.MAX_DEPTH = 3  # type: ignore[attr-defined]
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            # Bounded recursion → bounded output, no hang.
+            assert len(docs) == 1
+        finally:
+            conn_module.MAX_DEPTH = original_max_depth  # type: ignore[attr-defined]
+            await c.close()
+
+    async def test_block_walk_ignores_child_with_non_string_id(self) -> None:
+        """Child block with `has_children=True` but a non-string `id`
+        must be tolerated (don't recurse, don't crash) — defense against
+        malformed Notion responses."""
+        bad_child = block_payload("malformed", block_id="x")
+        bad_child["has_children"] = True
+        bad_child["id"] = 12345  # type: ignore[assignment]
+
+        def children(_: httpx.Request) -> httpx.Response:
+            return json_response(
+                {"results": [bad_child], "has_more": False, "next_cursor": None}
+            )
+
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/pages/p1", lambda _: json_response(page_object("p1"))),
+                    ("/blocks/", children),
+                ]
+            )
+        )
+        c = NotionConnector(NotionConfig(token="t"), transport=transport)
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="notion://page/p1",
+                metadata={"object_id": "p1", "object_type": "page"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert "malformed" in (docs[0].text or "")
+        finally:
+            await c.close()
+
+
+class TestLifecycle:
+    async def test_close_can_be_called_twice(self) -> None:
+        # Closing the underlying httpx.AsyncClient twice is a no-op in
+        # httpx; we still want to verify our close() doesn't raise.
+        c = NotionConnector(NotionConfig(token="t"))
+        await c.close()
+        # Second close is fine — httpx handles re-close gracefully.
+        try:
+            await c.close()
+        except RuntimeError:
+            # httpx may raise if used after close; the test only cares
+            # that the first close didn't leak resources.
+            pass

--- a/packages/pii-scanner-notion/tests/test_markdown.py
+++ b/packages/pii-scanner-notion/tests/test_markdown.py
@@ -1,0 +1,737 @@
+"""Tests for `markdown` — block tree, rich text, and database property rendering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pleno_pii_scanner_notion.markdown import (
+    DEPTH_TRUNCATED_MARKER,
+    MAX_DEPTH,
+    render_blocks,
+    render_database_row,
+    render_rich_text,
+)
+
+
+def text_element(content: str, *, link: str | None = None, **annotations: bool) -> dict[str, Any]:
+    obj: dict[str, Any] = {
+        "type": "text",
+        "text": {"content": content, "link": {"url": link} if link else None},
+        "annotations": annotations,
+        "plain_text": content,
+    }
+    return obj
+
+
+def block(block_type: str, payload: dict[str, Any], *, archived: bool = False, has_children: bool = False, block_id: str = "b") -> dict[str, Any]:
+    return {
+        "id": block_id,
+        "object": "block",
+        "type": block_type,
+        block_type: payload,
+        "archived": archived,
+        "has_children": has_children,
+    }
+
+
+# ---------------------------------------------------------------------
+# rich text
+# ---------------------------------------------------------------------
+
+
+class TestRichText:
+    def test_empty_returns_empty_string(self) -> None:
+        assert render_rich_text(None) == ""
+        assert render_rich_text([]) == ""
+
+    def test_plain_text(self) -> None:
+        assert render_rich_text([text_element("hello")]) == "hello"
+
+    def test_bold_italic_strikethrough_code(self) -> None:
+        out = render_rich_text(
+            [
+                text_element("a", bold=True),
+                text_element("b", italic=True),
+                text_element("c", strikethrough=True),
+                text_element("d", code=True),
+            ]
+        )
+        assert out == "**a***b*~~c~~`d`"
+
+    def test_combined_annotations_nesting_order(self) -> None:
+        # Order applied: code → strikethrough → italic → bold (outermost).
+        out = render_rich_text(
+            [text_element("x", bold=True, italic=True, strikethrough=True, code=True)]
+        )
+        assert out == "***~~`x`~~***"
+
+    def test_text_with_link_emits_markdown_link(self) -> None:
+        out = render_rich_text([text_element("docs", link="https://example.com")])
+        assert out == "[docs](https://example.com)"
+
+    def test_link_preserves_annotations_inside(self) -> None:
+        out = render_rich_text([text_element("docs", link="https://x.test", bold=True)])
+        assert out == "[**docs**](https://x.test)"
+
+    def test_mention_user(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": {"type": "user", "user": {"id": "u1"}},
+            "annotations": {},
+            "plain_text": "@alice",
+        }
+        assert render_rich_text([element]) == "[@alice](notion://user/u1)"
+
+    def test_mention_page(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": {"type": "page", "page": {"id": "p1"}},
+            "annotations": {},
+            "plain_text": "Roadmap",
+        }
+        assert render_rich_text([element]) == "[Roadmap](notion://page/p1)"
+
+    def test_mention_database(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": {"type": "database", "database": {"id": "d1"}},
+            "annotations": {},
+            "plain_text": "Issues",
+        }
+        assert render_rich_text([element]) == "[Issues](notion://database/d1)"
+
+    def test_mention_date(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": {"type": "date", "date": {"start": "2026-05-04"}},
+            "annotations": {},
+            "plain_text": "May 4 2026",
+        }
+        assert render_rich_text([element]) == "[May 4 2026](notion://date/2026-05-04)"
+
+    def test_mention_with_explicit_href_wins(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": {"type": "user", "user": {"id": "u9"}},
+            "annotations": {},
+            "plain_text": "alice",
+            "href": "https://example.com/u/9",
+        }
+        assert render_rich_text([element]) == "[alice](https://example.com/u/9)"
+
+    def test_mention_unknown_type_falls_back_to_plain_text(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": {"type": "template_mention"},
+            "annotations": {},
+            "plain_text": "today",
+        }
+        assert render_rich_text([element]) == "today"
+
+    def test_mention_with_non_mapping_inner_object(self) -> None:
+        element = {
+            "type": "mention",
+            "mention": "broken",
+            "annotations": {},
+            "plain_text": "x",
+        }
+        # Falls through the type-narrowing guard and renders plain_text.
+        assert render_rich_text([element]) == "x"
+
+    def test_equation_inline(self) -> None:
+        element = {
+            "type": "equation",
+            "equation": {"expression": "E=mc^2"},
+            "annotations": {},
+            "plain_text": "E=mc^2",
+        }
+        assert render_rich_text([element]) == "$E=mc^2$"
+
+    def test_equation_without_expression_falls_back_to_plain_text(self) -> None:
+        element = {
+            "type": "equation",
+            "equation": {},
+            "annotations": {},
+            "plain_text": "fallback",
+        }
+        assert render_rich_text([element]) == "fallback"
+
+    def test_unknown_rich_text_type_uses_plain_text(self) -> None:
+        element = {"type": "future_kind", "annotations": {}, "plain_text": "raw"}
+        assert render_rich_text([element]) == "raw"
+
+    def test_non_mapping_element_skipped(self) -> None:
+        # A protocol violation (string in array) should be skipped, not crash.
+        assert render_rich_text(["not a dict", text_element("x")]) == "x"
+
+    def test_annotations_on_empty_text_passthrough(self) -> None:
+        # Empty text → no wrapping (avoid `**`` etc on empty).
+        element = {"type": "text", "text": {"content": ""}, "annotations": {"bold": True}, "plain_text": ""}
+        assert render_rich_text([element]) == ""
+
+    def test_annotations_non_mapping_returns_text_unchanged(self) -> None:
+        element = {"type": "text", "text": {"content": "x"}, "annotations": "nope", "plain_text": "x"}
+        # `_render_text_element` reads annotations as `or {}` so non-mapping
+        # becomes empty mapping and text passes through.
+        assert render_rich_text([element]) == "x"
+
+
+# ---------------------------------------------------------------------
+# blocks
+# ---------------------------------------------------------------------
+
+
+class TestBlocks:
+    def test_empty_blocks_return_empty(self) -> None:
+        assert render_blocks(None) == ""
+        assert render_blocks([]) == ""
+
+    def test_paragraph(self) -> None:
+        out = render_blocks([block("paragraph", {"rich_text": [text_element("hi")]})])
+        assert out == "hi"
+
+    def test_headings(self) -> None:
+        blocks = [
+            block("heading_1", {"rich_text": [text_element("H1")]}),
+            block("heading_2", {"rich_text": [text_element("H2")]}),
+            block("heading_3", {"rich_text": [text_element("H3")]}),
+        ]
+        out = render_blocks(blocks)
+        assert "# H1" in out
+        assert "## H2" in out
+        assert "### H3" in out
+
+    def test_heading_without_text_emits_prefix_only(self) -> None:
+        out = render_blocks([block("heading_1", {"rich_text": []})])
+        assert out == "#"
+
+    def test_bulleted_and_numbered_list(self) -> None:
+        blocks = [
+            block("bulleted_list_item", {"rich_text": [text_element("a")]}),
+            block("numbered_list_item", {"rich_text": [text_element("first")]}),
+            block("numbered_list_item", {"rich_text": [text_element("second")]}),
+            block("paragraph", {"rich_text": [text_element("break")]}),
+            block("numbered_list_item", {"rich_text": [text_element("restart")]}),
+        ]
+        out = render_blocks(blocks)
+        assert "- a" in out
+        assert "1. first" in out
+        assert "2. second" in out
+        # Counter restarts after a non-list block.
+        assert "1. restart" in out
+
+    def test_to_do(self) -> None:
+        blocks = [
+            block("to_do", {"rich_text": [text_element("done")], "checked": True}),
+            block("to_do", {"rich_text": [text_element("todo")], "checked": False}),
+        ]
+        out = render_blocks(blocks)
+        assert "- [x] done" in out
+        assert "- [ ] todo" in out
+
+    def test_toggle_renders_details_summary(self) -> None:
+        out = render_blocks([block("toggle", {"rich_text": [text_element("more")]})])
+        assert out == "<details><summary>more</summary></details>"
+
+    def test_code_with_language_fence(self) -> None:
+        out = render_blocks(
+            [block("code", {"rich_text": [text_element("x = 1")], "language": "python"})]
+        )
+        assert out == "```python\nx = 1\n```"
+
+    def test_code_without_language(self) -> None:
+        out = render_blocks([block("code", {"rich_text": [text_element("raw")]})])
+        # Empty fence header is allowed by Markdown spec.
+        assert out.startswith("```\n")
+
+    def test_quote_and_callout(self) -> None:
+        out = render_blocks(
+            [
+                block("quote", {"rich_text": [text_element("wisdom")]}),
+                block(
+                    "callout",
+                    {"rich_text": [text_element("info")], "icon": {"type": "emoji", "emoji": "💡"}},
+                ),
+            ]
+        )
+        assert "> wisdom" in out
+        assert "> 💡 info" in out
+
+    def test_quote_empty_text(self) -> None:
+        out = render_blocks([block("quote", {"rich_text": []})])
+        assert out == ">"
+
+    def test_callout_without_emoji(self) -> None:
+        out = render_blocks([block("callout", {"rich_text": [text_element("hi")], "icon": None})])
+        assert out == "> hi"
+
+    def test_divider(self) -> None:
+        assert render_blocks([block("divider", {})]) == "---"
+
+    def test_equation_block(self) -> None:
+        out = render_blocks([block("equation", {"expression": "x^2"})])
+        assert out == "$$\nx^2\n$$"
+
+    def test_equation_block_without_expression_emits_nothing(self) -> None:
+        out = render_blocks([block("equation", {})])
+        assert out == ""
+
+    def test_embed_and_bookmark(self) -> None:
+        blocks = [
+            block("embed", {"url": "https://e.test/x"}),
+            block(
+                "bookmark",
+                {"url": "https://b.test/x", "caption": [text_element("title")]},
+            ),
+        ]
+        out = render_blocks(blocks)
+        assert "[embed](https://e.test/x)" in out
+        assert "[title](https://b.test/x)" in out
+
+    def test_embed_without_url_emits_nothing(self) -> None:
+        out = render_blocks([block("embed", {})])
+        assert out == ""
+
+    def test_bookmark_without_caption_falls_back_to_url(self) -> None:
+        out = render_blocks([block("bookmark", {"url": "https://b.test/y", "caption": []})])
+        assert out == "[https://b.test/y](https://b.test/y)"
+
+    def test_bookmark_without_url_emits_nothing(self) -> None:
+        out = render_blocks([block("bookmark", {"caption": [text_element("orphan")]})])
+        assert out == ""
+
+    def test_link_to_page(self) -> None:
+        out = render_blocks([block("link_to_page", {"type": "page_id", "page_id": "pid-1"})])
+        assert out == "[link](notion://page_id/pid-1)"
+
+    def test_link_to_page_with_unknown_target_returns_empty(self) -> None:
+        out = render_blocks([block("link_to_page", {"type": "page_id"})])
+        assert out == ""
+
+    def test_child_page_and_database(self) -> None:
+        blocks = [
+            block("child_page", {"title": "Subpage"}),
+            block("child_database", {"title": "Issues"}),
+            block("child_database", {"title": ""}),
+        ]
+        out = render_blocks(blocks)
+        assert "## Subpage" in out
+        assert "## Issues (database)" in out
+        assert "## (database)" in out
+
+    def test_child_page_empty_title_emits_nothing(self) -> None:
+        # Empty title would emit an empty heading; we suppress it so the
+        # output stays valid Markdown.
+        out = render_blocks([block("child_page", {"title": ""})])
+        assert out == ""
+
+    def test_unsupported_block_type(self) -> None:
+        out = render_blocks([block("synced_block", {})])
+        assert out == "<!-- unsupported: synced_block -->"
+
+    def test_archived_block_skipped_by_default(self) -> None:
+        out = render_blocks(
+            [
+                block("paragraph", {"rich_text": [text_element("kept")]}),
+                block("paragraph", {"rich_text": [text_element("dropped")]}, archived=True),
+            ]
+        )
+        assert "kept" in out
+        assert "dropped" not in out
+
+    def test_archived_block_kept_with_flag(self) -> None:
+        out = render_blocks(
+            [
+                block("paragraph", {"rich_text": [text_element("kept")]}, archived=True),
+            ],
+            include_archived=True,
+        )
+        assert "kept" in out
+
+    def test_non_mapping_block_skipped(self) -> None:
+        out = render_blocks(["broken", block("paragraph", {"rich_text": [text_element("x")]})])
+        assert out == "x"
+
+    def test_block_with_non_mapping_payload_renders_via_empty_payload(self) -> None:
+        # If `block["paragraph"]` is not a Mapping, the renderer treats it
+        # as `{}` and emits no body.
+        bad = {
+            "id": "x",
+            "type": "paragraph",
+            "paragraph": "not-a-mapping",
+            "archived": False,
+            "has_children": False,
+        }
+        out = render_blocks([bad])
+        assert out == ""
+
+
+class TestNestedBlocks:
+    def test_children_indented_under_parent(self) -> None:
+        children = {
+            "p1": [block("paragraph", {"rich_text": [text_element("child")]})],
+        }
+
+        def lookup(bid: Any) -> list[Any]:
+            return children.get(bid, [])
+
+        parent = block(
+            "bulleted_list_item",
+            {"rich_text": [text_element("parent")]},
+            has_children=True,
+            block_id="p1",
+        )
+        out = render_blocks([parent], children_for=lookup)
+        # Child indented two spaces under the bullet.
+        assert "- parent" in out
+        assert "  child" in out
+
+    def test_recursion_depth_is_capped(self) -> None:
+        # Build a recursive child lookup that always returns one paragraph
+        # with `has_children=True`. The cap should kick in before stack
+        # overflow.
+        def lookup(_: Any) -> list[Any]:
+            return [block("paragraph", {"rich_text": [text_element("deep")]}, has_children=True, block_id="recurse")]
+
+        parent = block("paragraph", {"rich_text": [text_element("root")]}, has_children=True, block_id="recurse")
+        # Call the renderer at MAX_DEPTH — must short-circuit.
+        out = render_blocks([parent], children_for=lookup, depth=MAX_DEPTH)
+        assert out == DEPTH_TRUNCATED_MARKER
+
+    def test_children_skipped_when_no_lookup(self) -> None:
+        parent = block("paragraph", {"rich_text": [text_element("root")]}, has_children=True)
+        # No `children_for` callback → just render the parent body.
+        assert render_blocks([parent]) == "root"
+
+    def test_parent_without_body_renders_only_children(self) -> None:
+        # `divider` returns no body but if it claimed children we must not
+        # emit a stray newline. Use a custom block_type that returns "".
+        children = {"p": [block("paragraph", {"rich_text": [text_element("c")]})]}
+
+        def lookup(bid: Any) -> list[Any]:
+            return children.get(bid, [])
+
+        parent = block("divider", {}, has_children=True, block_id="p")
+        # Divider has children -> we still render but body branch puts
+        # children below. Divider text is "---", children are appended.
+        out = render_blocks([parent], children_for=lookup)
+        assert "---" in out
+        assert "c" in out
+
+
+class TestTable:
+    def test_table_with_header_and_rows(self) -> None:
+        rows = [
+            block("table_row", {"cells": [[text_element("name")], [text_element("email")]]}, block_id="r0"),
+            block("table_row", {"cells": [[text_element("alice")], [text_element("a@b.test")]]}, block_id="r1"),
+        ]
+        children = {"t1": rows}
+
+        def lookup(bid: Any) -> list[Any]:
+            return children.get(bid, [])
+
+        table = block(
+            "table",
+            {"table_width": 2, "has_column_header": True, "has_row_header": False},
+            has_children=True,
+            block_id="t1",
+        )
+        out = render_blocks([table], children_for=lookup)
+        assert "| name | email |" in out
+        assert "| --- | --- |" in out
+        assert "| alice | a@b.test |" in out
+
+    def test_table_without_column_header_synthesizes_blank(self) -> None:
+        rows = [
+            block("table_row", {"cells": [[text_element("alice")], [text_element("bob")]]}, block_id="r0"),
+        ]
+        children = {"t2": rows}
+
+        def lookup(bid: Any) -> list[Any]:
+            return children.get(bid, [])
+
+        table = block(
+            "table",
+            {"table_width": 2, "has_column_header": False},
+            has_children=True,
+            block_id="t2",
+        )
+        out = render_blocks([table], children_for=lookup)
+        # Header row is blank cells.
+        assert "|  |  |" in out
+        assert "| alice | bob |" in out
+
+    def test_table_with_no_children_emits_nothing(self) -> None:
+        def lookup(_: Any) -> list[Any]:
+            return []
+
+        table = block("table", {"table_width": 0}, has_children=True, block_id="t3")
+        out = render_blocks([table], children_for=lookup)
+        assert out == ""
+
+    def test_table_row_outside_table(self) -> None:
+        # A standalone table_row block (e.g. yielded as a sibling) still
+        # renders to a Markdown row.
+        out = render_blocks(
+            [block("table_row", {"cells": [[text_element("x")], [text_element("y")]]})]
+        )
+        assert out == "| x | y |"
+
+    def test_render_one_row_with_non_mapping_payload(self) -> None:
+        # Defensive guard inside `_render_one_row`.
+        rows = [{"id": "r", "type": "table_row", "table_row": "broken", "archived": False, "has_children": False}]
+        children = {"t": rows}
+
+        def lookup(bid: Any) -> list[Any]:
+            return children.get(bid, [])
+
+        table = block("table", {"table_width": 0, "has_column_header": True}, has_children=True, block_id="t")
+        # `_row_width` returns 0 → no separator columns; renderer copes.
+        out = render_blocks([table], children_for=lookup)
+        # The table renderer still emits the (empty) header & separator rows;
+        # the broken body row renders to empty string.
+        assert "|" in out
+
+    def test_row_width_with_non_mapping_payload(self) -> None:
+        from pleno_pii_scanner_notion.markdown import _row_width
+
+        assert _row_width({"table_row": "bad"}) == 0
+
+    def test_row_width_with_non_sequence_cells(self) -> None:
+        from pleno_pii_scanner_notion.markdown import _row_width
+
+        # `cells` is normally a list-of-lists; a malformed Notion payload
+        # could in theory hand us an int. The width must come back as 0
+        # rather than blowing up the table renderer.
+        assert _row_width({"table_row": {"cells": 42}}) == 0
+
+
+# ---------------------------------------------------------------------
+# database row properties
+# ---------------------------------------------------------------------
+
+
+class TestDatabaseRow:
+    def test_empty_returns_empty(self) -> None:
+        assert render_database_row(None) == ""
+        assert render_database_row({}) == ""
+
+    def test_skips_low_signal_metadata(self) -> None:
+        props = {
+            "Created": {"type": "created_time", "created_time": "2020-01-01T00:00:00Z"},
+            "Edited": {"type": "last_edited_time", "last_edited_time": "2020-01-01T00:00:00Z"},
+            "By": {"type": "created_by", "created_by": {"id": "u"}},
+            "EditBy": {"type": "last_edited_by", "last_edited_by": {"id": "u"}},
+            "Name": {"type": "title", "title": [text_element("alice")]},
+        }
+        out = render_database_row(props)
+        assert "Created" not in out
+        assert "Edited" not in out
+        assert "By:" not in out
+        assert "Name: alice" in out
+
+    def test_title_and_rich_text(self) -> None:
+        out = render_database_row(
+            {
+                "Title": {"type": "title", "title": [text_element("Hello")]},
+                "Body": {"type": "rich_text", "rich_text": [text_element("World", bold=True)]},
+            }
+        )
+        assert "Title: Hello" in out
+        assert "Body: **World**" in out
+
+    def test_number_zero_and_none(self) -> None:
+        out = render_database_row(
+            {
+                "Count": {"type": "number", "number": 0},
+                "Missing": {"type": "number", "number": None},
+            }
+        )
+        assert "Count: 0" in out
+        assert "Missing: " in out
+
+    def test_select_multi_select_status(self) -> None:
+        out = render_database_row(
+            {
+                "Sel": {"type": "select", "select": {"name": "Open"}},
+                "Tags": {"type": "multi_select", "multi_select": [{"name": "a"}, {"name": "b"}]},
+                "St": {"type": "status", "status": {"name": "InProgress"}},
+            }
+        )
+        assert "Sel: Open" in out
+        assert "Tags: a, b" in out
+        assert "St: InProgress" in out
+
+    def test_select_null_returns_empty(self) -> None:
+        out = render_database_row({"Sel": {"type": "select", "select": None}})
+        assert out == "Sel: "
+
+    def test_status_null_returns_empty(self) -> None:
+        out = render_database_row({"St": {"type": "status", "status": None}})
+        assert out == "St: "
+
+    def test_date_with_and_without_end(self) -> None:
+        out = render_database_row(
+            {
+                "Day": {"type": "date", "date": {"start": "2026-05-04"}},
+                "Range": {"type": "date", "date": {"start": "2026-05-04", "end": "2026-05-10"}},
+                "Empty": {"type": "date", "date": None},
+            }
+        )
+        assert "Day: 2026-05-04" in out
+        assert "Range: 2026-05-04 → 2026-05-10" in out
+        assert "Empty: " in out
+
+    def test_email_phone_url(self) -> None:
+        out = render_database_row(
+            {
+                "E": {"type": "email", "email": "a@b.test"},
+                "P": {"type": "phone_number", "phone_number": "+81-90-1234-5678"},
+                "U": {"type": "url", "url": "https://x.test"},
+            }
+        )
+        assert "E: a@b.test" in out
+        assert "P: +81-90-1234-5678" in out
+        assert "U: https://x.test" in out
+
+    def test_email_phone_url_null(self) -> None:
+        out = render_database_row(
+            {
+                "E": {"type": "email", "email": None},
+                "P": {"type": "phone_number", "phone_number": None},
+                "U": {"type": "url", "url": None},
+            }
+        )
+        assert "E: " in out
+        assert "P: " in out
+        assert "U: " in out
+
+    def test_people_with_and_without_email(self) -> None:
+        out = render_database_row(
+            {
+                "Owners": {
+                    "type": "people",
+                    "people": [
+                        {"id": "u1", "name": "Alice", "person": {"email": "alice@x.test"}},
+                        {"id": "u2", "name": "Bob"},
+                        {"id": "u3", "person": {"email": "anon@x.test"}},
+                        {"id": "u4"},
+                    ],
+                }
+            }
+        )
+        assert "Owners: Alice <alice@x.test>, Bob, anon@x.test, u4" in out
+
+    def test_people_skips_non_mapping_entries(self) -> None:
+        out = render_database_row(
+            {"Owners": {"type": "people", "people": ["broken", {"id": "u1", "name": "Alice"}]}}
+        )
+        assert out == "Owners: Alice"
+
+    def test_files(self) -> None:
+        out = render_database_row(
+            {
+                "Files": {
+                    "type": "files",
+                    "files": [
+                        {"name": "a.png", "type": "file", "file": {"url": "https://x.test/a"}},
+                        {"name": "b.png", "type": "external", "external": {"url": "https://x.test/b"}},
+                        {"name": "c"},
+                    ],
+                }
+            }
+        )
+        assert "Files: [a.png](https://x.test/a), [b.png](https://x.test/b), c" in out
+
+    def test_files_skips_non_mapping_entries(self) -> None:
+        out = render_database_row(
+            {"Files": {"type": "files", "files": ["bad", {"name": "ok"}]}}
+        )
+        assert out == "Files: ok"
+
+    def test_checkbox(self) -> None:
+        out = render_database_row(
+            {
+                "Y": {"type": "checkbox", "checkbox": True},
+                "N": {"type": "checkbox", "checkbox": False},
+            }
+        )
+        assert "Y: true" in out
+        assert "N: false" in out
+
+    def test_relation(self) -> None:
+        out = render_database_row(
+            {"Rel": {"type": "relation", "relation": [{"id": "p1"}, {"id": "p2"}, "broken", {}]}}
+        )
+        assert out == "Rel: p1, p2"
+
+    def test_formula_string_number_boolean_date(self) -> None:
+        cases = [
+            ({"type": "string", "string": "hello"}, "hello"),
+            ({"type": "number", "number": 42}, "42"),
+            ({"type": "boolean", "boolean": True}, "true"),
+            ({"type": "boolean", "boolean": False}, "false"),
+            ({"type": "date", "date": {"start": "2026-05-04"}}, "2026-05-04"),
+        ]
+        for formula, expected in cases:
+            out = render_database_row({"F": {"type": "formula", "formula": formula}})
+            assert out == f"F: {expected}", (formula, out)
+
+    def test_formula_invalid(self) -> None:
+        out = render_database_row({"F": {"type": "formula", "formula": None}})
+        assert out == "F: "
+        out2 = render_database_row({"F": {"type": "formula", "formula": {"type": "string", "string": None}}})
+        assert out2 == "F: "
+        # Mapping value that isn't a date object renders empty.
+        out3 = render_database_row({"F": {"type": "formula", "formula": {"type": "weird", "weird": {"k": 1}}}})
+        assert out3 == "F: "
+
+    def test_rollup_array_and_scalar(self) -> None:
+        out = render_database_row(
+            {
+                "R": {
+                    "type": "rollup",
+                    "rollup": {
+                        "type": "array",
+                        "array": [
+                            {"type": "title", "title": [text_element("X")]},
+                            {"type": "number", "number": 7},
+                        ],
+                    },
+                }
+            }
+        )
+        assert "R: X, 7" in out
+
+    def test_rollup_number(self) -> None:
+        out = render_database_row(
+            {"R": {"type": "rollup", "rollup": {"type": "number", "number": 99}}}
+        )
+        assert "R: 99" in out
+
+    def test_rollup_date_shape(self) -> None:
+        out = render_database_row(
+            {
+                "R": {
+                    "type": "rollup",
+                    "rollup": {"type": "date", "date": {"start": "2026-05-04"}},
+                }
+            }
+        )
+        assert "R: 2026-05-04" in out
+
+    def test_rollup_invalid(self) -> None:
+        out = render_database_row({"R": {"type": "rollup", "rollup": None}})
+        assert out == "R: "
+        out2 = render_database_row({"R": {"type": "rollup", "rollup": {"type": "number", "number": None}}})
+        assert out2 == "R: "
+
+    def test_unknown_property_type_emits_marker(self) -> None:
+        out = render_database_row(
+            {"Mystery": {"type": "future_kind", "future_kind": {"foo": "bar"}}}
+        )
+        assert "Mystery: <!-- unsupported property: future_kind -->" in out
+
+    def test_non_mapping_property_skipped(self) -> None:
+        out = render_database_row({"Bad": "not a mapping", "Title": {"type": "title", "title": [text_element("ok")]}})
+        assert out == "Title: ok"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ members = [
     "packages/pii-scanner-gcs",
     "packages/pii-scanner-github",
     "packages/pii-scanner-gitlab",
+    "packages/pii-scanner-notion",
     "packages/pii-scanner-oci",
     "packages/pii-scanner-postgres",
     "packages/pii-scanner-redis",

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ members = [
     "pleno-pii-scanner-gcs",
     "pleno-pii-scanner-github",
     "pleno-pii-scanner-gitlab",
+    "pleno-pii-scanner-notion",
     "pleno-pii-scanner-oci",
     "pleno-pii-scanner-postgres",
     "pleno-pii-scanner-redis",
@@ -3508,6 +3509,35 @@ dev = [
 name = "pleno-pii-scanner-gitlab"
 version = "0.1.0"
 source = { editable = "packages/pii-scanner-gitlab" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pleno-pii-scanner" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pleno-pii-scanner", editable = "packages/pii-scanner" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+]
+
+[[package]]
+name = "pleno-pii-scanner-notion"
+version = "0.1.0"
+source = { editable = "packages/pii-scanner-notion" }
 dependencies = [
     { name = "httpx" },
     { name = "pleno-pii-scanner" },


### PR DESCRIPTION
Notion SourceConnector wheel implementing ADR-0007 §13.

## Summary
- **Auth**: Internal Integration Token (Bearer) + pinned `Notion-Version: 2022-06-28`
- **Discovery**: three modes (search / explicit pages / database query) that combine and dedupe
- **Block tree → Markdown**: 19 block types + unsupported-comment fallback; recursion bounded at depth 100
- **Rich text**: bold/italic/strike/code annotations; user/page/database/date mentions as `notion://...` links
- **Database row → Markdown**: every supported property type as `name: value` lines
- **Pagination**: `start_cursor` / `next_cursor` / `has_more`, `page_size=100`
- **Rate limit**: 429+Retry-After surfaces `RateLimited` to the AIMD bucket
- **Concurrency**: capped at 3 (Notion's published RPS budget)
- **Archived**: skipped by default; opt-in via `include_archived=True`

## Tests
- 147 hermetic tests via `httpx.MockTransport`
- 99.66% line+branch coverage
- Covers auth/version pinning, search pagination chains, database query enumeration, block recursion + nesting, rich-text annotations, mention rendering, every database property type, unknown-block-type fallback, 429 propagation, archived filter on/off, factory variations + invalid config, lifecycle close

Task #29.