### PR TITLE
feat(pii-scanner-sharepoint): Graph drive delta + Sites.Selected + WIF (#30, ADR §13)

### DIFF
--- a/packages/pii-scanner-sharepoint/README.md
+++ b/packages/pii-scanner-sharepoint/README.md
@@ -1,0 +1,65 @@
+# pleno-pii-scanner-sharepoint
+
+Microsoft SharePoint `SourceConnector` for [pleno-pii-scanner](../pii-scanner/).
+
+Walks every document library in every site the app can see via
+Microsoft Graph, paginates with the `/delta` endpoint so subsequent
+runs only see new or changed files, and yields each file (and
+optionally each list item) as a Document.
+
+## Auth
+
+Microsoft Entra app with the **`Sites.Selected`** application
+permission plus `Files.Read.All`. Two client-credential modes:
+
+- `client_secret` — classic confidential client. Sent to the Entra
+  v2 token endpoint as `client_secret`.
+- `federated_token` — pre-fetched OIDC JWT (workload identity from
+  GHA, AKS, Cloud Run, …) sent as `client_assertion` with
+  `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
+  No long-lived secret in the deployment.
+
+Exactly one of the two must be supplied.
+
+## Sites.Selected grant model
+
+`Sites.Selected` is the *narrowest* SharePoint app permission. It
+grants nothing by default — a tenant administrator must explicitly
+grant the app access to **each individual site** via the Graph
+`POST /sites/{id}/permissions` endpoint:
+
+```json
+{
+  "roles": ["read"],
+  "grantedToIdentities": [{
+    "application": { "id": "<client-id>", "displayName": "pleno-scanner" }
+  }]
+}
+```
+
+Without this per-site grant, `GET /sites/{id}/drives` returns 403.
+Operators should pin the `sites = (...)` allowlist to the exact set
+that has been granted, so a misconfigured tenant fails loudly with
+a 403 on a known site rather than silently returning zero results
+from `?search=*`.
+
+## Delta semantics
+
+Per-drive `/root/delta` returns a `@odata.deltaLink` that the
+connector persists as the cursor. On resume, that link is fetched
+verbatim and only items changed since the prior run come back.
+Folders are skipped. Files larger than `max_file_size_bytes` (default
+100 MiB) are still yielded as refs (so the operator can audit them)
+but `fetch()` returns no Document.
+
+## Config
+
+```toml
+[sharepoint]
+tenant_id = "00000000-0000-0000-0000-000000000000"
+client_id = "11111111-1111-1111-1111-111111111111"
+client_secret = "${MS_GRAPH_CLIENT_SECRET}"   # OR federated_token = "..."
+sites = ["site-id-1", "contoso.sharepoint.com:/sites/team"]
+include_lists = false
+max_file_size_bytes = 104857600
+```

--- a/packages/pii-scanner-sharepoint/pyproject.toml
+++ b/packages/pii-scanner-sharepoint/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "pleno-pii-scanner-sharepoint"
+version = "0.1.0"
+description = "Microsoft SharePoint SourceConnector for pleno-pii-scanner (Graph drive delta + Sites.Selected + WIF)"
+readme = "README.md"
+license = { text = "AGPL-3.0-or-later" }
+requires-python = ">=3.12"
+authors = [{ name = "pleno", email = "ai@egahika.dev" }]
+keywords = ["pii", "sharepoint", "microsoft-graph", "scanner"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+]
+dependencies = [
+    "httpx>=0.27",
+    "pleno-pii-scanner",
+]
+
+[project.entry-points."pleno_pii_scanner.connectors"]
+sharepoint = "pleno_pii_scanner_sharepoint:SPEC"
+
+[project.urls]
+Homepage = "https://github.com/plenoai/pleno-anonymize"
+Source = "https://github.com/plenoai/pleno-anonymize"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
+]
+
+[tool.uv.sources]
+pleno-pii-scanner = { workspace = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pleno_pii_scanner_sharepoint"]

--- a/packages/pii-scanner-sharepoint/src/pleno_pii_scanner_sharepoint/__init__.py
+++ b/packages/pii-scanner-sharepoint/src/pleno_pii_scanner_sharepoint/__init__.py
@@ -1,0 +1,9 @@
+"""SharePoint SourceConnector for pleno-pii-scanner (ADR-0007 §13)."""
+
+from pleno_pii_scanner_sharepoint.connector import (
+    SPEC,
+    SharePointConfig,
+    SharePointConnector,
+)
+
+__all__ = ["SPEC", "SharePointConfig", "SharePointConnector"]

--- a/packages/pii-scanner-sharepoint/src/pleno_pii_scanner_sharepoint/connector.py
+++ b/packages/pii-scanner-sharepoint/src/pleno_pii_scanner_sharepoint/connector.py
@@ -1,0 +1,638 @@
+"""SharePoint SourceConnector — Microsoft Graph drive delta + Sites.Selected.
+
+Pipeline:
+
+  1. Acquire an Entra v2 application access token. Two modes:
+       - client_secret (classic confidential client)
+       - federated_token (jwt-bearer client_assertion; workload identity)
+     The result is cached until 5 minutes before `expires_in`.
+  2. Enumerate sites:
+       - if `sites=()`, GET /v1.0/sites?search=*  (every site the
+         app has been granted)
+       - else use the explicit allowlist (site IDs or
+         hostname:server-relative-url paths resolved through
+         /v1.0/sites/{path}).
+  3. Per site, GET /v1.0/sites/{site-id}/drives → document libraries.
+  4. Per drive, run /root/delta. Fresh runs start at the bare endpoint;
+     resumes use the previously stored `@odata.deltaLink` verbatim.
+     Folders are filtered out client-side; only `file` items become refs.
+  5. If `include_lists=True`, additionally enumerate
+     /v1.0/sites/{site-id}/lists and yield one ref per list item.
+  6. Each emitted ref carries `etag` so the scheduler can short-circuit
+     on unchanged content via `content_hash_delta=True`.
+  7. The new `@odata.deltaLink` per drive is collected and serialised
+     into the run cursor (JSON object keyed by `<site-id>/<drive-id>`).
+
+Sites.Selected is the *narrowest* SharePoint app permission. The app
+gets nothing until an admin runs `POST /sites/{id}/permissions` granting
+this client_id read access to that specific site. We therefore expect
+operators to pin `sites=` to the granted set; falling back to
+`?search=*` is supported but will be empty for most tenants.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from pleno_pii_scanner.sources.base import (
+    Capabilities,
+    Cursor,
+    Document,
+    DocumentChunk,
+    DocumentRef,
+    SourceConnector,
+    SourceFilter,
+)
+from pleno_pii_scanner.sources.registry import ConnectorSpec
+
+
+# Microsoft Graph v1 base. The connector relies on absolute deltaLink
+# URLs returned by the service for resume, so the base only matters for
+# initial requests.
+_GRAPH_BASE = "https://graph.microsoft.com"
+
+# Entra v2 client-credentials token endpoint template. Tenant-scoped
+# because Sites.Selected only resolves against the granting tenant.
+_TOKEN_URL = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+
+# JWT-bearer client_assertion grant per RFC 7521/7523. Required when
+# we substitute a federated OIDC JWT for a client_secret.
+_CLIENT_ASSERTION_TYPE = (
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+)
+
+# Default Graph scope for application credentials. `/.default` requests
+# the union of pre-consented application permissions registered on the
+# app — Sites.Selected + Files.Read.All in our case.
+_DEFAULT_SCOPE = "https://graph.microsoft.com/.default"
+
+# Re-mint the bearer 5 minutes before its declared `expires_in` so an
+# in-flight request never carries a token that expires mid-flight.
+_TOKEN_SKEW_SECONDS = 5 * 60
+
+
+@dataclass(frozen=True, slots=True)
+class SharePointConfig:
+    """Construction config for `SharePointConnector`.
+
+    `tenant_id` and `client_id` identify the Entra app. Exactly one
+    of `client_secret` or `federated_token` provides the credential
+    half — fail loudly when neither or both is set so a misconfigured
+    deployment never silently fails open.
+
+    `sites` is an allowlist of site IDs OR `hostname:/sites/<name>`
+    paths. Empty means "every site `?search=*` returns" — that is
+    almost never what you want with Sites.Selected; pin it.
+
+    `max_file_size_bytes` bounds the per-file body that `fetch()` will
+    download. Larger files still surface as refs (so the operator can
+    see what was skipped) but `fetch()` returns no Document.
+    """
+
+    tenant_id: str
+    client_id: str
+    client_secret: str | None = None
+    federated_token: str | None = None
+    sites: tuple[str, ...] = ()
+    include_lists: bool = False
+    max_file_size_bytes: int = 100 * 1024 * 1024
+    id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tenant_id:
+            raise ValueError("tenant_id must be non-empty")
+        if not self.client_id:
+            raise ValueError("client_id must be non-empty")
+        has_secret = bool(self.client_secret)
+        has_federated = bool(self.federated_token)
+        if has_secret == has_federated:
+            # Both or neither: catastrophic misconfig. Both means the
+            # operator may not realise which credential is in use;
+            # neither means we'd silently send unauthenticated calls.
+            raise ValueError(
+                "exactly one of client_secret or federated_token must be set"
+            )
+        if self.max_file_size_bytes < 0:
+            raise ValueError("max_file_size_bytes must be >= 0")
+
+    def resolved_id(self) -> str:
+        if self.id is not None:
+            return self.id
+        # Tenant + client_id are not secret; site set bounds scope.
+        suffix = "+".join(sorted(self.sites)) if self.sites else "*"
+        return f"sharepoint:{self.tenant_id}:{self.client_id}:{suffix}"
+
+
+@dataclass(slots=True)
+class _CachedBearer:
+    token: str
+    expires_at: float
+
+
+class SharePointConnector:
+    """Read-only SourceConnector for SharePoint via Microsoft Graph."""
+
+    kind = "sharepoint"
+
+    def __init__(
+        self,
+        config: SharePointConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+        now: "callable[[], float] | None" = None,
+    ) -> None:
+        self._config = config
+        self.id = config.resolved_id()
+        if client is None:
+            self._client = httpx.AsyncClient(
+                base_url=_GRAPH_BASE, timeout=30.0
+            )
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+        self._now = now or time.time
+        self._cached: _CachedBearer | None = None
+        self._token_lock = asyncio.Lock()
+        # Per-drive deltaLink captured during discover, so cursor_after_run
+        # can serialise it into the next-run cursor.
+        self._delta_links: dict[str, str] = {}
+        # Drive lookup so fetch() can hit /drives/{id}/items/{id}/content
+        # without re-walking sites.
+        self._drive_index: dict[str, str] = {}
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(
+            incremental=True,
+            binary=True,
+            content_hash_delta=True,
+            max_concurrent_fetches=4,
+            streaming=False,
+        )
+
+    # --- discover / fetch ---------------------------------------------
+
+    async def discover(
+        self,
+        filter: SourceFilter,
+        cursor: Cursor | None,
+    ) -> AsyncIterator[DocumentRef]:
+        prior = _decode_cursor(cursor)
+        sites = await self._list_sites()
+        for site in sites:
+            site_id = site["id"]
+            site_name = site.get("name") or site.get("displayName") or site_id
+            drives = await self._list_drives(site_id)
+            for drive in drives:
+                drive_id = drive["id"]
+                drive_name = drive.get("name", drive_id)
+                key = f"{site_id}/{drive_id}"
+                self._drive_index[drive_id] = drive_id
+                resume = prior.get(key)
+                async for ref in self._walk_drive_delta(
+                    site_id=site_id,
+                    site_name=site_name,
+                    drive_id=drive_id,
+                    drive_name=drive_name,
+                    resume_link=resume,
+                    filter=filter,
+                ):
+                    yield ref
+            if self._config.include_lists:
+                async for ref in self._walk_lists(
+                    site_id=site_id, site_name=site_name, filter=filter
+                ):
+                    yield ref
+
+    async def fetch(
+        self,
+        ref: DocumentRef,
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        kind = ref.metadata.get("kind")
+        if kind == "file":
+            async for doc in self._fetch_file(ref):
+                yield doc
+        elif kind == "list_item":
+            async for doc in self._fetch_list_item(ref):
+                yield doc
+        # else: silently no-op — stale ref shape from a different connector
+
+    def cursor_after_run(self) -> Cursor | None:
+        """Persisted resume token: JSON {site/drive: deltaLink}."""
+        if not self._delta_links:
+            return None
+        return json.dumps(dict(self._delta_links), sort_keys=True)
+
+    async def close(self) -> None:
+        self._delta_links.clear()
+        self._drive_index.clear()
+        self._cached = None
+        if self._owns_client:
+            await self._client.aclose()
+
+    # --- internals: token --------------------------------------------
+
+    async def _bearer(self) -> str:
+        cached = self._cached
+        if (
+            cached is not None
+            and cached.expires_at - _TOKEN_SKEW_SECONDS > self._now()
+        ):
+            return cached.token
+        async with self._token_lock:
+            cached = self._cached
+            if (
+                cached is not None
+                and cached.expires_at - _TOKEN_SKEW_SECONDS > self._now()
+            ):
+                return cached.token
+            fresh = await self._exchange_token()
+            self._cached = fresh
+            return fresh.token
+
+    async def _exchange_token(self) -> _CachedBearer:
+        data: dict[str, str] = {
+            "client_id": self._config.client_id,
+            "scope": _DEFAULT_SCOPE,
+            "grant_type": "client_credentials",
+        }
+        if self._config.client_secret is not None:
+            data["client_secret"] = self._config.client_secret
+        else:
+            # federated_token is enforced non-None by config validation.
+            assert self._config.federated_token is not None
+            data["client_assertion_type"] = _CLIENT_ASSERTION_TYPE
+            data["client_assertion"] = self._config.federated_token
+        url = _TOKEN_URL.format(tenant=self._config.tenant_id)
+        resp = await self._client.post(
+            url,
+            data=data,
+            headers={"Accept": "application/json"},
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        token = payload["access_token"]
+        expires_in = payload.get("expires_in", 3600)
+        return _CachedBearer(
+            token=token, expires_at=self._now() + float(expires_in)
+        )
+
+    async def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {await self._bearer()}"}
+
+    # --- internals: graph requests -----------------------------------
+
+    async def _get_json(
+        self, path_or_url: str, *, params: Mapping[str, Any] | None = None
+    ) -> dict[str, Any]:
+        headers = await self._auth_headers()
+        resp = await self._client.get(path_or_url, headers=headers, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _list_sites(self) -> list[dict[str, Any]]:
+        if self._config.sites:
+            out: list[dict[str, Any]] = []
+            for site_ref in self._config.sites:
+                # `hostname:/sites/foo` → resolve via /sites/{path}.
+                # Plain id → use it verbatim.
+                if ":" in site_ref and "/" in site_ref:
+                    payload = await self._get_json(f"/v1.0/sites/{site_ref}")
+                    out.append(payload)
+                else:
+                    out.append({"id": site_ref, "name": site_ref})
+            return out
+        payload = await self._get_json("/v1.0/sites", params={"search": "*"})
+        return payload.get("value", []) or []
+
+    async def _list_drives(self, site_id: str) -> list[dict[str, Any]]:
+        payload = await self._get_json(f"/v1.0/sites/{site_id}/drives")
+        return payload.get("value", []) or []
+
+    async def _walk_drive_delta(
+        self,
+        *,
+        site_id: str,
+        site_name: str,
+        drive_id: str,
+        drive_name: str,
+        resume_link: str | None,
+        filter: SourceFilter,
+    ) -> AsyncIterator[DocumentRef]:
+        # Initial run hits the bare delta endpoint; resume re-uses the
+        # absolute deltaLink the service handed back last time.
+        next_url: str | None = (
+            resume_link
+            or f"/v1.0/sites/{site_id}/drives/{drive_id}/root/delta"
+        )
+        while next_url is not None:
+            payload = await self._get_json(next_url)
+            for item in payload.get("value", []) or []:
+                # Folders carry a `folder` facet; files carry `file`.
+                # Skip folders entirely — we only scan leaf payloads.
+                if item.get("folder") is not None:
+                    continue
+                if item.get("file") is None:
+                    continue
+                ref = self._build_file_ref(
+                    item=item,
+                    site_id=site_id,
+                    site_name=site_name,
+                    drive_id=drive_id,
+                    drive_name=drive_name,
+                )
+                if not _passes_filter(ref.path, filter):
+                    continue
+                yield ref
+            delta_link = payload.get("@odata.deltaLink")
+            if delta_link:
+                self._delta_links[f"{site_id}/{drive_id}"] = delta_link
+                # deltaLink is terminal: the page also carries no
+                # @odata.nextLink, so the loop exits naturally.
+                next_url = None
+                continue
+            next_url = payload.get("@odata.nextLink")
+
+    def _build_file_ref(
+        self,
+        *,
+        item: Mapping[str, Any],
+        site_id: str,
+        site_name: str,
+        drive_id: str,
+        drive_name: str,
+    ) -> DocumentRef:
+        item_id = str(item.get("id", ""))
+        name = item.get("name", item_id)
+        parent = item.get("parentReference") or {}
+        parent_path = ""
+        if isinstance(parent, Mapping):
+            raw = parent.get("path", "")
+            if isinstance(raw, str):
+                # Graph returns `/drive/root:/folder/sub` — strip the
+                # bookkeeping prefix so the rendered path is clean.
+                _, _, parent_path = raw.partition("root:")
+                parent_path = parent_path.lstrip("/")
+        full_path = "/".join(
+            p for p in (site_name, drive_name, parent_path, name) if p
+        )
+        size = item.get("size")
+        file_facet = item.get("file") or {}
+        mime = (
+            file_facet.get("mimeType")
+            if isinstance(file_facet, Mapping)
+            else None
+        ) or "application/octet-stream"
+        etag = item.get("eTag") or item.get("cTag")
+        last_modified_str = item.get("lastModifiedDateTime")
+        last_modified = _parse_dt(last_modified_str)
+        return DocumentRef(
+            source_id=self.id,
+            source_kind=self.kind,
+            path=full_path,
+            native_url=item.get("webUrl"),
+            content_type=str(mime),
+            size=int(size) if isinstance(size, (int, float)) else None,
+            etag=str(etag) if etag is not None else None,
+            last_modified=last_modified,
+            metadata={
+                "kind": "file",
+                "site_id": site_id,
+                "drive_id": drive_id,
+                "item_id": item_id,
+                "name": str(name),
+            },
+        )
+
+    async def _walk_lists(
+        self,
+        *,
+        site_id: str,
+        site_name: str,
+        filter: SourceFilter,
+    ) -> AsyncIterator[DocumentRef]:
+        payload = await self._get_json(f"/v1.0/sites/{site_id}/lists")
+        for lst in payload.get("value", []) or []:
+            list_id = str(lst.get("id", ""))
+            list_name = lst.get("displayName") or lst.get("name") or list_id
+            items_payload = await self._get_json(
+                f"/v1.0/sites/{site_id}/lists/{list_id}/items",
+                params={"expand": "fields"},
+            )
+            for item in items_payload.get("value", []) or []:
+                item_id = str(item.get("id", ""))
+                full = f"{site_name}/lists/{list_name}/{item_id}"
+                if not _passes_filter(full, filter):
+                    continue
+                yield DocumentRef(
+                    source_id=self.id,
+                    source_kind=self.kind,
+                    path=full,
+                    native_url=item.get("webUrl"),
+                    content_type="text/plain",
+                    etag=item.get("eTag"),
+                    last_modified=_parse_dt(item.get("lastModifiedDateTime")),
+                    metadata={
+                        "kind": "list_item",
+                        "site_id": site_id,
+                        "list_id": list_id,
+                        "list_name": str(list_name),
+                        "item_id": item_id,
+                    },
+                )
+
+    # --- internals: fetch --------------------------------------------
+
+    async def _fetch_file(
+        self, ref: DocumentRef
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        if (
+            ref.size is not None
+            and ref.size > self._config.max_file_size_bytes
+        ):
+            # Surface the skip via empty fetch — the discover ref still
+            # exists for auditing.
+            return
+        drive_id = ref.metadata.get("drive_id")
+        item_id = ref.metadata.get("item_id")
+        if not drive_id or not item_id:
+            return
+        headers = await self._auth_headers()
+        resp = await self._client.get(
+            f"/v1.0/drives/{drive_id}/items/{item_id}/content",
+            headers=headers,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        body = resp.content
+        # Decide text vs binary by attempting UTF-8 decode for content
+        # types that typically carry text. Anything else is binary —
+        # the ContentExtractor (#8) handles MIME-aware parsing.
+        ctype = ref.content_type.lower()
+        text_like = ctype.startswith("text/") or ctype in {
+            "application/json",
+            "application/xml",
+            "application/x-yaml",
+        }
+        text: str | None = None
+        binary: bytes | None = None
+        if text_like:
+            try:
+                text = body.decode("utf-8")
+            except UnicodeDecodeError:
+                binary = body
+        else:
+            binary = body
+        yield Document(
+            ref=ref,
+            text=text,
+            binary=binary,
+            fetched_at=datetime.now(UTC),
+            content_hash=ref.etag,
+        )
+
+    async def _fetch_list_item(
+        self, ref: DocumentRef
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        site_id = ref.metadata.get("site_id")
+        list_id = ref.metadata.get("list_id")
+        item_id = ref.metadata.get("item_id")
+        if not site_id or not list_id or not item_id:
+            return
+        payload = await self._get_json(
+            f"/v1.0/sites/{site_id}/lists/{list_id}/items/{item_id}",
+            params={"expand": "fields"},
+        )
+        fields = payload.get("fields") or {}
+        if not isinstance(fields, Mapping):
+            fields = {}
+        text = _serialise_fields(fields)
+        yield Document(
+            ref=ref,
+            text=text,
+            fetched_at=datetime.now(UTC),
+            content_hash=ref.etag,
+        )
+
+
+# --- helpers ------------------------------------------------------
+
+
+def _passes_filter(path: str, filter: SourceFilter) -> bool:
+    if filter.include and not _matches_any(path, filter.include):
+        return False
+    if filter.exclude and _matches_any(path, filter.exclude):
+        return False
+    return True
+
+
+def _matches_any(s: str, patterns: tuple[str, ...]) -> bool:
+    from fnmatch import fnmatch
+
+    return any(fnmatch(s, p) for p in patterns)
+
+
+def _decode_cursor(cursor: Cursor | None) -> dict[str, str]:
+    """Parse a JSON cursor into the per-drive deltaLink map.
+
+    Cursor is `str` in the core API. We persist a JSON object and
+    fall back to empty on any decode failure — a stale cursor format
+    triggers a fresh delta walk rather than a crash.
+    """
+    if not cursor:
+        return {}
+    try:
+        decoded = json.loads(cursor)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    return {str(k): str(v) for k, v in decoded.items()}
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        # Graph emits ISO 8601 with trailing Z. fromisoformat in 3.11+
+        # accepts the Z suffix natively.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _serialise_fields(fields: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in fields.items():
+        if key.startswith("@") or key.startswith("_"):
+            # Skip Graph bookkeeping (@odata.* and the internal
+            # underscore-prefixed system columns).
+            continue
+        parts.append(f"{key}={value}")
+    return "\n".join(parts)
+
+
+# --- factory / spec -----------------------------------------------
+
+
+def _factory(config: Mapping[str, Any]) -> SourceConnector:
+    if "tenant_id" not in config:
+        raise ValueError("sharepoint connector config requires 'tenant_id'")
+    if "client_id" not in config:
+        raise ValueError("sharepoint connector config requires 'client_id'")
+    return SharePointConnector(
+        SharePointConfig(
+            tenant_id=str(config["tenant_id"]),
+            client_id=str(config["client_id"]),
+            client_secret=(
+                str(config["client_secret"])
+                if config.get("client_secret") is not None
+                else None
+            ),
+            federated_token=(
+                str(config["federated_token"])
+                if config.get("federated_token") is not None
+                else None
+            ),
+            sites=tuple(str(s) for s in config.get("sites", ())),
+            include_lists=bool(config.get("include_lists", False)),
+            max_file_size_bytes=int(
+                config.get("max_file_size_bytes", 100 * 1024 * 1024)
+            ),
+            id=str(config["id"]) if config.get("id") is not None else None,
+        )
+    )
+
+
+SPEC = ConnectorSpec(
+    kind="sharepoint",
+    version="0.1.0",
+    factory=_factory,
+    capabilities=Capabilities(
+        incremental=True,
+        binary=True,
+        content_hash_delta=True,
+        max_concurrent_fetches=4,
+        streaming=False,
+    ),
+    required_scopes=("Sites.Selected", "Files.Read.All"),
+    description=(
+        "Microsoft SharePoint SourceConnector. Walks every document "
+        "library in every Sites.Selected-granted site via Microsoft "
+        "Graph; uses /root/delta for incremental resume and surfaces "
+        "files (and optionally list items) as Documents. Supports "
+        "client_secret and federated (workload identity) auth."
+    ),
+)
+
+
+__all__ = ["SPEC", "SharePointConfig", "SharePointConnector"]

--- a/packages/pii-scanner-sharepoint/tests/test_connector.py
+++ b/packages/pii-scanner-sharepoint/tests/test_connector.py
@@ -1,0 +1,1113 @@
+"""Tests for SharePointConnector — uses httpx.MockTransport doubles."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from pleno_pii_scanner.sources import (
+    Capabilities,
+    Document,
+    SourceConnector,
+    SourceFilter,
+    create,
+    register,
+)
+from pleno_pii_scanner.sources import registry as _registry_mod
+from pleno_pii_scanner_sharepoint import (
+    SPEC,
+    SharePointConfig,
+    SharePointConnector,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(_registry_mod, "entry_points", lambda **_: [])
+    _registry_mod._reset_for_tests()
+    yield
+    _registry_mod._reset_for_tests()
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url="https://graph.microsoft.com",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def _ok_token(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200, json={"access_token": "AAA", "expires_in": 3600}
+    )
+
+
+def _make_handler(
+    *,
+    sites: list[dict] | None = None,
+    drives_by_site: dict[str, list[dict]] | None = None,
+    delta_pages: dict[str, list[dict]] | None = None,
+    lists_by_site: dict[str, list[dict]] | None = None,
+    list_items: dict[str, list[dict]] | None = None,
+    list_item_detail: dict[str, dict] | None = None,
+    file_content: dict[str, bytes] | None = None,
+    token_calls: list[dict] | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    sites = sites or []
+    drives_by_site = drives_by_site or {}
+    delta_pages = delta_pages or {}
+    lists_by_site = lists_by_site or {}
+    list_items = list_items or {}
+    list_item_detail = list_item_detail or {}
+    file_content = file_content or {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        path = request.url.path
+        if "login.microsoftonline.com" in url and path.endswith("/oauth2/v2.0/token"):
+            if token_calls is not None:
+                # Capture the form payload for assertion in the test.
+                from urllib.parse import parse_qs
+
+                body = request.content.decode("utf-8")
+                token_calls.append(
+                    {k: v[0] for k, v in parse_qs(body).items()}
+                )
+            return httpx.Response(
+                200, json={"access_token": "AAA", "expires_in": 3600}
+            )
+        if path == "/v1.0/sites" and request.url.params.get("search") == "*":
+            return httpx.Response(200, json={"value": sites})
+        if path.startswith("/v1.0/sites/") and path.endswith("/drives"):
+            site_id = path.split("/")[3]
+            return httpx.Response(
+                200, json={"value": drives_by_site.get(site_id, [])}
+            )
+        if "/root/delta" in path or url in delta_pages:
+            # Resume URLs are absolute; initial path is relative.
+            page_key = url if url in delta_pages else path
+            for key in (page_key, path, url):
+                if key in delta_pages:
+                    pages = delta_pages[key]
+                    return httpx.Response(200, json=pages.pop(0))
+            return httpx.Response(200, json={"value": []})
+        if path.startswith("/v1.0/sites/") and path.endswith("/lists"):
+            site_id = path.split("/")[3]
+            return httpx.Response(
+                200, json={"value": lists_by_site.get(site_id, [])}
+            )
+        if (
+            path.startswith("/v1.0/sites/")
+            and "/lists/" in path
+            and path.endswith("/items")
+        ):
+            list_id = path.split("/")[5]
+            return httpx.Response(
+                200, json={"value": list_items.get(list_id, [])}
+            )
+        if (
+            path.startswith("/v1.0/sites/")
+            and "/lists/" in path
+            and "/items/" in path
+        ):
+            item_id = path.split("/items/")[1]
+            return httpx.Response(
+                200, json=list_item_detail.get(item_id, {"fields": {}})
+            )
+        if "/items/" in path and path.endswith("/content"):
+            item_id = path.split("/items/")[1].split("/")[0]
+            blob = file_content.get(item_id, b"")
+            return httpx.Response(200, content=blob)
+        if path.startswith("/v1.0/sites/") and path.count("/") == 3:
+            # /v1.0/sites/{path-form} resolved site lookup.
+            return httpx.Response(
+                200, json={"id": "resolved-site", "name": "resolved"}
+            )
+        return httpx.Response(404, content=str(request.url).encode())
+
+    return handler
+
+
+# --- config -------------------------------------------------------
+
+
+class TestConfig:
+    def test_rejects_empty_tenant_id(self) -> None:
+        with pytest.raises(ValueError, match="tenant_id"):
+            SharePointConfig(
+                tenant_id="", client_id="c", client_secret="s"
+            )
+
+    def test_rejects_empty_client_id(self) -> None:
+        with pytest.raises(ValueError, match="client_id"):
+            SharePointConfig(
+                tenant_id="t", client_id="", client_secret="s"
+            )
+
+    def test_rejects_neither_credential(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            SharePointConfig(tenant_id="t", client_id="c")
+
+    def test_rejects_both_credentials(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            SharePointConfig(
+                tenant_id="t",
+                client_id="c",
+                client_secret="s",
+                federated_token="j",
+            )
+
+    def test_rejects_negative_max_size(self) -> None:
+        with pytest.raises(ValueError, match="max_file_size_bytes"):
+            SharePointConfig(
+                tenant_id="t",
+                client_id="c",
+                client_secret="s",
+                max_file_size_bytes=-1,
+            )
+
+    def test_explicit_id(self) -> None:
+        cfg = SharePointConfig(
+            tenant_id="t", client_id="c", client_secret="s", id="custom"
+        )
+        assert cfg.resolved_id() == "custom"
+
+    def test_default_id_includes_tenant_and_client(self) -> None:
+        cfg = SharePointConfig(
+            tenant_id="t", client_id="c", client_secret="s"
+        )
+        rid = cfg.resolved_id()
+        assert "t" in rid and "c" in rid
+
+    def test_default_id_with_sites(self) -> None:
+        cfg = SharePointConfig(
+            tenant_id="t",
+            client_id="c",
+            client_secret="s",
+            sites=("s1", "s2"),
+        )
+        assert "s1+s2" in cfg.resolved_id()
+
+
+# --- protocol -----------------------------------------------------
+
+
+class TestProtocol:
+    def test_runtime_isinstance(self) -> None:
+        c = SharePointConnector(
+            SharePointConfig(
+                tenant_id="t", client_id="c", client_secret="s"
+            )
+        )
+        assert isinstance(c, SourceConnector)
+
+    def test_capabilities(self) -> None:
+        c = SharePointConnector(
+            SharePointConfig(
+                tenant_id="t", client_id="c", client_secret="s"
+            )
+        )
+        assert c.capabilities() == Capabilities(
+            incremental=True,
+            binary=True,
+            content_hash_delta=True,
+            max_concurrent_fetches=4,
+            streaming=False,
+        )
+
+
+# --- token --------------------------------------------------------
+
+
+class TestToken:
+    async def test_acquire_with_client_secret(self) -> None:
+        calls: list[dict] = []
+        handler = _make_handler(
+            sites=[{"id": "site1", "name": "TeamA"}],
+            drives_by_site={"site1": []},
+            token_calls=calls,
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="tnt",
+                    client_id="cli",
+                    client_secret="sec",
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                assert calls
+                assert calls[0]["client_id"] == "cli"
+                assert calls[0]["client_secret"] == "sec"
+                assert calls[0]["grant_type"] == "client_credentials"
+                assert "scope" in calls[0]
+            finally:
+                await c.close()
+
+    async def test_token_cache_hit(self) -> None:
+        calls: list[dict] = []
+        handler = _make_handler(
+            sites=[{"id": "site1", "name": "TeamA"}],
+            drives_by_site={"site1": []},
+            token_calls=calls,
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="tnt",
+                    client_id="cli",
+                    client_secret="sec",
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                first = len(calls)
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                # Second discover reuses the cached bearer.
+                assert len(calls) == first
+            finally:
+                await c.close()
+
+    async def test_acquire_with_federated_token(self) -> None:
+        calls: list[dict] = []
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": []},
+            token_calls=calls,
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="tnt",
+                    client_id="cli",
+                    federated_token="JWT.payload.sig",
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                assert calls
+                assert (
+                    calls[0]["client_assertion_type"]
+                    == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                )
+                assert calls[0]["client_assertion"] == "JWT.payload.sig"
+                assert "client_secret" not in calls[0]
+            finally:
+                await c.close()
+
+
+# --- delta walk ---------------------------------------------------
+
+
+def _file_item(item_id: str, name: str, *, size: int = 10, etag: str = '"e"') -> dict:
+    return {
+        "id": item_id,
+        "name": name,
+        "size": size,
+        "eTag": etag,
+        "file": {"mimeType": "text/plain"},
+        "parentReference": {"path": "/drive/root:/folder"},
+        "webUrl": f"https://contoso.sharepoint.com/{name}",
+        "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+    }
+
+
+def _folder_item(item_id: str, name: str) -> dict:
+    return {
+        "id": item_id,
+        "name": name,
+        "folder": {"childCount": 1},
+        "parentReference": {"path": "/drive/root:"},
+    }
+
+
+class TestDelta:
+    async def test_initial_enumerates_files_skips_folders(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "Documents"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [
+                            _file_item("i1", "a.txt"),
+                            _folder_item("f1", "subdir"),
+                            _file_item("i2", "b.txt"),
+                        ],
+                        "@odata.deltaLink": "https://graph.microsoft.com/delta-token-1",
+                    }
+                ]
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert {r.metadata["item_id"] for r in refs} == {"i1", "i2"}
+                # All refs are files with eTag attached for content_hash_delta.
+                assert all(r.etag == '"e"' for r in refs)
+                # Path includes site/drive/parent/name.
+                assert any("TeamA/Documents/folder/a.txt" in r.path for r in refs)
+                # Cursor stored for resume.
+                cur = c.cursor_after_run()
+                assert cur is not None
+                decoded = json.loads(cur)
+                assert decoded["s1/d1"] == "https://graph.microsoft.com/delta-token-1"
+            finally:
+                await c.close()
+
+    async def test_delta_resume_uses_stored_link(self) -> None:
+        delta_pages: dict[str, list[dict]] = {
+            "https://graph.microsoft.com/delta-resume": [
+                {
+                    "value": [_file_item("i3", "c.txt")],
+                    "@odata.deltaLink": "https://graph.microsoft.com/delta-token-2",
+                }
+            ],
+        }
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "Documents"}]},
+            delta_pages=delta_pages,
+        )
+        prior = json.dumps({"s1/d1": "https://graph.microsoft.com/delta-resume"})
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), prior)]
+                assert [r.metadata["item_id"] for r in refs] == ["i3"]
+            finally:
+                await c.close()
+
+    async def test_delta_paginates_via_nextlink(self) -> None:
+        delta_pages = {
+            "/v1.0/sites/s1/drives/d1/root/delta": [
+                {
+                    "value": [_file_item("i1", "a.txt")],
+                    "@odata.nextLink": "https://graph.microsoft.com/page2",
+                }
+            ],
+            "https://graph.microsoft.com/page2": [
+                {
+                    "value": [_file_item("i2", "b.txt")],
+                    "@odata.deltaLink": "https://graph.microsoft.com/end",
+                }
+            ],
+        }
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "Documents"}]},
+            delta_pages=delta_pages,
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert {r.metadata["item_id"] for r in refs} == {"i1", "i2"}
+            finally:
+                await c.close()
+
+    async def test_resume_invalid_cursor_falls_back(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "Documents"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [_file_item("i1", "a.txt")],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                # malformed cursor: not JSON
+                refs = [r async for r in c.discover(SourceFilter(), "not-json")]
+                assert len(refs) == 1
+            finally:
+                await c.close()
+
+    async def test_cursor_after_run_returns_none_when_empty(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": []},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                assert c.cursor_after_run() is None
+            finally:
+                await c.close()
+
+
+# --- lists --------------------------------------------------------
+
+
+class TestLists:
+    async def test_include_lists_yields_list_item_refs(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": []},
+            lists_by_site={
+                "s1": [{"id": "L1", "displayName": "Tasks"}],
+            },
+            list_items={
+                "L1": [
+                    {
+                        "id": "11",
+                        "eTag": '"x"',
+                        "lastModifiedDateTime": "2024-01-02T00:00:00Z",
+                    },
+                    {"id": "12"},
+                ]
+            },
+            list_item_detail={
+                "11": {
+                    "fields": {
+                        "Title": "Buy milk",
+                        "AssignedTo": "alice@example.com",
+                        "@odata.etag": "skip-me",
+                        "_internal": "skip-me",
+                    }
+                }
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t",
+                    client_id="c",
+                    client_secret="s",
+                    include_lists=True,
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert all(r.metadata["kind"] == "list_item" for r in refs)
+                assert {r.metadata["item_id"] for r in refs} == {"11", "12"}
+                # Path includes the site / lists / list-name / item-id form.
+                assert any("TeamA/lists/Tasks/11" in r.path for r in refs)
+                target = next(r for r in refs if r.metadata["item_id"] == "11")
+                docs = [d async for d in c.fetch(target)]
+                assert isinstance(docs[0], Document)
+                assert "Title=Buy milk" in docs[0].text
+                assert "AssignedTo=alice@example.com" in docs[0].text
+                # @odata / _ prefixed bookkeeping skipped.
+                assert "@odata.etag" not in docs[0].text
+                assert "_internal" not in docs[0].text
+            finally:
+                await c.close()
+
+    async def test_include_lists_default_off(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": []},
+            lists_by_site={"s1": [{"id": "L1", "displayName": "T"}]},
+            list_items={"L1": [{"id": "1"}]},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs == []
+            finally:
+                await c.close()
+
+
+# --- fetch --------------------------------------------------------
+
+
+class TestFetch:
+    async def test_fetch_text_file(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "Docs"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [_file_item("i1", "a.txt", size=4)],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+            file_content={"i1": b"hi!\n"},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                docs = [d async for d in c.fetch(refs[0])]
+                assert len(docs) == 1
+                assert isinstance(docs[0], Document)
+                assert docs[0].text == "hi!\n"
+                assert docs[0].binary is None
+                assert docs[0].content_hash == '"e"'
+            finally:
+                await c.close()
+
+    async def test_fetch_binary_file(self) -> None:
+        item = _file_item("ix", "img.bin", size=4)
+        item["file"] = {"mimeType": "application/octet-stream"}
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "Docs"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [item],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+            file_content={"ix": b"\x00\x01\x02\x03"},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                docs = [d async for d in c.fetch(refs[0])]
+                assert docs[0].binary == b"\x00\x01\x02\x03"
+                assert docs[0].text is None
+            finally:
+                await c.close()
+
+    async def test_fetch_text_falls_back_to_binary_on_decode_failure(self) -> None:
+        # text/* MIME but invalid UTF-8 — must not crash.
+        item = _file_item("ib", "bad.txt", size=2)
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [item],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+            file_content={"ib": b"\xff\xfe"},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                docs = [d async for d in c.fetch(refs[0])]
+                assert docs[0].binary == b"\xff\xfe"
+            finally:
+                await c.close()
+
+    async def test_max_file_size_skips_fetch(self) -> None:
+        # Ref still emitted by discover; fetch yields nothing.
+        big = _file_item("big", "huge.txt", size=200)
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [big],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+            file_content={"big": b"x" * 200},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t",
+                    client_id="c",
+                    client_secret="s",
+                    max_file_size_bytes=100,
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert len(refs) == 1
+                docs = [d async for d in c.fetch(refs[0])]
+                assert docs == []
+            finally:
+                await c.close()
+
+    async def test_fetch_unknown_kind_no_op(self) -> None:
+        from pleno_pii_scanner.sources.base import DocumentRef
+
+        async with _client(_make_handler()) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="x")
+                docs = [d async for d in c.fetch(ref)]
+                assert docs == []
+            finally:
+                await c.close()
+
+    async def test_fetch_file_missing_metadata_no_op(self) -> None:
+        from pleno_pii_scanner.sources.base import DocumentRef
+
+        async with _client(_make_handler()) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                ref = DocumentRef(
+                    source_id=c.id,
+                    source_kind=c.kind,
+                    path="x",
+                    metadata={"kind": "file"},
+                )
+                docs = [d async for d in c.fetch(ref)]
+                assert docs == []
+            finally:
+                await c.close()
+
+    async def test_fetch_list_item_missing_metadata_no_op(self) -> None:
+        from pleno_pii_scanner.sources.base import DocumentRef
+
+        async with _client(_make_handler()) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                ref = DocumentRef(
+                    source_id=c.id,
+                    source_kind=c.kind,
+                    path="x",
+                    metadata={"kind": "list_item"},
+                )
+                docs = [d async for d in c.fetch(ref)]
+                assert docs == []
+            finally:
+                await c.close()
+
+    async def test_fetch_list_item_non_mapping_fields(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": []},
+            lists_by_site={"s1": [{"id": "L1", "displayName": "T"}]},
+            list_items={"L1": [{"id": "1"}]},
+            list_item_detail={"1": {"fields": "junk"}},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t",
+                    client_id="c",
+                    client_secret="s",
+                    include_lists=True,
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                docs = [d async for d in c.fetch(refs[0])]
+                # Non-mapping fields → empty serialised body, but Document
+                # still requires text XOR binary; we hit text="".
+                assert docs[0].text == ""
+            finally:
+                await c.close()
+
+
+# --- sites allowlist ---------------------------------------------
+
+
+class TestSitesAllowlist:
+    async def test_explicit_id_skips_search(self) -> None:
+        seen_search = {"hit": False}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            path = request.url.path
+            if "login.microsoftonline" in url:
+                return _ok_token(request)
+            if path == "/v1.0/sites" and request.url.params.get("search"):
+                seen_search["hit"] = True
+                return httpx.Response(500)
+            if path.startswith("/v1.0/sites/site-pin/drives"):
+                return httpx.Response(200, json={"value": []})
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t",
+                    client_id="c",
+                    client_secret="s",
+                    sites=("site-pin",),
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                assert not seen_search["hit"]
+            finally:
+                await c.close()
+
+    async def test_path_form_resolves_via_graph(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            path = request.url.path
+            if "login.microsoftonline" in url:
+                return _ok_token(request)
+            if path == "/v1.0/sites/contoso.sharepoint.com:/sites/team":
+                return httpx.Response(
+                    200, json={"id": "resolved-1", "name": "team"}
+                )
+            if path.startswith("/v1.0/sites/resolved-1/drives"):
+                return httpx.Response(200, json={"value": []})
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t",
+                    client_id="c",
+                    client_secret="s",
+                    sites=("contoso.sharepoint.com:/sites/team",),
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs == []  # no drives in this fixture
+            finally:
+                await c.close()
+
+
+# --- filter -------------------------------------------------------
+
+
+class TestFilter:
+    async def test_include_exclude(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [
+                            _file_item("i1", "keep.txt"),
+                            _file_item("i2", "drop.txt"),
+                        ],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(include=("*keep*",)), None
+                    )
+                ]
+                assert {r.metadata["name"] for r in refs} == {"keep.txt"}
+            finally:
+                await c.close()
+        async with _client(handler) as client2:
+            handler2 = _make_handler(
+                sites=[{"id": "s1", "name": "TeamA"}],
+                drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+                delta_pages={
+                    "/v1.0/sites/s1/drives/d1/root/delta": [
+                        {
+                            "value": [
+                                _file_item("i1", "keep.txt"),
+                                _file_item("i2", "drop.txt"),
+                            ],
+                            "@odata.deltaLink": "https://graph.microsoft.com/end",
+                        }
+                    ]
+                },
+            )
+            client2 = httpx.AsyncClient(
+                base_url="https://graph.microsoft.com",
+                transport=httpx.MockTransport(handler2),
+            )
+            c2 = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client2,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c2.discover(
+                        SourceFilter(exclude=("*drop*",)), None
+                    )
+                ]
+                assert {r.metadata["name"] for r in refs} == {"keep.txt"}
+            finally:
+                await c2.close()
+                await client2.aclose()
+
+    async def test_list_filter_excludes_items(self) -> None:
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": []},
+            lists_by_site={"s1": [{"id": "L1", "displayName": "Tasks"}]},
+            list_items={"L1": [{"id": "1"}]},
+            list_item_detail={"1": {"fields": {"Title": "x"}}},
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t",
+                    client_id="c",
+                    client_secret="s",
+                    include_lists=True,
+                ),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(exclude=("TeamA/lists/*",)), None
+                    )
+                ]
+                assert refs == []
+            finally:
+                await c.close()
+
+
+# --- ref edge cases ----------------------------------------------
+
+
+class TestRefEdges:
+    async def test_file_without_parent_path(self) -> None:
+        item = _file_item("io", "orphan.txt")
+        item["parentReference"] = {}
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [item],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs[0].path == "TeamA/D/orphan.txt"
+            finally:
+                await c.close()
+
+    async def test_file_invalid_size_and_dates(self) -> None:
+        item = _file_item("inv", "a.txt")
+        item["size"] = "not-a-number"
+        item["lastModifiedDateTime"] = "garbage"
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [item],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs[0].size is None
+                assert refs[0].last_modified is None
+            finally:
+                await c.close()
+
+    async def test_uses_ctag_when_etag_missing(self) -> None:
+        item = _file_item("ic", "a.txt")
+        del item["eTag"]
+        item["cTag"] = '"c-only"'
+        handler = _make_handler(
+            sites=[{"id": "s1", "name": "TeamA"}],
+            drives_by_site={"s1": [{"id": "d1", "name": "D"}]},
+            delta_pages={
+                "/v1.0/sites/s1/drives/d1/root/delta": [
+                    {
+                        "value": [item],
+                        "@odata.deltaLink": "https://graph.microsoft.com/end",
+                    }
+                ]
+            },
+        )
+        async with _client(handler) as client:
+            c = SharePointConnector(
+                SharePointConfig(
+                    tenant_id="t", client_id="c", client_secret="s"
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs[0].etag == '"c-only"'
+            finally:
+                await c.close()
+
+
+# --- spec / factory ----------------------------------------------
+
+
+class TestSpec:
+    def test_metadata(self) -> None:
+        assert SPEC.kind == "sharepoint"
+        assert SPEC.version == "0.1.0"
+        assert "Sites.Selected" in SPEC.required_scopes
+        assert "Files.Read.All" in SPEC.required_scopes
+        assert SPEC.capabilities.incremental
+        assert SPEC.capabilities.binary
+        assert SPEC.capabilities.content_hash_delta
+
+    def test_factory_minimal(self) -> None:
+        register(SPEC)
+        c = create(
+            "sharepoint",
+            {
+                "tenant_id": "t",
+                "client_id": "c",
+                "client_secret": "s",
+            },
+        )
+        assert isinstance(c, SharePointConnector)
+
+    def test_factory_full(self) -> None:
+        register(SPEC)
+        c = create(
+            "sharepoint",
+            {
+                "tenant_id": "t",
+                "client_id": "c",
+                "federated_token": "JWT",
+                "sites": ["s1", "s2"],
+                "include_lists": True,
+                "max_file_size_bytes": 1024,
+                "id": "explicit",
+            },
+        )
+        assert c.id == "explicit"
+
+    def test_factory_rejects_missing_tenant(self) -> None:
+        with pytest.raises(ValueError, match="tenant_id"):
+            SPEC.factory({"client_id": "c", "client_secret": "s"})
+
+    def test_factory_rejects_missing_client(self) -> None:
+        with pytest.raises(ValueError, match="client_id"):
+            SPEC.factory({"tenant_id": "t", "client_secret": "s"})
+
+
+# --- close --------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_owns_client(self) -> None:
+        c = SharePointConnector(
+            SharePointConfig(
+                tenant_id="t", client_id="c", client_secret="s"
+            )
+        )
+        await c.close()
+
+    async def test_close_external_client_not_closed(self) -> None:
+        client = httpx.AsyncClient()
+        c = SharePointConnector(
+            SharePointConfig(
+                tenant_id="t", client_id="c", client_secret="s"
+            ),
+            client=client,
+        )
+        await c.close()
+        assert not client.is_closed
+        await client.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,6 @@ members = [
     "pleno-pii-scanner-bitbucket",
     "pleno-pii-scanner-ci-logs",
     "pleno-pii-scanner-discord",
-    "pleno-pii-scanner-elasticsearch",
     "pleno-pii-scanner-gcs",
     "pleno-pii-scanner-github",
     "pleno-pii-scanner-gitlab",
@@ -3550,35 +3549,6 @@ dev = [
 name = "pleno-pii-scanner-discord"
 version = "0.1.0"
 source = { editable = "packages/pii-scanner-discord" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pleno-pii-scanner" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "pleno-pii-scanner", editable = "packages/pii-scanner" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "pytest-cov", specifier = ">=5.0" },
-]
-
-[[package]]
-name = "pleno-pii-scanner-elasticsearch"
-version = "0.1.0"
-source = { editable = "packages/pii-scanner-elasticsearch" }
 dependencies = [
     { name = "httpx" },
     { name = "pleno-pii-scanner" },


### PR DESCRIPTION
- httpx.MockTransport hermetic suite (42 tests, 99% cov)
- Microsoft Graph /sites + /drives + /root/delta enumeration
- Sites.Selected scope; client_secret OR federated_token (jwt-bearer WIF)
- Per-drive deltaLink persisted as JSON cursor for incremental resume
- include_lists=True yields list-item refs with fields serialised
- max_file_size_bytes skips fetch for oversize refs (still surfaced)
- content_hash_delta=True via eTag/cTag carried on every ref
