### PR TITLE
feat(pii-scanner-bigquery): TABLESAMPLE + dry_run cost cap + WIF (#39, ADR §16)

### DIFF
--- a/packages/pii-scanner-bigquery/README.md
+++ b/packages/pii-scanner-bigquery/README.md
@@ -1,0 +1,56 @@
+# pleno-pii-scanner-bigquery
+
+Google BigQuery `SourceConnector` for [pleno-pii-scanner](../pii-scanner/).
+
+BigQuery warehouses concentrate analytics data — production exports,
+event logs, joined identity tables — and a single misconfigured share
+can leak millions of customer records. This connector samples each
+table, lets the scanner inspect row content, and refuses to issue
+queries that would burn unbounded warehouse cost.
+
+## Why TABLESAMPLE
+
+Full-table scans against a 10 TB events table cost more than the
+entire scanner's quarterly budget and provide no extra signal once
+PII is densely present. `TABLESAMPLE SYSTEM (n PERCENT)` reads a
+deterministic block-level subset — the same sample on repeat scans
+when the table has not been re-clustered — at a fraction of the cost.
+We omit the clause when `sample_percent=100` so partition-pruning
+and clustered reads still apply.
+
+## Why dry-run cost cap
+
+BigQuery bills by `bytesProcessed`. A single query against an
+unpartitioned wide table can cost thousands of dollars. The
+connector runs every query through `jobs.insert?dryRun=true` first,
+reads `totalBytesProcessed` from the response, and refuses to
+execute when the projection exceeds `max_bytes_billed`
+(default 100 GiB). The same cap is also passed to BigQuery as
+`maximumBytesBilled` so the warehouse refuses the job server-side
+even if the dry-run estimate slipped under the limit.
+
+## Auth
+
+Two modes, exactly one is required:
+
+- `service_account_json` — full SA key JSON (string). The connector
+  signs a JWT and exchanges it at the Google OAuth token endpoint.
+- `federated_token` — a Workload Identity Federation access token
+  that has already been exchanged externally (GitHub Actions OIDC,
+  EKS IRSA, etc.). The connector uses it directly as the bearer
+  without ever holding SA key material.
+
+The minimum IAM scope is `https://www.googleapis.com/auth/bigquery.readonly`.
+
+## Config
+
+```toml
+[bigquery]
+project = "my-gcp-project"
+datasets = ["analytics", "marketing"]   # optional allowlist
+service_account_json = "${BQ_SA_JSON}"
+sample_percent = 1.0                     # TABLESAMPLE percent
+max_bytes_billed = 107374182400          # 100 GiB cap
+page_size = 1000
+location = "US"
+```

--- a/packages/pii-scanner-bigquery/pyproject.toml
+++ b/packages/pii-scanner-bigquery/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "pleno-pii-scanner-bigquery"
+version = "0.1.0"
+description = "Google BigQuery SourceConnector for pleno-pii-scanner (TABLESAMPLE + dry_run cost cap + WIF)"
+readme = "README.md"
+license = { text = "AGPL-3.0-or-later" }
+requires-python = ">=3.12"
+authors = [{ name = "pleno", email = "ai@egahika.dev" }]
+keywords = ["pii", "bigquery", "scanner", "google-cloud"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+]
+dependencies = [
+    "httpx>=0.27",
+    "pleno-pii-scanner",
+]
+
+[project.entry-points."pleno_pii_scanner.connectors"]
+bigquery = "pleno_pii_scanner_bigquery:SPEC"
+
+[project.urls]
+Homepage = "https://github.com/plenoai/pleno-anonymize"
+Source = "https://github.com/plenoai/pleno-anonymize"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
+]
+
+[tool.uv.sources]
+pleno-pii-scanner = { workspace = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pleno_pii_scanner_bigquery"]

--- a/packages/pii-scanner-bigquery/src/pleno_pii_scanner_bigquery/__init__.py
+++ b/packages/pii-scanner-bigquery/src/pleno_pii_scanner_bigquery/__init__.py
@@ -1,0 +1,15 @@
+"""Google BigQuery SourceConnector for pleno-pii-scanner (ADR-0007 §16)."""
+
+from pleno_pii_scanner_bigquery.connector import (
+    SPEC,
+    BigQueryConfig,
+    BigQueryConnector,
+    BigQueryCostCapExceeded,
+)
+
+__all__ = [
+    "SPEC",
+    "BigQueryConfig",
+    "BigQueryConnector",
+    "BigQueryCostCapExceeded",
+]

--- a/packages/pii-scanner-bigquery/src/pleno_pii_scanner_bigquery/connector.py
+++ b/packages/pii-scanner-bigquery/src/pleno_pii_scanner_bigquery/connector.py
@@ -1,0 +1,633 @@
+"""BigQuery SourceConnector — TABLESAMPLE + dry_run cost cap + WIF.
+
+Pipeline per scan:
+
+  1. Acquire OAuth bearer token. Two modes:
+     - `service_account_json`: sign a JWT with the SA private key, POST to
+       https://oauth2.googleapis.com/token (urn:ietf:params:oauth:grant-type:jwt-bearer)
+       and pull `access_token`.
+     - `federated_token`: a WIF-exchanged access token supplied by the
+       caller — used directly as the bearer. Lets ops keep SA key
+       material out of the scanner entirely.
+  2. List datasets in `project` via the BigQuery REST `datasets.list`
+     endpoint, OR honour an explicit `datasets` allowlist.
+  3. Per dataset, list tables via `tables.list`.
+  4. For each table, build a sampling SQL:
+       SELECT * FROM `project.dataset.table` TABLESAMPLE SYSTEM (n PERCENT)
+     The TABLESAMPLE clause is omitted when `sample_percent=100` so the
+     query stays partition-pruning-friendly for small / clustered tables.
+  5. Dry-run the SQL via `jobs.insert?dryRun=true`. Read
+     `totalBytesProcessed` from the response and raise
+     `BigQueryCostCapExceeded` when it exceeds `max_bytes_billed`.
+  6. Execute the query via `jobs.query`. Pass `maximumBytesBilled` so
+     the warehouse will also refuse the job server-side if the dry-run
+     estimate slipped past the cap (defence in depth).
+  7. Paginate through `jobs.getQueryResults` until `pageToken` runs out.
+  8. Yield one DocumentRef per row, path = "<dataset>/<table>/<row-index>".
+
+`fetch()` returns a Document whose text body is the row dict serialised
+as JSON keyed by the schema column names — keeps the body
+PII-detector-friendly while preserving column boundaries.
+
+Tests inject the bearer token via monkeypatching `_acquire_token` so we
+never have to construct a real RS256 JWT in unit tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from fnmatch import fnmatch
+from typing import Any
+
+import httpx
+
+from pleno_pii_scanner.sources.base import (
+    Capabilities,
+    Cursor,
+    Document,
+    DocumentChunk,
+    DocumentRef,
+    SourceConnector,
+    SourceFilter,
+)
+from pleno_pii_scanner.sources.registry import ConnectorSpec
+
+
+KIND = "bigquery"
+SCOPE = "https://www.googleapis.com/auth/bigquery.readonly"
+_API_BASE = "https://bigquery.googleapis.com/bigquery/v2"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+_DEFAULT_MAX_BYTES = 100 * 1024**3  # 100 GiB
+
+# JWT lifetime fed into the SA-key exchange. Google caps this at 1h;
+# 50 minutes leaves headroom against clock skew.
+_JWT_LIFETIME_SECS = 3000
+
+
+class BigQueryCostCapExceeded(RuntimeError):
+    """Raised when a query's dry-run cost estimate exceeds the cap.
+
+    Carries the query and the byte counts so operators can decide whether
+    to raise the cap, narrow the projection, or skip the table.
+    """
+
+    def __init__(
+        self,
+        *,
+        sql: str,
+        total_bytes_processed: int,
+        cap: int,
+    ) -> None:
+        super().__init__(
+            f"BigQuery dry-run estimate {total_bytes_processed:,}B exceeds "
+            f"cap {cap:,}B for query: {sql[:200]}"
+        )
+        self.sql = sql
+        self.total_bytes_processed = total_bytes_processed
+        self.cap = cap
+
+
+@dataclass(frozen=True, slots=True)
+class BigQueryConfig:
+    """Construction config for `BigQueryConnector`.
+
+    Exactly one of `service_account_json` / `federated_token` must be set.
+
+    `sample_percent` is the TABLESAMPLE percentage in the open-ended
+    interval (0, 100]. `max_bytes_billed` is the cost cap enforced both
+    via dry-run pre-check AND server-side `maximumBytesBilled`.
+    """
+
+    project: str
+    datasets: tuple[str, ...] = ()
+    service_account_json: str | None = None
+    federated_token: str | None = None
+    sample_percent: float = 1.0
+    max_bytes_billed: int = _DEFAULT_MAX_BYTES
+    page_size: int = 1000
+    location: str = "US"
+    id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.project:
+            raise ValueError("project must be non-empty")
+        # Exactly-one auth mode — both is ambiguous, neither is unauthenticated.
+        modes = sum(
+            1
+            for v in (self.service_account_json, self.federated_token)
+            if v
+        )
+        if modes == 0:
+            raise ValueError(
+                "exactly one of service_account_json or federated_token "
+                "must be provided"
+            )
+        if modes > 1:
+            raise ValueError(
+                "service_account_json and federated_token are mutually exclusive"
+            )
+        if not 0 < self.sample_percent <= 100:
+            raise ValueError("sample_percent must be in (0, 100]")
+        if self.max_bytes_billed < 1:
+            raise ValueError("max_bytes_billed must be >= 1")
+        if self.page_size < 1:
+            raise ValueError("page_size must be >= 1")
+
+    def resolved_id(self) -> str:
+        if self.id is not None:
+            return self.id
+        # Hash project + dataset allowlist so we get a stable id without
+        # leaking SA key material into ops-visible identifiers.
+        import hashlib
+
+        h = hashlib.sha256()
+        h.update(self.project.encode())
+        for ds in sorted(self.datasets):
+            h.update(b"\0")
+            h.update(ds.encode())
+        return f"bigquery:{h.hexdigest()[:16]}"
+
+
+class BigQueryConnector:
+    """Read-only SourceConnector for Google BigQuery."""
+
+    kind = KIND
+
+    def __init__(
+        self,
+        config: BigQueryConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self.id = config.resolved_id()
+        if client is None:
+            self._client = httpx.AsyncClient(timeout=60.0)
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+        # Cached bearer token — refreshed lazily when expired.
+        self._token: str | None = None
+        self._token_expires_at: float = 0.0
+        # Per-row text cache so fetch() does not re-issue a query.
+        self._documents: dict[str, str] = {}
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(
+            incremental=False,
+            binary=False,
+            content_hash_delta=False,
+            max_concurrent_fetches=2,
+            streaming=False,
+        )
+
+    async def discover(
+        self,
+        filter: SourceFilter,
+        cursor: Cursor | None,
+    ) -> AsyncIterator[DocumentRef]:
+        del cursor  # incremental=False; cursor is informational only
+        token = await self._acquire_token()
+        datasets = await self._list_datasets(token)
+        for dataset in datasets:
+            tables = await self._list_tables(token, dataset)
+            for table in tables:
+                async for ref in self._scan_table(
+                    token=token,
+                    dataset=dataset,
+                    table=table,
+                    filter=filter,
+                ):
+                    yield ref
+
+    async def fetch(
+        self,
+        ref: DocumentRef,
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        text = self._documents.get(ref.path)
+        if text is None:
+            return
+        yield Document(
+            ref=ref,
+            text=text,
+            fetched_at=datetime.now(UTC),
+            extra=dict(ref.metadata),
+        )
+
+    async def close(self) -> None:
+        self._documents.clear()
+        if self._owns_client:
+            await self._client.aclose()
+
+    # --- discovery internals ----------------------------------------
+
+    async def _list_datasets(self, token: str) -> list[str]:
+        # Allowlist short-circuits the API call — also lets operators
+        # scan a project they don't have datasets.list permission on.
+        if self._config.datasets:
+            return list(self._config.datasets)
+        url = f"{_API_BASE}/projects/{self._config.project}/datasets"
+        out: list[str] = []
+        page_token: str | None = None
+        while True:
+            params: dict[str, str] = {}
+            if page_token:
+                params["pageToken"] = page_token
+            body = await self._authed_get_json(token, url, params=params)
+            for item in body.get("datasets", []) or []:
+                ref = item.get("datasetReference") or {}
+                ds_id = ref.get("datasetId")
+                if ds_id:
+                    out.append(ds_id)
+            page_token = body.get("nextPageToken")
+            if not page_token:
+                break
+        return out
+
+    async def _list_tables(self, token: str, dataset: str) -> list[str]:
+        url = (
+            f"{_API_BASE}/projects/{self._config.project}"
+            f"/datasets/{dataset}/tables"
+        )
+        out: list[str] = []
+        page_token: str | None = None
+        while True:
+            params: dict[str, str] = {}
+            if page_token:
+                params["pageToken"] = page_token
+            body = await self._authed_get_json(token, url, params=params)
+            for item in body.get("tables", []) or []:
+                ref = item.get("tableReference") or {}
+                t_id = ref.get("tableId")
+                if t_id:
+                    out.append(t_id)
+            page_token = body.get("nextPageToken")
+            if not page_token:
+                break
+        return out
+
+    def _build_sql(self, dataset: str, table: str) -> str:
+        # 100% sampling defeats the purpose of TABLESAMPLE and prevents
+        # partition-pruning. Same for the historical 1.0 ratio (some
+        # callers pass a fraction by accident — treat it as 1%).
+        fqn = f"`{self._config.project}.{dataset}.{table}`"
+        if self._config.sample_percent >= 100.0:
+            return f"SELECT * FROM {fqn}"
+        return (
+            f"SELECT * FROM {fqn} "
+            f"TABLESAMPLE SYSTEM ({self._config.sample_percent} PERCENT)"
+        )
+
+    async def _scan_table(
+        self,
+        *,
+        token: str,
+        dataset: str,
+        table: str,
+        filter: SourceFilter,
+    ) -> AsyncIterator[DocumentRef]:
+        sql = self._build_sql(dataset, table)
+        # Cost cap — pre-flight dry-run.
+        await self._dry_run_or_raise(token, sql)
+        # Execute query (jobs.query) and paginate through getQueryResults.
+        first_url = f"{_API_BASE}/projects/{self._config.project}/queries"
+        page = await self._authed_post_json(
+            token,
+            first_url,
+            json_body={
+                "query": sql,
+                "maxResults": self._config.page_size,
+                "useLegacySql": False,
+                "maximumBytesBilled": str(self._config.max_bytes_billed),
+                "location": self._config.location,
+            },
+        )
+        # Schema is returned only on the first page — cache it so
+        # subsequent getQueryResults calls (which sometimes elide the
+        # schema) can still project rows by column name.
+        schema = page.get("schema") or {}
+        job_ref = page.get("jobReference") or {}
+        job_id = job_ref.get("jobId")
+        row_index = 0
+        while True:
+            async for ref in self._yield_page(
+                dataset=dataset,
+                table=table,
+                page=page,
+                filter=filter,
+                start_index=row_index,
+                schema=schema,
+            ):
+                yield ref
+            row_index += self._page_row_count(page)
+            page_token = page.get("pageToken")
+            if not page_token or not job_id:
+                return
+            page_url = (
+                f"{_API_BASE}/projects/{self._config.project}"
+                f"/queries/{job_id}"
+            )
+            params: dict[str, str] = {
+                "pageToken": page_token,
+                "maxResults": str(self._config.page_size),
+            }
+            location = job_ref.get("location") or self._config.location
+            if location:
+                params["location"] = location
+            page = await self._authed_get_json(
+                token, page_url, params=params
+            )
+
+    @staticmethod
+    def _page_row_count(page: Mapping[str, Any]) -> int:
+        rows = page.get("rows") or []
+        return len(rows)
+
+    async def _yield_page(
+        self,
+        *,
+        dataset: str,
+        table: str,
+        page: Mapping[str, Any],
+        filter: SourceFilter,
+        start_index: int,
+        schema: Mapping[str, Any] | None = None,
+    ) -> AsyncIterator[DocumentRef]:
+        # Prefer the page's own schema when present (first page); fall
+        # back to the cached schema captured at scan start.
+        page_schema = page.get("schema") or schema or {}
+        fields = page_schema.get("fields") or []
+        column_names = [f.get("name", f"col_{i}") for i, f in enumerate(fields)]
+        rows = page.get("rows") or []
+        for offset, row in enumerate(rows):
+            idx = start_index + offset
+            full = f"{dataset}/{table}/{idx}"
+            if filter.include and not _matches_any(full, filter.include):
+                continue
+            if filter.exclude and _matches_any(full, filter.exclude):
+                continue
+            row_dict = _project_row(row, column_names)
+            text = json.dumps(row_dict, ensure_ascii=False, default=str)
+            self._documents[full] = text
+            yield DocumentRef(
+                source_id=self.id,
+                source_kind=self.kind,
+                path=full,
+                content_type="application/json",
+                size=len(text),
+                metadata={
+                    "bq_project": self._config.project,
+                    "bq_dataset": dataset,
+                    "bq_table": table,
+                    "row_index": str(idx),
+                },
+            )
+
+    async def _dry_run_or_raise(self, token: str, sql: str) -> None:
+        url = (
+            f"{_API_BASE}/projects/{self._config.project}/jobs?dryRun=true"
+        )
+        # `jobs.insert` (not jobs.query) is the dry-run-supporting endpoint.
+        body = await self._authed_post_json(
+            token,
+            url,
+            json_body={
+                "configuration": {
+                    "query": {
+                        "query": sql,
+                        "useLegacySql": False,
+                    },
+                    "dryRun": True,
+                }
+            },
+        )
+        # Response shape: {"statistics": {"totalBytesProcessed": "1234", ...}}
+        # Fall through silently when the API returns a number directly
+        # (some unit-test mocks do this).
+        stats = body.get("statistics") or {}
+        raw = stats.get("totalBytesProcessed", body.get("totalBytesProcessed", 0))
+        try:
+            total = int(raw)
+        except (TypeError, ValueError):
+            total = 0
+        if total > self._config.max_bytes_billed:
+            raise BigQueryCostCapExceeded(
+                sql=sql,
+                total_bytes_processed=total,
+                cap=self._config.max_bytes_billed,
+            )
+
+    # --- token internals --------------------------------------------
+
+    async def _acquire_token(self) -> str:
+        """Return a usable bearer token, refreshing when expired.
+
+        Two paths:
+          * federated_token shortcut — already-exchanged WIF token.
+            We treat it as long-lived enough for one scan; rotation is
+            the caller's problem (typical WIF lifetime is 1h).
+          * service_account_json — sign + exchange a JWT.
+
+        Tests monkeypatch this entire method to skip JWT signing.
+        """
+        now = time.time()
+        if self._token and now < self._token_expires_at - 30:
+            return self._token
+        if self._config.federated_token:
+            self._token = self._config.federated_token
+            # Federated tokens don't expose lifetime in the wire here;
+            # cache for an hour, which is the GCP STS default.
+            self._token_expires_at = now + 3600
+            return self._token
+        # SA key flow.
+        assert self._config.service_account_json is not None
+        sa_data = json.loads(self._config.service_account_json)
+        jwt = _sign_sa_jwt(sa_data, scope=SCOPE, lifetime_secs=_JWT_LIFETIME_SECS)
+        resp = await self._client.post(
+            _TOKEN_URL,
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "assertion": jwt,
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        token = body.get("access_token")
+        if not token:
+            raise RuntimeError("token endpoint returned no access_token")
+        self._token = token
+        self._token_expires_at = now + int(body.get("expires_in", 3600))
+        return token
+
+    # --- HTTP internals ---------------------------------------------
+
+    async def _authed_get_json(
+        self,
+        token: str,
+        url: str,
+        *,
+        params: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        resp = await self._client.get(
+            url,
+            params=params,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _authed_post_json(
+        self,
+        token: str,
+        url: str,
+        *,
+        json_body: Any,
+    ) -> dict[str, Any]:
+        resp = await self._client.post(
+            url,
+            json=json_body,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# --- helpers --------------------------------------------------------
+
+
+def _matches_any(s: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch(s, p) for p in patterns)
+
+
+def _project_row(
+    row: Mapping[str, Any], column_names: list[str]
+) -> dict[str, Any]:
+    """Project a BigQuery row (`{"f": [{"v": ...}, ...]}`) to a dict.
+
+    BigQuery's REST API returns rows in a column-positional shape; we
+    re-assemble them into a name->value dict so the JSON body the
+    scanner sees is column-aware.
+    """
+    cells = row.get("f") if isinstance(row, Mapping) else None
+    if not isinstance(cells, list):
+        return {}
+    out: dict[str, Any] = {}
+    for i, cell in enumerate(cells):
+        if i >= len(column_names):
+            break
+        if isinstance(cell, Mapping):
+            out[column_names[i]] = cell.get("v")
+        else:
+            out[column_names[i]] = None
+    return out
+
+
+def _sign_sa_jwt(
+    sa_data: Mapping[str, Any], *, scope: str, lifetime_secs: int
+) -> str:
+    """Sign a Google service-account JWT (RS256).
+
+    Keeps the dependency surface to stdlib + cryptography (which httpx
+    already pulls transitively via certifi-of-something? — no, we need
+    to import it lazily to avoid forcing the dep when only WIF is
+    used).
+    """
+    # Lazy import so federated-token-only deployments don't require
+    # `cryptography` at install time.
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    iat = int(time.time())
+    exp = iat + lifetime_secs
+    header = {"alg": "RS256", "typ": "JWT", "kid": sa_data.get("private_key_id")}
+    payload = {
+        "iss": sa_data.get("client_email"),
+        "scope": scope,
+        "aud": _TOKEN_URL,
+        "iat": iat,
+        "exp": exp,
+    }
+    seg_h = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    seg_p = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{seg_h}.{seg_p}".encode()
+    private_key_pem = sa_data["private_key"].encode()
+    private_key = serialization.load_pem_private_key(
+        private_key_pem, password=None
+    )
+    signature = private_key.sign(
+        signing_input, padding.PKCS1v15(), hashes.SHA256()
+    )
+    return f"{seg_h}.{seg_p}.{_b64url(signature)}"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+# --- factory / spec -------------------------------------------------
+
+
+def _factory(config: Mapping[str, Any]) -> SourceConnector:
+    if "project" not in config:
+        raise ValueError("bigquery connector config requires 'project'")
+    return BigQueryConnector(
+        BigQueryConfig(
+            project=str(config["project"]),
+            datasets=tuple(str(d) for d in config.get("datasets", ()) or ()),
+            service_account_json=_opt_str(config, "service_account_json"),
+            federated_token=_opt_str(config, "federated_token"),
+            sample_percent=float(config.get("sample_percent", 1.0)),
+            max_bytes_billed=int(
+                config.get("max_bytes_billed", _DEFAULT_MAX_BYTES)
+            ),
+            page_size=int(config.get("page_size", 1000)),
+            location=str(config.get("location", "US")),
+            id=_opt_str(config, "id"),
+        )
+    )
+
+
+def _opt_str(config: Mapping[str, Any], key: str) -> str | None:
+    value = config.get(key)
+    return str(value) if value is not None else None
+
+
+SPEC = ConnectorSpec(
+    kind=KIND,
+    version="0.1.0",
+    factory=_factory,
+    capabilities=Capabilities(
+        incremental=False,
+        binary=False,
+        content_hash_delta=False,
+        max_concurrent_fetches=2,
+        streaming=False,
+    ),
+    required_scopes=(SCOPE,),
+    description=(
+        "Google BigQuery SourceConnector. Lists datasets + tables, "
+        "samples each table via TABLESAMPLE SYSTEM, refuses queries "
+        "whose dry-run cost estimate exceeds max_bytes_billed, and "
+        "supports both service-account JSON keys and pre-exchanged "
+        "Workload Identity Federation tokens."
+    ),
+)
+
+
+__all__ = [
+    "BigQueryConfig",
+    "BigQueryConnector",
+    "BigQueryCostCapExceeded",
+    "KIND",
+    "SCOPE",
+    "SPEC",
+]

--- a/packages/pii-scanner-bigquery/tests/test_connector.py
+++ b/packages/pii-scanner-bigquery/tests/test_connector.py
@@ -1,0 +1,943 @@
+"""Tests for BigQueryConnector — hermetic via httpx.MockTransport.
+
+Bearer-token acquisition is monkeypatched on `_acquire_token` so we
+never have to construct a real RS256 JWT in unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from pleno_pii_scanner.sources import (
+    Capabilities,
+    Document,
+    SourceConnector,
+    SourceFilter,
+    create,
+    register,
+)
+from pleno_pii_scanner.sources import registry as _registry_mod
+from pleno_pii_scanner_bigquery import (
+    SPEC,
+    BigQueryConfig,
+    BigQueryConnector,
+    BigQueryCostCapExceeded,
+)
+from pleno_pii_scanner_bigquery import connector as _conn_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(_registry_mod, "entry_points", lambda **_: [])
+    _registry_mod._reset_for_tests()
+    yield
+    _registry_mod._reset_for_tests()
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _stub_token(c: BigQueryConnector, value: str = "test-token") -> None:
+    """Pin the bearer token without forcing the real JWT/STS exchange."""
+
+    async def _acq() -> str:
+        return value
+
+    c._acquire_token = _acq  # type: ignore[method-assign]
+
+
+# --- config --------------------------------------------------------
+
+
+class TestConfig:
+    def test_rejects_empty_project(self) -> None:
+        with pytest.raises(ValueError, match="project"):
+            BigQueryConfig(project="", federated_token="t")
+
+    def test_rejects_neither_auth(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            BigQueryConfig(project="p")
+
+    def test_rejects_both_auth(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            BigQueryConfig(
+                project="p",
+                service_account_json="{}",
+                federated_token="t",
+            )
+
+    def test_rejects_zero_sample(self) -> None:
+        with pytest.raises(ValueError, match="sample_percent"):
+            BigQueryConfig(project="p", federated_token="t", sample_percent=0)
+
+    def test_rejects_oversized_sample(self) -> None:
+        with pytest.raises(ValueError, match="sample_percent"):
+            BigQueryConfig(
+                project="p", federated_token="t", sample_percent=200
+            )
+
+    def test_rejects_zero_max_bytes(self) -> None:
+        with pytest.raises(ValueError, match="max_bytes_billed"):
+            BigQueryConfig(
+                project="p", federated_token="t", max_bytes_billed=0
+            )
+
+    def test_rejects_zero_page_size(self) -> None:
+        with pytest.raises(ValueError, match="page_size"):
+            BigQueryConfig(project="p", federated_token="t", page_size=0)
+
+    def test_explicit_id(self) -> None:
+        cfg = BigQueryConfig(project="p", federated_token="t", id="x")
+        assert cfg.resolved_id() == "x"
+
+    def test_default_id_no_secret_leak(self) -> None:
+        cfg = BigQueryConfig(
+            project="p",
+            federated_token="VERY-SECRET-TOKEN",
+            datasets=("d1", "d2"),
+        )
+        rid = cfg.resolved_id()
+        assert "VERY-SECRET-TOKEN" not in rid
+        assert rid.startswith("bigquery:")
+
+    def test_default_id_dataset_order_independent(self) -> None:
+        a = BigQueryConfig(
+            project="p", federated_token="t", datasets=("a", "b")
+        )
+        b = BigQueryConfig(
+            project="p", federated_token="t", datasets=("b", "a")
+        )
+        assert a.resolved_id() == b.resolved_id()
+
+
+# --- protocol ------------------------------------------------------
+
+
+class TestProtocol:
+    def test_runtime_isinstance(self) -> None:
+        c = BigQueryConnector(
+            BigQueryConfig(project="p", federated_token="t")
+        )
+        assert isinstance(c, SourceConnector)
+
+    def test_capabilities(self) -> None:
+        c = BigQueryConnector(
+            BigQueryConfig(project="p", federated_token="t")
+        )
+        assert c.capabilities() == Capabilities(
+            incremental=False,
+            binary=False,
+            content_hash_delta=False,
+            max_concurrent_fetches=2,
+            streaming=False,
+        )
+
+
+# --- token acquisition ---------------------------------------------
+
+
+class TestTokenAcquisition:
+    async def test_federated_token_shortcut(self) -> None:
+        # No HTTP needed for the shortcut path.
+        async with _client(lambda _r: httpx.Response(500)) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="WIF-TOKEN"),
+                client=client,
+            )
+            try:
+                tok = await c._acquire_token()
+                assert tok == "WIF-TOKEN"
+                # Cached on second call.
+                tok2 = await c._acquire_token()
+                assert tok2 == "WIF-TOKEN"
+            finally:
+                await c.close()
+
+    async def test_service_account_signing_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Monkeypatch _sign_sa_jwt so we don't pull in real RSA keys.
+        monkeypatch.setattr(
+            _conn_mod, "_sign_sa_jwt", lambda *_a, **_kw: "fake.jwt.signature"
+        )
+
+        captured: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["body"] = request.content.decode()
+            return httpx.Response(
+                200, json={"access_token": "exchanged-token", "expires_in": 3600}
+            )
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(
+                    project="p",
+                    service_account_json=json.dumps(
+                        {
+                            "client_email": "sa@p.iam.gserviceaccount.com",
+                            "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+                            "private_key_id": "kid-1",
+                        }
+                    ),
+                ),
+                client=client,
+            )
+            try:
+                tok = await c._acquire_token()
+                assert tok == "exchanged-token"
+                assert "oauth2.googleapis.com/token" in captured["url"]
+                assert "fake.jwt.signature" in captured["body"]
+                assert "jwt-bearer" in captured["body"]
+            finally:
+                await c.close()
+
+    async def test_service_account_token_endpoint_missing_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            _conn_mod, "_sign_sa_jwt", lambda *_a, **_kw: "fake.jwt"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={})  # no access_token field
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(
+                    project="p",
+                    service_account_json=json.dumps(
+                        {
+                            "client_email": "sa@p.iam.gserviceaccount.com",
+                            "private_key": "x",
+                            "private_key_id": "kid",
+                        }
+                    ),
+                ),
+                client=client,
+            )
+            try:
+                with pytest.raises(RuntimeError, match="no access_token"):
+                    await c._acquire_token()
+            finally:
+                await c.close()
+
+
+# --- discover / dataset listing -----------------------------------
+
+
+def _job_response(
+    *,
+    rows: list[dict] | None = None,
+    schema_fields: list[dict] | None = None,
+    page_token: str | None = None,
+    job_id: str = "job-1",
+    location: str = "US",
+) -> dict:
+    body: dict = {
+        "jobReference": {
+            "projectId": "p",
+            "jobId": job_id,
+            "location": location,
+        },
+        "schema": {"fields": schema_fields or [{"name": "col1", "type": "STRING"}]},
+        "rows": rows or [],
+    }
+    if page_token:
+        body["pageToken"] = page_token
+    return body
+
+
+def _dry_run_response(total_bytes: int = 1024) -> dict:
+    return {
+        "statistics": {"totalBytesProcessed": str(total_bytes)},
+    }
+
+
+class TestDiscoverDatasets:
+    async def test_lists_datasets_via_api(self) -> None:
+        sql_seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}},
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [
+                            {"tableReference": {"tableId": "t1"}},
+                        ]
+                    },
+                )
+            if "dryRun=true" in url:
+                payload = json.loads(request.content)
+                sql_seen.append(payload["configuration"]["query"]["query"])
+                return httpx.Response(200, json=_dry_run_response(1024))
+            if url.endswith("/queries"):
+                return httpx.Response(
+                    200,
+                    json=_job_response(
+                        rows=[{"f": [{"v": "alice"}]}],
+                    ),
+                )
+            return httpx.Response(404, content=url.encode())
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(
+                    project="p",
+                    federated_token="t",
+                    sample_percent=10.0,
+                ),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert len(refs) == 1
+                assert refs[0].path == "d1/t1/0"
+                # TABLESAMPLE included for sub-100 percent.
+                assert any("TABLESAMPLE SYSTEM" in s for s in sql_seen)
+            finally:
+                await c.close()
+
+    async def test_dataset_allowlist_skips_list_call(self) -> None:
+        api_calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            api_calls.append(url)
+            if url.endswith("/datasets"):
+                # Should NOT be called when allowlist is set.
+                return httpx.Response(500)
+            if url.endswith("/datasets/only/tables"):
+                return httpx.Response(
+                    200,
+                    json={"tables": []},
+                )
+            return httpx.Response(404, content=url.encode())
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(
+                    project="p",
+                    federated_token="t",
+                    datasets=("only",),
+                ),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs == []
+                assert not any(u.endswith("/datasets") for u in api_calls)
+            finally:
+                await c.close()
+
+    async def test_datasets_pagination(self) -> None:
+        # Cover the nextPageToken loop in _list_datasets and _list_tables.
+        ds_calls = {"n": 0}
+        table_calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if "/datasets/d1/tables" in url:
+                table_calls["n"] += 1
+                if "pageToken=tnext" in url:
+                    return httpx.Response(
+                        200,
+                        json={
+                            "tables": [
+                                {"tableReference": {"tableId": "t2"}}
+                            ]
+                        },
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [{"tableReference": {"tableId": "t1"}}],
+                        "nextPageToken": "tnext",
+                    },
+                )
+            if url.rstrip("?").endswith("/datasets") or (
+                "/datasets" in url and "/tables" not in url
+            ):
+                ds_calls["n"] += 1
+                if "pageToken=dnext" in url:
+                    return httpx.Response(
+                        200,
+                        json={
+                            "datasets": []  # tail page yields nothing
+                        },
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}},
+                            # Garbage entries skipped silently.
+                            {"datasetReference": {}},
+                            {},
+                        ],
+                        "nextPageToken": "dnext",
+                    },
+                )
+            if "dryRun=true" in url:
+                return httpx.Response(200, json=_dry_run_response(1))
+            if url.endswith("/queries"):
+                return httpx.Response(200, json=_job_response(rows=[]))
+            return httpx.Response(404, content=url.encode())
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs == []
+                assert ds_calls["n"] == 2
+                # 2 tables for d1 means 2 table-list calls.
+                assert table_calls["n"] == 2
+            finally:
+                await c.close()
+
+
+# --- TABLESAMPLE semantics ----------------------------------------
+
+
+class TestTableSampleClause:
+    def test_omitted_at_100_percent(self) -> None:
+        c = BigQueryConnector(
+            BigQueryConfig(
+                project="p", federated_token="t", sample_percent=100.0
+            )
+        )
+        sql = c._build_sql("d", "t")
+        assert "TABLESAMPLE" not in sql
+        assert "`p.d.t`" in sql
+
+    def test_included_below_100(self) -> None:
+        c = BigQueryConnector(
+            BigQueryConfig(
+                project="p", federated_token="t", sample_percent=5.0
+            )
+        )
+        sql = c._build_sql("d", "t")
+        assert "TABLESAMPLE SYSTEM (5.0 PERCENT)" in sql
+
+
+# --- dry-run cost cap ---------------------------------------------
+
+
+class TestDryRunCostCap:
+    async def test_raises_when_estimate_over_cap(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}}
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [
+                            {"tableReference": {"tableId": "huge"}}
+                        ]
+                    },
+                )
+            if "dryRun=true" in url:
+                # 10 GB estimate vs 1 KB cap.
+                return httpx.Response(
+                    200, json=_dry_run_response(10 * 1024**3)
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(
+                    project="p",
+                    federated_token="t",
+                    max_bytes_billed=1024,
+                ),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                with pytest.raises(BigQueryCostCapExceeded) as exc_info:
+                    _ = [r async for r in c.discover(SourceFilter(), None)]
+                assert exc_info.value.cap == 1024
+                assert exc_info.value.total_bytes_processed == 10 * 1024**3
+                assert "huge" in exc_info.value.sql
+            finally:
+                await c.close()
+
+    async def test_passes_when_estimate_under_cap(self) -> None:
+        # Exercises the "stats says 0 / unparseable" path too.
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}}
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [{"tableReference": {"tableId": "t1"}}]
+                    },
+                )
+            if "dryRun=true" in url:
+                # Garbage value → falls through to 0, well under cap.
+                return httpx.Response(
+                    200, json={"statistics": {"totalBytesProcessed": "not-a-number"}}
+                )
+            if url.endswith("/queries"):
+                return httpx.Response(200, json=_job_response(rows=[]))
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert refs == []
+            finally:
+                await c.close()
+
+
+# --- pagination ----------------------------------------------------
+
+
+class TestPagination:
+    async def test_paginates_query_results(self) -> None:
+        get_query_calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}}
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [
+                            {"tableReference": {"tableId": "t1"}}
+                        ]
+                    },
+                )
+            if "dryRun=true" in url:
+                return httpx.Response(200, json=_dry_run_response(1))
+            if url.endswith("/queries"):
+                # First page with token → triggers getQueryResults follow-up.
+                return httpx.Response(
+                    200,
+                    json=_job_response(
+                        rows=[
+                            {"f": [{"v": "row0"}]},
+                            {"f": [{"v": "row1"}]},
+                        ],
+                        page_token="next-1",
+                    ),
+                )
+            if "/queries/job-1" in url:
+                get_query_calls["n"] += 1
+                if "pageToken=next-1" in url:
+                    return httpx.Response(
+                        200,
+                        json=_job_response(
+                            rows=[{"f": [{"v": "row2"}]}],
+                            page_token="next-2",
+                            job_id="job-1",
+                        ),
+                    )
+                if "pageToken=next-2" in url:
+                    return httpx.Response(
+                        200,
+                        json=_job_response(
+                            rows=[{"f": [{"v": "row3"}]}],
+                            job_id="job-1",
+                        ),
+                    )
+            return httpx.Response(404, content=url.encode())
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert [r.path for r in refs] == [
+                    "d1/t1/0",
+                    "d1/t1/1",
+                    "d1/t1/2",
+                    "d1/t1/3",
+                ]
+                # Second + third pages each via getQueryResults.
+                assert get_query_calls["n"] == 2
+            finally:
+                await c.close()
+
+    async def test_no_job_id_aborts_after_first_page(self) -> None:
+        # Defensive: server returns a pageToken without a jobId — we
+        # cannot follow up, so we stop cleanly rather than 404-loop.
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}}
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [
+                            {"tableReference": {"tableId": "t1"}}
+                        ]
+                    },
+                )
+            if "dryRun=true" in url:
+                return httpx.Response(200, json=_dry_run_response(1))
+            if url.endswith("/queries"):
+                # pageToken set but jobReference missing — no follow-up.
+                return httpx.Response(
+                    200,
+                    json={
+                        "schema": {"fields": [{"name": "c"}]},
+                        "rows": [{"f": [{"v": "x"}]}],
+                        "pageToken": "next",
+                    },
+                )
+            return httpx.Response(404, content=url.encode())
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                # First page yielded once; pagination aborted gracefully.
+                assert [r.path for r in refs] == ["d1/t1/0"]
+            finally:
+                await c.close()
+
+
+# --- document body / row projection -------------------------------
+
+
+class TestFetchDocument:
+    async def test_text_contains_row_json(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}}
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [
+                            {"tableReference": {"tableId": "users"}}
+                        ]
+                    },
+                )
+            if "dryRun=true" in url:
+                return httpx.Response(200, json=_dry_run_response(1))
+            if url.endswith("/queries"):
+                return httpx.Response(
+                    200,
+                    json=_job_response(
+                        schema_fields=[
+                            {"name": "name"},
+                            {"name": "email"},
+                        ],
+                        rows=[
+                            {
+                                "f": [
+                                    {"v": "Alice"},
+                                    {"v": "alice@example.com"},
+                                ]
+                            }
+                        ],
+                    ),
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                assert len(refs) == 1
+                docs = [d async for d in c.fetch(refs[0])]
+                assert len(docs) == 1
+                assert isinstance(docs[0], Document)
+                payload = json.loads(docs[0].text)
+                assert payload == {"name": "Alice", "email": "alice@example.com"}
+                # Metadata propagated.
+                assert refs[0].metadata["bq_dataset"] == "d1"
+                assert refs[0].metadata["bq_table"] == "users"
+                assert refs[0].metadata["row_index"] == "0"
+            finally:
+                await c.close()
+
+    async def test_unknown_path_returns_empty(self) -> None:
+        from pleno_pii_scanner.sources.base import DocumentRef
+
+        async with _client(lambda _r: httpx.Response(404)) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            try:
+                ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="x")
+                docs = [d async for d in c.fetch(ref)]
+                assert docs == []
+            finally:
+                await c.close()
+
+    def test_project_row_handles_garbage_shape(self) -> None:
+        from pleno_pii_scanner_bigquery.connector import _project_row
+
+        # Non-mapping cell falls back to None.
+        assert _project_row(
+            {"f": [{"v": "x"}, "garbage"]}, ["a", "b"]
+        ) == {"a": "x", "b": None}
+        # Cell list longer than schema is truncated.
+        assert _project_row(
+            {"f": [{"v": 1}, {"v": 2}]}, ["a"]
+        ) == {"a": 1}
+        # Missing 'f' returns empty dict.
+        assert _project_row({"x": 1}, ["a"]) == {}
+        # Non-mapping row returns empty dict.
+        assert _project_row("not-a-mapping", ["a"]) == {}  # type: ignore[arg-type]
+
+
+# --- filter --------------------------------------------------------
+
+
+class TestFilter:
+    async def test_include_exclude_filters_paths(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if url.endswith("/datasets"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "datasets": [
+                            {"datasetReference": {"datasetId": "d1"}}
+                        ]
+                    },
+                )
+            if url.endswith("/datasets/d1/tables"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "tables": [
+                            {"tableReference": {"tableId": "users"}},
+                            {"tableReference": {"tableId": "internal"}},
+                        ]
+                    },
+                )
+            if "dryRun=true" in url:
+                return httpx.Response(200, json=_dry_run_response(1))
+            if url.endswith("/queries"):
+                # Each table issued the same shape.
+                return httpx.Response(
+                    200,
+                    json=_job_response(
+                        rows=[{"f": [{"v": "x"}]}],
+                    ),
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client,
+            )
+            _stub_token(c)
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(include=("d1/users/*",)), None
+                    )
+                ]
+                assert all(r.path.startswith("d1/users/") for r in refs)
+                assert all(
+                    r.metadata["bq_table"] == "users" for r in refs
+                )
+            finally:
+                await c.close()
+
+        async with _client(handler) as client2:
+            c2 = BigQueryConnector(
+                BigQueryConfig(project="p", federated_token="t"),
+                client=client2,
+            )
+            _stub_token(c2)
+            try:
+                refs2 = [
+                    r
+                    async for r in c2.discover(
+                        SourceFilter(exclude=("d1/internal/*",)), None
+                    )
+                ]
+                assert all(r.metadata["bq_table"] == "users" for r in refs2)
+            finally:
+                await c2.close()
+
+
+# --- factory + spec -----------------------------------------------
+
+
+class TestSpec:
+    def test_metadata(self) -> None:
+        assert SPEC.kind == "bigquery"
+        assert SPEC.version == "0.1.0"
+        assert SPEC.required_scopes == (
+            "https://www.googleapis.com/auth/bigquery.readonly",
+        )
+
+    def test_factory_minimal(self) -> None:
+        register(SPEC)
+        c = create("bigquery", {"project": "p", "federated_token": "t"})
+        assert isinstance(c, BigQueryConnector)
+
+    def test_factory_full(self) -> None:
+        register(SPEC)
+        c = create(
+            "bigquery",
+            {
+                "project": "p",
+                "datasets": ["d1"],
+                "service_account_json": json.dumps(
+                    {
+                        "client_email": "x",
+                        "private_key": "y",
+                        "private_key_id": "z",
+                    }
+                ),
+                "sample_percent": 5.0,
+                "max_bytes_billed": 2048,
+                "page_size": 100,
+                "location": "EU",
+                "id": "x",
+            },
+        )
+        assert c.id == "x"
+
+    def test_factory_rejects_missing_project(self) -> None:
+        with pytest.raises(ValueError, match="project"):
+            SPEC.factory({})
+
+
+# --- close --------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_owns_client(self) -> None:
+        c = BigQueryConnector(
+            BigQueryConfig(project="p", federated_token="t")
+        )
+        await c.close()
+
+    async def test_close_external_client_not_closed(self) -> None:
+        client = httpx.AsyncClient()
+        c = BigQueryConnector(
+            BigQueryConfig(project="p", federated_token="t"),
+            client=client,
+        )
+        await c.close()
+        assert not client.is_closed
+        await client.aclose()
+
+
+# --- helpers ------------------------------------------------------
+
+
+class TestHelpers:
+    def test_b64url_strips_padding(self) -> None:
+        from pleno_pii_scanner_bigquery.connector import _b64url
+
+        # Multiple of 3 → no padding to strip; non-multiple → padding stripped.
+        assert _b64url(b"abc") == "YWJj"
+        assert "=" not in _b64url(b"a")
+
+    def test_sign_sa_jwt_produces_three_segments(self) -> None:
+        # End-to-end signing path with a generated key — covers the
+        # otherwise-unreached cryptography branch.
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        sa = {
+            "client_email": "sa@p.iam.gserviceaccount.com",
+            "private_key": pem,
+            "private_key_id": "kid",
+        }
+        from pleno_pii_scanner_bigquery.connector import _sign_sa_jwt
+
+        token = _sign_sa_jwt(sa, scope="s", lifetime_secs=60)
+        assert token.count(".") == 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ members = [
     "packages/pii-scanner-azure-blob",
     "packages/pii-scanner-azure-devops",
     "packages/pii-scanner-bitbucket",
+    "packages/pii-scanner-bigquery",
     "packages/pii-scanner-ci-logs",
     "packages/pii-scanner-discord",
     "packages/pii-scanner-gcs",

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,7 @@ members = [
     "pleno-pii-scanner-aws",
     "pleno-pii-scanner-azure-blob",
     "pleno-pii-scanner-azure-devops",
+    "pleno-pii-scanner-bigquery",
     "pleno-pii-scanner-bitbucket",
     "pleno-pii-scanner-ci-logs",
     "pleno-pii-scanner-discord",
@@ -3462,6 +3463,35 @@ dev = [
 name = "pleno-pii-scanner-azure-devops"
 version = "0.1.0"
 source = { editable = "packages/pii-scanner-azure-devops" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pleno-pii-scanner" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pleno-pii-scanner", editable = "packages/pii-scanner" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+]
+
+[[package]]
+name = "pleno-pii-scanner-bigquery"
+version = "0.1.0"
+source = { editable = "packages/pii-scanner-bigquery" }
 dependencies = [
     { name = "httpx" },
     { name = "pleno-pii-scanner" },


### PR DESCRIPTION
Implements `pleno-pii-scanner-bigquery` per task #39 / ADR-0007 §16.

## Surface

- `BigQueryConfig` — project + datasets allowlist + auth (service_account_json XOR federated_token) + sample_percent + max_bytes_billed + page_size + location.
- `BigQueryConnector` — SourceConnector implementation:
  - `discover()`: list datasets (via API or allowlist) → list tables → per table, build TABLESAMPLE SQL → dry-run → execute query → paginate via getQueryResults → yield one DocumentRef per row.
  - `fetch()`: returns Document with text body = JSON-projected row dict (column name → value).
  - `close()`: aclose owned httpx client.
- `BigQueryCostCapExceeded` — raised when dry-run \`totalBytesProcessed\` exceeds \`max_bytes_billed\`.
- `SPEC` + factory + scope \`https://www.googleapis.com/auth/bigquery.readonly\`.

## Key design decisions

- **TABLESAMPLE omitted at 100 PERCENT** so partition-pruning and clustered reads still apply on small / clustered tables.
- **Dry-run cost cap is defence in depth**: pre-flight dry-run + server-side \`maximumBytesBilled\`. Either alone is insufficient (dry-run estimate can drift; server-side enforcement won't tell us *why* the job was killed).
- **WIF shortcut path**: \`federated_token\` is a pre-exchanged STS token used directly as the bearer — no SA key material in the scanner process.
- **Cursor type**: \`str\`, JSON-encoded (informational only since incremental=False).
- **Capabilities**: incremental=False, content_hash_delta=False, binary=False, max_concurrent_fetches=2, streaming=False — query results aren't byte-streamable and BigQuery exposes no native incremental over arbitrary tables.

## Tests

36 tests, **100% line coverage**:
- Config validation (empty project, both/neither auth, sample_percent bounds, max_bytes_billed/page_size bounds)
- Token acquisition: federated shortcut + SA-key signing path (mocked) + missing-access-token error
- Dataset listing + dataset allowlist (skips API)
- Table listing per dataset (with pagination)
- TABLESAMPLE included < 100% / omitted at 100%
- Dry-run cost cap raises \`BigQueryCostCapExceeded\` over cap
- Query execution + getQueryResults pagination across multiple pages
- Document text contains row JSON keyed by schema column names
- include/exclude path filtering on \`<ds>/<table>/<row>\`
- Factory + spec metadata
- Close (owned vs external httpx client)
- Helpers: \`_b64url\`, \`_project_row\`, \`_sign_sa_jwt\` (real RSA key end-to-end)

## Workspace

\`packages/pii-scanner-bigquery\` added to root \`pyproject.toml\` workspace members between \`-bitbucket\` and \`-ci-logs\` per the task brief.