### PR TITLE
feat(pii-scanner-jira): expand to ADF/storage walkers + 179 tests (#27, post-merge upgrade)

### DIFF
--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/adf.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/adf.py
@@ -1,0 +1,421 @@
+"""ADF (Atlassian Document Format) -> plain-text converter.
+
+Cloud Jira returns issue body fields (`description`, `comment[].body`)
+as ADF — a JSON tree of typed nodes. Detectors downstream operate on
+plain text, so we flatten the tree before handing it off.
+
+Why plain text rather than Markdown:
+
+* The Jira PII scan target is the user-visible body content; ADF
+  formatting (bold, panels, tables) carries no PII signal but adds
+  syntactic noise that confuses regex match positions.
+* ADF table cells, panel bodies and code blocks all contain the same
+  rich-text leaves; a flat newline-separated stream keeps the detector
+  surface uniform across containers.
+
+Defensive contract: an unknown node `type` emits
+`<!-- unsupported: {type} -->` and the recursion continues. A future
+ADF schema change must never crash a scan. Recursion is bounded at
+`MAX_DEPTH=100` — well above Jira's UI cap (~6 levels of nested
+panels) but enough to defend against a pathological cycle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+# Hard cap on ADF tree recursion. Jira's UI imposes <10 levels in
+# practice; 100 leaves headroom while bounding the worst case if a
+# malformed response (or a future API bug) accidentally produces a
+# self-referential `content` array. Picked to match the equivalent
+# Notion connector cap so operators see one consistent depth budget.
+MAX_DEPTH = 100
+
+
+# Sentinel emitted when recursion is truncated. Picked so an operator
+# grepping output can find truncated regions without ambiguity vs. real
+# document content.
+DEPTH_TRUNCATED_MARKER = "<!-- depth-truncated -->"
+
+
+# Block-level node types that must produce a trailing newline so
+# detectors do not see neighbouring blocks as one run-on sentence.
+_BLOCK_TYPES: frozenset[str] = frozenset(
+    {
+        "paragraph",
+        "heading",
+        "bulletList",
+        "orderedList",
+        "listItem",
+        "codeBlock",
+        "blockquote",
+        "panel",
+        "table",
+        "tableRow",
+        "rule",
+        "mediaSingle",
+        "mediaGroup",
+        "expand",
+        "nestedExpand",
+    }
+)
+
+
+def adf_to_text(node: Any, *, max_depth: int = MAX_DEPTH) -> str:
+    """Render an ADF node (or document root) as plain text.
+
+    `node` is the parsed JSON. The document root looks like
+    `{"type": "doc", "version": 1, "content": [...]}`; individual nodes
+    look like `{"type": "paragraph", "content": [...]}` or
+    `{"type": "text", "text": "...", "marks": [...]}`. We accept either
+    a root document, an arbitrary node, or a list of nodes — all three
+    forms occur in the wild (issue `description` is a doc, comment
+    bodies are docs, but tests sometimes hand us a bare paragraph).
+
+    Anything that is not a Mapping or a Sequence (None, int, the wrong
+    type) renders as the empty string. Defensive: ADF parsers in
+    Atlassian's own SDKs treat malformed payloads the same way.
+    """
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        # A bare string slipped past the schema; render it verbatim so
+        # the operator at least sees the leaked content.
+        return node
+    if isinstance(node, Sequence) and not isinstance(node, (str, bytes)):
+        # A list of nodes — common when callers pass `doc["content"]`
+        # directly. Render as a sibling sequence.
+        return _render_sequence(list(node), depth=0, max_depth=max_depth)
+    if not isinstance(node, Mapping):
+        return ""
+    return _render_node(node, depth=0, max_depth=max_depth)
+
+
+def _render_node(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
+    """Dispatch on `node['type']`."""
+    if depth >= max_depth:
+        return DEPTH_TRUNCATED_MARKER
+    node_type = node.get("type")
+    if not isinstance(node_type, str):
+        return ""
+    handler = _HANDLERS.get(node_type)
+    if handler is not None:
+        return handler(node, depth=depth, max_depth=max_depth)
+    # Unknown node type — emit the sentinel and continue rendering any
+    # children present. This keeps the scan output forward-compatible
+    # with new ADF node types Atlassian rolls out.
+    inner = _render_children(node, depth=depth + 1, max_depth=max_depth)
+    marker = f"<!-- unsupported: {node_type} -->"
+    return f"{marker}\n{inner}".rstrip() if inner else marker
+
+
+def _render_children(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """Render `node['content']` as a sibling sequence."""
+    children = node.get("content")
+    if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
+        return ""
+    return _render_sequence(list(children), depth=depth, max_depth=max_depth)
+
+
+def _render_sequence(
+    nodes: list[Any], *, depth: int, max_depth: int
+) -> str:
+    """Render a list of sibling nodes, joining block-level ones with newlines.
+
+    Inline runs (`text`, `mention`, `emoji`, inline marks) are
+    concatenated verbatim. Block-level nodes get a trailing newline so
+    detectors see one paragraph per line. We do not collapse multiple
+    blank lines because the result is downstream-only — humans never
+    read it.
+    """
+    parts: list[str] = []
+    for child in nodes:
+        if not isinstance(child, Mapping):
+            continue
+        rendered = _render_node(child, depth=depth, max_depth=max_depth)
+        if not rendered:
+            continue
+        if child.get("type") in _BLOCK_TYPES:
+            parts.append(rendered.rstrip("\n") + "\n")
+        else:
+            parts.append(rendered)
+    return "".join(parts).rstrip("\n")
+
+
+# ---------------------------------------------------------------------
+# leaf handlers
+# ---------------------------------------------------------------------
+
+
+def _handle_text(node: Mapping[str, Any], **_: Any) -> str:
+    """`{type: "text", text: "...", marks: [...]}` — the inline leaf.
+
+    Marks (bold, italic, strike, code, underline, link) carry no PII
+    signal in plain text, so we drop them. Link marks are an exception:
+    the URL itself can contain credentials (`?token=...`) so we surface
+    the href next to the visible text.
+    """
+    text = node.get("text")
+    if not isinstance(text, str):
+        return ""
+    marks = node.get("marks")
+    if isinstance(marks, Sequence) and not isinstance(marks, (str, bytes)):
+        for mark in marks:
+            if not isinstance(mark, Mapping):
+                continue
+            if mark.get("type") == "link":
+                attrs = mark.get("attrs")
+                if isinstance(attrs, Mapping):
+                    href = attrs.get("href")
+                    if isinstance(href, str) and href and href != text:
+                        # Render `text (href)` so a detector sees both
+                        # the visible label and the embedded URL. This
+                        # catches the common phishing pattern where a
+                        # benign label masks a token-bearing URL.
+                        return f"{text} ({href})"
+    return text
+
+
+def _handle_paragraph(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+def _handle_heading(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    # Drop the `# ` prefix Markdown renderers would emit; downstream
+    # consumers only care about the body text. The level lives in
+    # `attrs.level` if a future renderer wants it.
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+def _handle_list(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """bulletList / orderedList — render each `listItem` on its own line."""
+    children = node.get("content")
+    if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
+        return ""
+    items: list[str] = []
+    for child in children:
+        if not isinstance(child, Mapping):
+            continue
+        if child.get("type") != "listItem":
+            continue
+        rendered = _handle_list_item(child, depth=depth + 1, max_depth=max_depth)
+        if rendered:
+            items.append(rendered)
+    return "\n".join(items)
+
+
+def _handle_list_item(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    inner = _render_children(node, depth=depth + 1, max_depth=max_depth)
+    # Strip the trailing newline added by block children inside the
+    # item; the outer list joiner re-adds one between items.
+    return inner.rstrip("\n")
+
+
+def _handle_code_block(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """codeBlock — flatten to its inner text, dropping the language attr.
+
+    Detectors care about the literal code (a `password = "x"` constant
+    is a finding regardless of the language tag); `attrs.language` is
+    metadata that adds nothing to PII signal.
+    """
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+def _handle_inline_code(node: Mapping[str, Any], **_: Any) -> str:
+    """Some ADF dialects emit a top-level `code` node; treat as text."""
+    text = node.get("text")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+def _handle_mention(node: Mapping[str, Any], **_: Any) -> str:
+    """`{type: "mention", attrs: {id, text, accessLevel}}`.
+
+    The `attrs.text` is the user-visible `@Display Name` form; the
+    `attrs.id` is the Atlassian Account ID — both are useful: the
+    display name often contains a real name (PII), and the id is the
+    canonical identifier downstream tools key on.
+    """
+    attrs = node.get("attrs")
+    if not isinstance(attrs, Mapping):
+        return ""
+    text = attrs.get("text")
+    if isinstance(text, str) and text:
+        return text
+    mention_id = attrs.get("id")
+    if isinstance(mention_id, str) and mention_id:
+        return f"@{mention_id}"
+    return ""
+
+
+def _handle_emoji(node: Mapping[str, Any], **_: Any) -> str:
+    attrs = node.get("attrs")
+    if isinstance(attrs, Mapping):
+        shortname = attrs.get("shortName")
+        if isinstance(shortname, str):
+            return shortname
+        text = attrs.get("text")
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def _handle_hard_break(_node: Mapping[str, Any], **_: Any) -> str:
+    return "\n"
+
+
+def _handle_inline_card(node: Mapping[str, Any], **_: Any) -> str:
+    """`inlineCard` — a Smart Link. The URL is the entire payload."""
+    attrs = node.get("attrs")
+    if not isinstance(attrs, Mapping):
+        return ""
+    url = attrs.get("url")
+    if isinstance(url, str) and url:
+        return url
+    return ""
+
+
+def _handle_media_single(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """mediaSingle — wraps a single `media` node; surface its filename/url."""
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+def _handle_media(node: Mapping[str, Any], **_: Any) -> str:
+    attrs = node.get("attrs")
+    if not isinstance(attrs, Mapping):
+        return ""
+    parts: list[str] = []
+    for key in ("collection", "id", "url", "alt"):
+        v = attrs.get(key)
+        if isinstance(v, str) and v:
+            parts.append(f"{key}={v}")
+    return " ".join(parts)
+
+
+def _handle_panel(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """panel — coloured callout box. Render its content verbatim.
+
+    The `attrs.panelType` (info, warning, error, note, success) carries
+    no PII signal; we drop it.
+    """
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+def _handle_blockquote(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+def _handle_rule(_node: Mapping[str, Any], **_: Any) -> str:
+    # Horizontal rule has no content; emit a single newline so adjacent
+    # blocks do not run together when joined.
+    return "\n"
+
+
+def _handle_table(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """table — newline-separated rows; each row is tab-separated cells."""
+    children = node.get("content")
+    if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
+        return ""
+    rows: list[str] = []
+    for row in children:
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("type") != "tableRow":
+            continue
+        rendered = _handle_table_row(row, depth=depth + 1, max_depth=max_depth)
+        if rendered:
+            rows.append(rendered)
+    return "\n".join(rows)
+
+
+def _handle_table_row(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    cells = node.get("content")
+    if not isinstance(cells, Sequence) or isinstance(cells, (str, bytes)):
+        return ""
+    cell_texts: list[str] = []
+    for cell in cells:
+        if not isinstance(cell, Mapping):
+            continue
+        if cell.get("type") not in ("tableCell", "tableHeader"):
+            continue
+        text = _render_children(cell, depth=depth + 1, max_depth=max_depth)
+        cell_texts.append(text.replace("\n", " ").strip())
+    return "\t".join(cell_texts)
+
+
+def _handle_doc(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """The document root; just descend into `content`."""
+    return _render_children(node, depth=depth, max_depth=max_depth)
+
+
+def _handle_expand(
+    node: Mapping[str, Any], *, depth: int, max_depth: int
+) -> str:
+    """expand / nestedExpand — collapsible block. Render the body."""
+    return _render_children(node, depth=depth + 1, max_depth=max_depth)
+
+
+# Dispatch table. Defined after the handlers so the references are
+# bound. `_HANDLERS.get(t)` returns None for unknown types, which the
+# top-level `_render_node` translates into the unsupported sentinel.
+_HANDLERS: Mapping[str, Any] = {
+    "doc": _handle_doc,
+    "text": _handle_text,
+    "paragraph": _handle_paragraph,
+    "heading": _handle_heading,
+    "bulletList": _handle_list,
+    "orderedList": _handle_list,
+    "listItem": _handle_list_item,
+    "codeBlock": _handle_code_block,
+    "code": _handle_inline_code,
+    "mention": _handle_mention,
+    "emoji": _handle_emoji,
+    "hardBreak": _handle_hard_break,
+    "inlineCard": _handle_inline_card,
+    "mediaSingle": _handle_media_single,
+    "mediaGroup": _handle_media_single,
+    "media": _handle_media,
+    "panel": _handle_panel,
+    "blockquote": _handle_blockquote,
+    "rule": _handle_rule,
+    "table": _handle_table,
+    "tableRow": _handle_table_row,
+    "tableCell": _handle_paragraph,
+    "tableHeader": _handle_paragraph,
+    "expand": _handle_expand,
+    "nestedExpand": _handle_expand,
+}
+
+
+__all__ = [
+    "DEPTH_TRUNCATED_MARKER",
+    "MAX_DEPTH",
+    "adf_to_text",
+]

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/api.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/api.py
@@ -1,0 +1,293 @@
+"""Minimal httpx wrapper for the Jira REST endpoints we touch.
+
+Two flavors share one client because the differences live in the URL
+prefix (`/rest/api/3` vs `/rest/api/2`), the auth header style, and
+the rate-limit status code — not in the HTTP layer:
+
+* **Cloud** — `https://{site}.atlassian.net/rest/api/3`. Auth: HTTP
+  Basic (`email`/`api_token`) or Bearer (OAuth 2.0 access token).
+  Rate limit: `429 Too Many Requests` with `Retry-After`.
+* **Data Center** — `<base_url>/rest/api/2`. Auth: Bearer (Personal
+  Access Token) or HTTP Basic (PAT or password). Rate limit:
+  `503 Service Unavailable` with `Retry-After` (DC's rate limiter
+  sits in front of the application and chooses 503 over 429 by
+  policy — both must be honoured).
+
+We deliberately avoid `atlassian-python-api`: it depends on
+`requests` (blocking, no asyncio), uses `six`, and exposes no
+transport seam for hermetic tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import httpx
+
+
+# Cloud / DataCenter flavor literal. Selecting one at construction time
+# locks the URL shape into the client; passing the wrong flavor against
+# the wrong base_url is an early-boot misconfiguration (e.g. pointing a
+# "cloud" client at a Data Center instance) and we would rather fail
+# loudly than silently 404 every request.
+Flavor = Literal["cloud", "datacenter"]
+
+
+# Default per-request timeout (seconds). Jira Cloud's published p99 for
+# `/search` with JQL is ~5s; 30s leaves headroom for slow project
+# imports without letting a hung connection wedge the whole scan.
+DEFAULT_TIMEOUT = 30.0
+
+
+# Fallback retry delay when a 429/503 lacks `Retry-After`. The DC rate
+# limiter usually omits the header; we pick a conservative default
+# rather than retrying immediately because the scan would otherwise
+# spin a hot loop against an already-overloaded endpoint.
+_DEFAULT_RETRY_AFTER_SECONDS = 30.0
+
+
+# Maximum total wait imposed by a single retry. A 429 with
+# `Retry-After: 3600` (Cloud's worst-case) would otherwise stall the
+# whole scan for an hour; capping at 60s lets the scheduler's AIMD
+# bucket take over for longer cool-downs.
+_MAX_RETRY_AFTER_SECONDS = 60.0
+
+
+class JiraApiError(Exception):
+    """Non-retryable upstream failure (4xx other than 401/403/429/503)."""
+
+
+@dataclass(frozen=True, slots=True)
+class BasicAuth:
+    """HTTP Basic — Cloud (`email` + `api_token`) or DC (PAT/password).
+
+    The token never lands in `__repr__` because the dataclass auto-repr
+    only shows field names; we further centralise the header build in
+    `header_value()` so a future refactor cannot accidentally hand
+    httpx a `(user, pass)` tuple that traces would log.
+    """
+
+    username: str
+    password: str
+
+    def header_value(self) -> str:
+        # Pre-compute once at use site. b64encode requires bytes input.
+        raw = f"{self.username}:{self.password}".encode("utf-8")
+        return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+@dataclass(frozen=True, slots=True)
+class BearerAuth:
+    """Bearer — Cloud OAuth 2.0 access token or DC Personal Access Token."""
+
+    token: str
+
+    def header_value(self) -> str:
+        return f"Bearer {self.token}"
+
+
+# Either of the auth modes the connector accepts. Constrained to a
+# union (not a base class) so type checkers narrow exhaustively in the
+# header builder — adding a third mode later forces every match site
+# to update, which is the behavior we want.
+AuthMode = BasicAuth | BearerAuth
+
+
+def _api_prefix(flavor: Flavor) -> str:
+    """Return the REST API path prefix for the given flavor.
+
+    Cloud sites mount the API under `/rest/api/3`; DC keeps the
+    long-standing `/rest/api/2` prefix because v3 was never backported.
+    Centralised so the URL builder cannot drift between Connector and
+    helpers.
+    """
+    return "/rest/api/3" if flavor == "cloud" else "/rest/api/2"
+
+
+class JiraApi:
+    """Thin async wrapper around `httpx.AsyncClient`.
+
+    Owns one client per connector lifetime. Tests inject a mock
+    transport; production callers pass `transport=None` for the
+    default. Cloud credentials never expire (long-lived API tokens);
+    DC PATs have an expiry but Atlassian's lifecycle is operator-
+    managed so we do not auto-refresh.
+    """
+
+    def __init__(
+        self,
+        *,
+        flavor: Flavor,
+        base_url: str,
+        auth: AuthMode,
+        transport: httpx.AsyncBaseTransport | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        sleep: Any | None = None,
+    ) -> None:
+        if flavor not in ("cloud", "datacenter"):
+            raise ValueError(f"unsupported jira flavor: {flavor!r}")
+        self._flavor: Flavor = flavor
+        self._base_url = base_url.rstrip("/")
+        self._api_prefix = _api_prefix(flavor)
+        self._auth = auth
+        kwargs: dict[str, Any] = {"timeout": timeout}
+        if transport is not None:
+            kwargs["transport"] = transport
+        self._client = httpx.AsyncClient(**kwargs)
+        # Injectable sleep so 429/503 backoff tests do not actually
+        # sleep. Defaults to asyncio.sleep in production.
+        self._sleep = sleep or asyncio.sleep
+
+    @property
+    def flavor(self) -> Flavor:
+        return self._flavor
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def api_prefix(self) -> str:
+        return self._api_prefix
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # request layer
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        # `Accept: application/json` keeps Jira from falling back to XML
+        # on a few legacy endpoints. `User-Agent` is good citizenship —
+        # Atlassian's abuse detector keys off it for client identification.
+        return {
+            "Accept": "application/json",
+            "User-Agent": "pleno-pii-scanner-jira",
+            "Authorization": self._auth.header_value(),
+        }
+
+    def _absolute(self, path_or_url: str) -> str:
+        if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
+            return path_or_url
+        if not path_or_url.startswith("/"):
+            path_or_url = "/" + path_or_url
+        # Paths beginning with `/rest/` are passed through untouched so
+        # callers can hit non-`/api/` endpoints (e.g. `/rest/auth/1/session`)
+        # without us mangling the prefix.
+        if path_or_url.startswith("/rest/"):
+            return f"{self._base_url}{path_or_url}"
+        return f"{self._base_url}{self._api_prefix}{path_or_url}"
+
+    async def get(
+        self,
+        path_or_url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """REST GET with rate-limit backoff.
+
+        On 429 (Cloud) or 503 (DC) we honour `Retry-After` (seconds)
+        and retry exactly once; a second throttle propagates as
+        `JiraApiError` so the scheduler's AIMD bucket can shrink.
+
+        `params` values that are `None` are dropped — httpx encodes them
+        as the literal string `"None"` otherwise, which Jira's JQL
+        parser then rejects with a 400.
+        """
+        url = self._absolute(path_or_url)
+        clean_params = (
+            {k: v for k, v in params.items() if v is not None}
+            if params
+            else None
+        )
+        for attempt in (1, 2):
+            response = await self._client.get(
+                url, params=clean_params, headers=self._headers()
+            )
+            if not _is_throttle(response, self._flavor):
+                return self._handle(response)
+            if attempt == 2:
+                raise JiraApiError(
+                    f"jira {response.status_code} {url}: persistent throttle "
+                    f"after one retry"
+                )
+            delay = _retry_after_seconds(response)
+            await self._sleep(delay)
+        # Unreachable — both branches above exit. `pragma: no cover`
+        # documents the defensive fall-through for static analysis.
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    def _handle(self, response: httpx.Response) -> dict[str, Any]:
+        """Translate HTTP status into either a parsed body or an exception."""
+        status = response.status_code
+        if status == 404:
+            # 404 is the Atlassian idiom for "no permission OR doesn't
+            # exist"; we surface an empty dict so paginated callers can
+            # `if not body: return` and skip the page silently. Mirrors
+            # the github connector's "private repo == empty result" idiom.
+            return {}
+        if status >= 400:
+            raise JiraApiError(
+                f"jira {status} {response.request.method} "
+                f"{response.request.url.path}: {response.text[:200]}"
+            )
+        # 2xx — Jira always returns JSON; .json() raising means the
+        # upstream sent a corrupt body and we want the loud failure.
+        return response.json()
+
+
+# ---------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------
+
+
+def _is_throttle(response: httpx.Response, flavor: Flavor) -> bool:
+    """True if the response represents a rate-limit signal worth retrying.
+
+    Cloud: 429 (the standard). DC: 503 (their reverse proxy emits
+    Service Unavailable when the rate limiter rejects). We treat both
+    as the same retryable signal so the connector behaves uniformly
+    across flavors.
+    """
+    if response.status_code == 429:
+        return True
+    if response.status_code == 503 and flavor == "datacenter":
+        return True
+    return False
+
+
+def _retry_after_seconds(response: httpx.Response) -> float:
+    """Parse `Retry-After` (seconds form) with a safe fallback + cap.
+
+    Jira sends `Retry-After` as integer seconds. Anything unparseable
+    falls back to `_DEFAULT_RETRY_AFTER_SECONDS` rather than 0 — a
+    too-aggressive retry on a throttled endpoint is the fastest way to
+    get the whole scan IP-banned. Values larger than
+    `_MAX_RETRY_AFTER_SECONDS` are capped because we do not want a
+    single request to stall the scheduler for an hour; the scheduler's
+    AIMD bucket takes over for longer cool-downs.
+    """
+    raw = response.headers.get("Retry-After")
+    if raw is None:
+        return _DEFAULT_RETRY_AFTER_SECONDS
+    try:
+        seconds = max(0.0, float(raw))
+    except (ValueError, TypeError):
+        return _DEFAULT_RETRY_AFTER_SECONDS
+    return min(seconds, _MAX_RETRY_AFTER_SECONDS)
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT",
+    "AuthMode",
+    "BasicAuth",
+    "BearerAuth",
+    "Flavor",
+    "JiraApi",
+    "JiraApiError",
+]

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/connector.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/connector.py
@@ -1,38 +1,46 @@
-"""Atlassian Jira SourceConnector — Cloud + DC, ADF→text, JQL incremental.
+"""JiraConnector — Cloud + Data Center `SourceConnector`.
+
+Single connector kind (`jira`) backed by two REST flavors selected at
+construction time. The wire-level differences (URL prefix, body format
+for issue descriptions/comments, throttle status code) live inside
+`api.py` and the body converters; the `SourceConnector` contract the
+scheduler sees is identical to every other ADR-0007 §13 connector.
 
 Pipeline:
 
-  1. Build JQL: `(project in (P1,P2)) AND updated >= "<cursor>" ORDER BY updated ASC`
-     — `project in (...)` clause omitted when no allowlist is configured;
-     `updated >=` clause omitted on a fresh scan (cursor is None).
-  2. Paginate `/rest/api/3/search`:
-       - Cloud: `nextPageToken` (opaque server token)
-       - DC:    `startAt` / `maxResults` (classic offset paging)
-  3. For each issue, yield one DocumentRef (path = `<project>/<issue-key>`).
-  4. If `include_comments`, fetch `/rest/api/3/issue/{key}/comment` and
-     yield one DocumentRef per comment (path = `<project>/<issue-key>/comments/<id>`).
-  5. fetch() yields the cached body verbatim — discover() pre-renders
-     summary + ADF→text description / ADF→text comment body.
+    1. /project/search  -> enumerate every project the principal can read
+    2. JQL `project = X AND updated >= cursor`  -> issues touched since
+       the last incremental cursor (full walk on first run)
+    3. /issue/{key}/comment  -> all comments per issue (paginated)
+    4. ADF (Cloud) or storage XHTML (DC) -> plain text
+    5. attachments rendered as `attachment={name}, url={url}` lines —
+       we never download attachment bodies (operator-controlled cost)
 
-ADF (Atlassian Document Format) is a JSON tree of nodes. The walker
-descends unconditionally, accumulating every `text` node and emitting
-a newline at structural boundaries (`paragraph`, `heading`, `listItem`).
-A purpose-built walker beats pulling a heavy `atlaskit` dependency in.
+Each issue becomes one Document carrying:
 
-Cursor: ISO-8601 string of the latest `updated` timestamp seen in the
-run. Persisted verbatim by the scheduler and round-tripped through
-`discover(..., cursor=...)` — `Cursor` is a type alias for `str` in
-the core API, never a class.
+    key=PROJ-123
+    summary=...
+    status=...
+    assignee=...
+    reporter=...
+    description=...
+    comment[<id>]=...
+    attachment=name, url=...
+
+The `discover()` cursor is a JSON-encoded `{ "highest_updated":
+"<iso8601>" }`. On each scan the JQL `updated >= cursor` resumes
+incrementally; malformed cursor values are silently ignored so a
+forward-incompatible cursor never crashes a scan.
 """
 
 from __future__ import annotations
 
-import base64
-from collections.abc import AsyncIterator, Mapping
+import asyncio
+import json
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from fnmatch import fnmatch
-from typing import Any, Literal
+from typing import Any
 
 import httpx
 
@@ -40,89 +48,208 @@ from pleno_pii_scanner.sources.base import (
     Capabilities,
     Cursor,
     Document,
-    DocumentChunk,
+    DocumentChunk,  # noqa: F401 — referenced in fetch return-type annotation
     DocumentRef,
     SourceConnector,
     SourceFilter,
 )
 from pleno_pii_scanner.sources.registry import ConnectorSpec
 
+from .adf import adf_to_text
+from .api import (
+    DEFAULT_TIMEOUT,
+    AuthMode,
+    BasicAuth,
+    BearerAuth,
+    Flavor,
+    JiraApi,
+)
+from .storage import storage_to_text
 
-_SEARCH_PATH = "/rest/api/3/search"
-_ISSUE_PATH_TPL = "/rest/api/3/issue/{key}/comment"
-# Defensive cap on JQL pagination — protects against a misconfigured
-# server returning the same nextPageToken indefinitely.
-_MAX_PAGES = 10_000
+
+# Connector kind exported via the `pleno_pii_scanner.connectors` entry
+# point group (see pyproject.toml). One kind covers both flavors; the
+# wire flavor is selected by config.
+KIND = "jira"
+
+
+# Page size for /search and /project/search. Jira Cloud caps `/search`
+# at 100; DC defaults to 50 with a configurable max. 100 stays under
+# both — going higher trades latency for marginal request-count savings
+# and risks tripping admin-configured query timeouts.
+_PAGE_SIZE = 100
+
+
+# Comment endpoint page size. /issue/{key}/comment caps at 100 on Cloud
+# and DC; we use the max because comment bodies are typically small and
+# we want one paginated round-trip per typical issue.
+_COMMENT_PAGE_SIZE = 100
+
+
+# Maximum total pages we will walk per paginated endpoint without the
+# server signalling completion. Defends against a buggy upstream that
+# always claims more data exists. 10_000 × 100 = a million records,
+# well above any realistic single-project size.
+_MAX_PAGINATION_DEPTH = 10_000
 
 
 @dataclass(frozen=True, slots=True)
 class JiraConfig:
-    """Construction config for `JiraConnector`."""
+    """Construction config for `JiraConnector`.
 
+    `flavor` selects the wire protocol. `base_url` is the site root
+    (`https://acme.atlassian.net` for Cloud, `https://jira.acme.internal`
+    for DC) — the connector appends `/rest/api/3` or `/rest/api/2`.
+
+    Auth: pick exactly one of:
+      - `email` + `api_token` (Cloud Basic)
+      - `access_token` (Cloud OAuth 2.0 OR DC PAT — both are Bearer)
+      - `username` + `password` (DC HTTP Basic)
+
+    `projects` allow-lists projects by key (`("ENG", "OPS")`); empty
+    means every readable project. `include_comments` toggles the comment
+    endpoint walk; `include_attachments` toggles the `attachment=` line
+    serialisation (we never download attachment bodies regardless).
+    """
+
+    flavor: Flavor
     base_url: str
-    email: str
-    api_token: str
+    email: str | None = None
+    api_token: str | None = None
+    access_token: str | None = None
+    username: str | None = None
+    password: str | None = None
     projects: tuple[str, ...] = ()
     include_comments: bool = True
-    deployment: Literal["cloud", "dc"] = "cloud"
+    include_attachments: bool = True
+    request_timeout: float = DEFAULT_TIMEOUT
     id: str | None = None
 
     def __post_init__(self) -> None:
-        if not self.base_url:
-            raise ValueError("base_url must be non-empty")
-        if not self.api_token:
-            raise ValueError("api_token must be non-empty")
-        if self.deployment not in ("cloud", "dc"):
+        if self.flavor not in ("cloud", "datacenter"):
             raise ValueError(
-                f"deployment must be 'cloud' or 'dc'; got {self.deployment!r}"
+                f"JiraConfig.flavor must be 'cloud' or 'datacenter'; "
+                f"got {self.flavor!r}"
+            )
+        if not self.base_url:
+            raise ValueError("JiraConfig.base_url must be a non-empty URL")
+        if not self.base_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"JiraConfig.base_url must start with http:// or https://; "
+                f"got {self.base_url!r}"
+            )
+        # Validate auth shape upfront so a misconfigured profile fails
+        # at construction rather than mid-discover. We accept exactly
+        # one of the four supported modes.
+        modes = self._present_auth_modes()
+        if not modes:
+            raise ValueError(
+                "JiraConfig requires one of: (email + api_token) [cloud basic], "
+                "access_token [cloud OAuth or DC PAT], "
+                "or (username + password) [DC basic]"
+            )
+        if len(modes) > 1:
+            raise ValueError(
+                f"JiraConfig accepts exactly one auth mode; "
+                f"received: {sorted(modes)}"
             )
 
+    def _present_auth_modes(self) -> set[str]:
+        modes: set[str] = set()
+        if self.email and self.api_token:
+            modes.add("email+api_token")
+        if self.access_token:
+            modes.add("access_token")
+        if self.username and self.password:
+            modes.add("username+password")
+        return modes
+
     def resolved_id(self) -> str:
+        """Stable identifier safe to surface in logs / findings.
+
+        Critically: must not embed `api_token` / `access_token` /
+        `password`. We derive the id from the host portion of the
+        `base_url` plus the flavor — both are non-secret.
+        """
         if self.id is not None:
             return self.id
-        # Token is sensitive; identify by base_url + hashed token + project set.
-        import hashlib
+        host = _host_only(self.base_url)
+        return f"jira-{self.flavor}:{host}"
 
-        h = hashlib.sha256()
-        h.update(self.base_url.encode())
-        h.update(b"\0")
-        h.update(self.api_token.encode())
-        for p in sorted(self.projects):
-            h.update(b"\0")
-            h.update(p.encode())
-        return f"jira:{h.hexdigest()[:16]}"
+    def build_auth(self) -> AuthMode:
+        """Construct the AuthMode for the configured credential.
+
+        Order matches `__post_init__`'s validation. The check for
+        exactly-one-mode happens there, so by the time we reach here
+        we have one and only one set of fields populated.
+        """
+        if self.access_token:
+            return BearerAuth(token=self.access_token)
+        if self.email and self.api_token:
+            # Cloud Basic uses the user's email as the username and the
+            # API token as the password (Atlassian's documented form).
+            return BasicAuth(username=self.email, password=self.api_token)
+        # The remaining branch is `username + password` (DC Basic);
+        # __post_init__ guarantees these are both set.
+        assert self.username is not None and self.password is not None
+        return BasicAuth(username=self.username, password=self.password)
 
 
 class JiraConnector:
-    """Read-only SourceConnector for Atlassian Jira (Cloud + DC)."""
+    """`SourceConnector` for Jira Cloud + Jira Data Center.
 
-    kind = "jira"
+    Owns one `JiraApi` (HTTP session) for the connector's lifetime.
+    `discover()` enumerates issues; `fetch()` materialises an issue
+    into one Document. Issue payloads observed during discover are
+    cached in-memory so fetch() avoids re-issuing `/issue/{key}`.
+    """
+
+    kind = KIND
 
     def __init__(
         self,
         config: JiraConfig,
         *,
-        client: httpx.AsyncClient | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+        sleep: Any | None = None,
     ) -> None:
         self._config = config
         self.id = config.resolved_id()
-        if client is None:
-            self._client = httpx.AsyncClient(
-                base_url=config.base_url.rstrip("/"),
-                timeout=30.0,
-            )
-            self._owns_client = True
-        else:
-            self._client = client
-            self._owns_client = False
-        self._auth_headers = _build_auth_headers(config)
-        # Cache of pre-rendered bodies keyed by ref.path so fetch()
-        # doesn't re-walk the JSON tree.
-        self._documents: dict[str, str] = {}
-        # Latest `updated` timestamp seen this run; drives cursor_after_run().
+        self._api = JiraApi(
+            flavor=config.flavor,
+            base_url=config.base_url,
+            auth=config.build_auth(),
+            transport=transport,
+            timeout=config.request_timeout,
+            sleep=sleep,
+        )
+        # Map of issue key -> {"issue": dict, "comments": list[dict]}
+        # populated during discover() so fetch() does not re-issue
+        # /issue/{key}; cleared on close().
+        self._issue_cache: dict[str, dict[str, Any]] = {}
+        # Highest `updated` timestamp seen across the run, in raw Jira
+        # ISO-8601 form. Surfaced via cursor_after_run() for the next
+        # incremental scan.
         self._high_water: str | None = None
+        # Lock guarding _issue_cache + _high_water mutation so concurrent
+        # fetch() calls (max_concurrent_fetches > 1) cannot race.
+        self._lock = asyncio.Lock()
+
+    @property
+    def api(self) -> JiraApi:
+        # Exposed for tests + advanced operators that want to issue raw
+        # endpoints (e.g. /myself for credential probing).
+        return self._api
+
+    @property
+    def config(self) -> JiraConfig:
+        return self._config
 
     def capabilities(self) -> Capabilities:
+        # `incremental=True` because we round-trip the highest-updated
+        # cursor between runs. `binary=False` — we never download
+        # attachment bodies (operators wire the `attachment=` URL into
+        # a separate http connector if they want body scans).
         return Capabilities(
             incremental=True,
             binary=False,
@@ -131,354 +258,579 @@ class JiraConnector:
             streaming=False,
         )
 
+    # ------------------------------------------------------------------
+    # discover
+    # ------------------------------------------------------------------
+
     async def discover(
         self,
         filter: SourceFilter,
         cursor: Cursor | None,
     ) -> AsyncIterator[DocumentRef]:
-        jql = _build_jql(self._config.projects, cursor)
-        async for issue in self._iter_issues(jql):
-            project_key = (
-                issue.get("fields", {}).get("project", {}).get("key")
-                or issue.get("key", "").split("-", 1)[0]
-            )
-            issue_key = issue.get("key", "")
-            full = f"{project_key}/{issue_key}"
-            if filter.include and not _matches_any(full, filter.include):
-                continue
-            if filter.exclude and _matches_any(full, filter.exclude):
-                continue
-            updated = issue.get("fields", {}).get("updated")
-            if isinstance(updated, str):
-                if self._high_water is None or updated > self._high_water:
-                    self._high_water = updated
-            text = _serialise_issue(issue)
-            self._documents[full] = text
-            yield DocumentRef(
-                source_id=self.id,
-                source_kind=self.kind,
-                path=full,
-                native_url=_issue_url(self._config.base_url, issue_key),
-                content_type="text/plain",
-                size=len(text),
-                etag=issue.get("id"),
-                last_modified=_parse_iso(updated),
-                metadata={
-                    "project_key": str(project_key or ""),
-                    "issue_key": issue_key,
-                    "issue_id": str(issue.get("id", "")),
-                    "kind": "issue",
-                    "_cursor": self._high_water or "",
-                },
-            )
-            if self._config.include_comments:
-                async for comment in self._iter_comments(issue_key):
-                    cid = str(comment.get("id", ""))
-                    cpath = f"{full}/comments/{cid}"
-                    if filter.include and not _matches_any(cpath, filter.include):
-                        continue
-                    if filter.exclude and _matches_any(cpath, filter.exclude):
-                        continue
-                    ctext = _serialise_comment(comment)
-                    self._documents[cpath] = ctext
-                    cupdated = comment.get("updated") or comment.get("created")
-                    yield DocumentRef(
-                        source_id=self.id,
-                        source_kind=self.kind,
-                        path=cpath,
-                        native_url=_issue_url(
-                            self._config.base_url, issue_key, comment_id=cid
-                        ),
-                        content_type="text/plain",
-                        size=len(ctext),
-                        etag=cid,
-                        last_modified=_parse_iso(cupdated),
-                        metadata={
-                            "project_key": str(project_key or ""),
-                            "issue_key": issue_key,
-                            "comment_id": cid,
-                            "kind": "comment",
-                        },
-                    )
+        """Yield one DocumentRef per issue updated since `cursor`.
+
+        The cursor is a JSON object carrying `highest_updated`. JQL is
+        built as `project = X AND updated >= "<ts>" ORDER BY updated
+        ASC`; ASC ordering means the last issue we see has the highest
+        `updated`, which we persist as the next cursor.
+        """
+        prior_high_water = _decode_cursor(cursor)
+        # `filter.since` overrides the cursor when both are present;
+        # operator-supplied `--since` is the authoritative knob (tests
+        # also rely on this for deterministic JQL assertions).
+        since = (
+            filter.since.isoformat()
+            if filter.since is not None
+            else prior_high_water
+        )
+        projects = await self._enumerate_projects(filter)
+        for project_key in projects:
+            async for issue in self._iter_issues(project_key, since=since):
+                key = issue.get("key")
+                if not isinstance(key, str) or not key:
+                    # Defensive: Jira's response schema is stable but
+                    # third-party Jira-compatible servers occasionally
+                    # emit issues without a key. Skip rather than crash.
+                    continue
+                comments: list[Mapping[str, Any]] = []
+                if self._config.include_comments:
+                    comments = await self._fetch_comments(key)
+                async with self._lock:
+                    self._issue_cache[key] = {
+                        "issue": issue,
+                        "comments": comments,
+                    }
+                    updated = _issue_updated(issue)
+                    if updated and (
+                        self._high_water is None or updated > self._high_water
+                    ):
+                        self._high_water = updated
+                yield self._issue_to_ref(project_key, issue, comments)
 
     async def fetch(
         self,
         ref: DocumentRef,
     ) -> AsyncIterator[Document | DocumentChunk]:
-        text = self._documents.get(ref.path)
-        if text is None:
+        """Materialise an issue into one Document."""
+        key = ref.metadata.get("key")
+        if not key:
+            return
+        async with self._lock:
+            cached = self._issue_cache.get(key)
+        if cached is None:
+            # The ref was emitted by a different connector instance, or
+            # the cache was already drained. Fall back to a live fetch
+            # so the operator can hand-craft a DocumentRef and still
+            # pull the body.
+            issue = await self._api.get(f"/issue/{key}")
+            comments: list[Mapping[str, Any]] = []
+            if self._config.include_comments and issue:
+                comments = await self._fetch_comments(key)
+        else:
+            issue = cached["issue"]
+            comments = cached["comments"]
+        if not issue:
+            return
+        text = self._serialise_issue(issue, comments)
+        if not text:
             return
         yield Document(
             ref=ref,
             text=text,
             fetched_at=datetime.now(UTC),
-            extra=dict(ref.metadata),
+            content_hash=str(key),
         )
 
     def cursor_after_run(self) -> Cursor | None:
-        """ISO-8601 timestamp of the newest issue seen this run, or None."""
-        return self._high_water
+        """Return the JSON-encoded cursor for the next incremental run.
+
+        Returns `None` (not an empty JSON object) when nothing was
+        observed; callers persist `None` as "no resume token" rather
+        than emitting a placeholder cursor that would later need to be
+        special-cased.
+        """
+        if self._high_water is None:
+            return None
+        return json.dumps({"highest_updated": self._high_water}, sort_keys=True)
 
     async def close(self) -> None:
-        self._documents.clear()
-        if self._owns_client:
-            await self._client.aclose()
+        """Release the HTTP client + drop in-memory caches.
 
-    # --- internals ------------------------------------------------
+        `close()` must be idempotent — the scheduler invokes it from a
+        finally clause and may also call it explicitly on shutdown.
+        Clearing the caches first means a double-call cannot leak
+        references after the second invocation.
+        """
+        async with self._lock:
+            self._issue_cache.clear()
+            self._high_water = None
+        await self._api.aclose()
 
-    async def _iter_issues(self, jql: str) -> AsyncIterator[dict[str, Any]]:
-        if self._config.deployment == "cloud":
-            async for issue in self._iter_issues_cloud(jql):
-                yield issue
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    async def _enumerate_projects(
+        self, filter: SourceFilter
+    ) -> list[str]:
+        """Return project keys to scan, applying allow-list + filter."""
+        if self._config.projects:
+            # Operator-supplied allow-list short-circuits enumeration —
+            # fewer API calls + the operator's intent is authoritative.
+            allow = list(self._config.projects)
         else:
-            async for issue in self._iter_issues_dc(jql):
-                yield issue
+            allow = await self._list_all_projects()
+        out: list[str] = []
+        for project_key in allow:
+            if filter.include and not _matches_any(project_key, filter.include):
+                continue
+            if filter.exclude and _matches_any(project_key, filter.exclude):
+                continue
+            out.append(project_key)
+        return out
 
-    async def _iter_issues_cloud(
-        self, jql: str
-    ) -> AsyncIterator[dict[str, Any]]:
-        next_token: str | None = None
-        pages = 0
-        while pages < _MAX_PAGES:  # pragma: no branch
-            pages += 1
-            params: dict[str, Any] = {
-                "jql": jql,
-                "fields": "summary,description,updated,project",
-            }
-            if next_token is not None:
-                params["nextPageToken"] = next_token
-            body = await self._get_json(_SEARCH_PATH, params=params)
-            issues = body.get("issues", []) or []
-            for issue in issues:
-                yield issue
-            next_token = body.get("nextPageToken")
-            if not next_token or not issues:
-                return
-
-    async def _iter_issues_dc(self, jql: str) -> AsyncIterator[dict[str, Any]]:
+    async def _list_all_projects(self) -> list[str]:
+        """Page through `/project/search` and return every project key."""
+        keys: list[str] = []
         start_at = 0
-        max_results = 50
-        pages = 0
-        while pages < _MAX_PAGES:  # pragma: no branch
-            pages += 1
-            params: dict[str, Any] = {
-                "jql": jql,
-                "fields": "summary,description,updated,project",
-                "startAt": start_at,
-                "maxResults": max_results,
-            }
-            body = await self._get_json(_SEARCH_PATH, params=params)
-            issues = body.get("issues", []) or []
+        depth = 0
+        while True:
+            depth += 1
+            if depth > _MAX_PAGINATION_DEPTH:
+                # See `_MAX_PAGINATION_DEPTH`: defensive against a
+                # buggy upstream that never sets `isLast`. Surfacing as
+                # an explicit failure beats spinning the discover loop.
+                raise RuntimeError(  # pragma: no cover
+                    f"jira /project/search exceeded {_MAX_PAGINATION_DEPTH} pages"
+                )
+            body = await self._api.get(
+                "/project/search",
+                params={"startAt": start_at, "maxResults": _PAGE_SIZE},
+            )
+            if not body:
+                return keys
+            values = body.get("values") or []
+            for project in values:
+                key = (
+                    project.get("key") if isinstance(project, Mapping) else None
+                )
+                if isinstance(key, str) and key:
+                    keys.append(key)
+            if body.get("isLast", True):
+                return keys
+            if not values:
+                # No values on this page but isLast=false — break to
+                # avoid an infinite loop. Treat as end-of-list.
+                return keys
+            start_at += len(values)
+
+    async def _iter_issues(
+        self, project_key: str, *, since: str | None
+    ) -> AsyncIterator[Mapping[str, Any]]:
+        """Paginate `/search` issues for `project_key`, applying `since`."""
+        jql = _build_jql(project_key, since)
+        # Field selection: keep the response payload small but include
+        # everything the serialiser needs. `*all` would balloon the
+        # response with every custom field; the explicit list keeps the
+        # surface stable for snapshot tests.
+        fields = ",".join(
+            (
+                "summary",
+                "status",
+                "assignee",
+                "reporter",
+                "description",
+                "updated",
+                "attachment",
+                "issuetype",
+                "priority",
+            )
+        )
+        start_at = 0
+        depth = 0
+        while True:
+            depth += 1
+            if depth > _MAX_PAGINATION_DEPTH:
+                raise RuntimeError(  # pragma: no cover
+                    f"jira /search exceeded {_MAX_PAGINATION_DEPTH} pages"
+                )
+            body = await self._api.get(
+                "/search",
+                params={
+                    "jql": jql,
+                    "startAt": start_at,
+                    "maxResults": _PAGE_SIZE,
+                    "fields": fields,
+                },
+            )
+            if not body:
+                return
+            issues = body.get("issues") or []
             for issue in issues:
-                yield issue
+                if isinstance(issue, Mapping):
+                    yield issue
+            total = body.get("total")
+            new_start = start_at + len(issues)
             if not issues:
                 return
-            total = body.get("total")
-            start_at += len(issues)
-            # Use server-reported max when present (lets the server
-            # cap pages without us guessing wrong).
-            srv_max = body.get("maxResults")
-            if isinstance(srv_max, int) and srv_max > 0:
-                max_results = srv_max
-            if isinstance(total, int) and start_at >= total:
+            # End-of-list when we've consumed every issue Jira reports.
+            # `total` is best-effort (Jira documents it as approximate)
+            # so we also stop when a page is shorter than maxResults.
+            if isinstance(total, int) and new_start >= total:
                 return
+            if len(issues) < _PAGE_SIZE:
+                return
+            start_at = new_start
 
-    async def _iter_comments(
+    async def _fetch_comments(
         self, issue_key: str
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> list[Mapping[str, Any]]:
+        """Paginate `/issue/{key}/comment` and return every comment."""
+        out: list[Mapping[str, Any]] = []
         start_at = 0
-        pages = 0
-        while pages < _MAX_PAGES:  # pragma: no branch
-            pages += 1
-            body = await self._get_json(
-                _ISSUE_PATH_TPL.format(key=issue_key),
-                params={"startAt": start_at, "maxResults": 100},
+        depth = 0
+        while True:
+            depth += 1
+            if depth > _MAX_PAGINATION_DEPTH:
+                raise RuntimeError(  # pragma: no cover
+                    f"jira /issue/{issue_key}/comment exceeded "
+                    f"{_MAX_PAGINATION_DEPTH} pages"
+                )
+            body = await self._api.get(
+                f"/issue/{issue_key}/comment",
+                params={
+                    "startAt": start_at,
+                    "maxResults": _COMMENT_PAGE_SIZE,
+                },
             )
-            comments = body.get("comments", []) or []
-            for c in comments:
-                yield c
-            if not comments:
-                return
+            if not body:
+                return out
+            comments = body.get("comments") or []
+            for comment in comments:
+                if isinstance(comment, Mapping):
+                    out.append(comment)
             total = body.get("total")
-            start_at += len(comments)
-            if isinstance(total, int) and start_at >= total:
-                return
+            new_start = start_at + len(comments)
+            if not comments:
+                return out
+            if isinstance(total, int) and new_start >= total:
+                return out
+            if len(comments) < _COMMENT_PAGE_SIZE:
+                return out
+            start_at = new_start
 
-    async def _get_json(
-        self, path: str, *, params: Mapping[str, Any] | None = None
-    ) -> dict[str, Any]:
-        resp = await self._client.get(
-            path, params=params, headers=self._auth_headers
+    # --- ref + serialisation -----------------------------------------
+
+    def _issue_to_ref(
+        self,
+        project_key: str,
+        issue: Mapping[str, Any],
+        comments: Sequence[Mapping[str, Any]],
+    ) -> DocumentRef:
+        key = str(issue.get("key", ""))
+        fields = issue.get("fields") or {}
+        summary = fields.get("summary") if isinstance(fields, Mapping) else None
+        last_modified = _parse_iso(_issue_updated(issue))
+        # `etag` keys cache short-circuit: the issue's own `updated`
+        # changes monotonically, so the scheduler can use it to skip
+        # unchanged refs even when the cursor pulls them in.
+        etag = _issue_updated(issue)
+        size = len(summary) if isinstance(summary, str) else None
+        host = _host_only(self._config.base_url)
+        native_url = f"https://{host}/browse/{key}" if key else None
+        return DocumentRef(
+            source_id=self.id,
+            source_kind=self.kind,
+            path=f"jira://{project_key}/{key}",
+            native_url=native_url,
+            parent_chain=(f"jira://{project_key}",),
+            content_type="text/plain",
+            size=size,
+            etag=etag,
+            last_modified=last_modified,
+            metadata={
+                "key": key,
+                "project": project_key,
+                "flavor": self._config.flavor,
+                "comment_count": str(len(comments)),
+            },
         )
-        resp.raise_for_status()
-        return resp.json()
+
+    def _serialise_issue(
+        self,
+        issue: Mapping[str, Any],
+        comments: Sequence[Mapping[str, Any]],
+    ) -> str:
+        """Render an issue + its comments + attachments as one text block."""
+        fields = issue.get("fields")
+        if not isinstance(fields, Mapping):
+            fields = {}
+        parts: list[str] = []
+        key = issue.get("key")
+        if isinstance(key, str) and key:
+            parts.append(f"key={key}")
+        summary = fields.get("summary")
+        if isinstance(summary, str) and summary:
+            parts.append(f"summary={summary}")
+        status = _named(fields.get("status"))
+        if status:
+            parts.append(f"status={status}")
+        assignee = _display_name(fields.get("assignee"))
+        if assignee:
+            parts.append(f"assignee={assignee}")
+        reporter = _display_name(fields.get("reporter"))
+        if reporter:
+            parts.append(f"reporter={reporter}")
+        # Body conversion differs between flavors: Cloud is ADF JSON,
+        # DC is storage-XHTML string. The dispatcher picks the right
+        # converter based on the connector's flavor.
+        description_text = self._convert_body(fields.get("description"))
+        if description_text:
+            parts.append(f"description={description_text}")
+        for comment in comments:
+            comment_id = comment.get("id")
+            author = _display_name(
+                comment.get("author") or comment.get("updateAuthor")
+            )
+            body_text = self._convert_body(comment.get("body"))
+            if not body_text:
+                continue
+            label = f"comment[{comment_id}]" if comment_id else "comment"
+            if author:
+                parts.append(f"{label}={author}: {body_text}")
+            else:
+                parts.append(f"{label}={body_text}")
+        if self._config.include_attachments:
+            for attachment in fields.get("attachment") or []:
+                if not isinstance(attachment, Mapping):
+                    continue
+                name = (
+                    attachment.get("filename") or attachment.get("name") or ""
+                )
+                content_url = (
+                    attachment.get("content")
+                    or attachment.get("contentUrl")
+                    or ""
+                )
+                if name or content_url:
+                    parts.append(f"attachment={name}, url={content_url}")
+        return "\n".join(parts)
+
+    def _convert_body(self, body: Any) -> str:
+        """Dispatch body conversion based on the configured flavor.
+
+        Cloud bodies are ADF JSON (`{"type": "doc", "content": [...]}`);
+        DC bodies are storage-XHTML strings (or, for some custom-field
+        shapes, a `{"value": "...", "representation": "..."}` wrapper).
+        """
+        if body is None or body == "":
+            return ""
+        if self._config.flavor == "cloud":
+            # Cloud sometimes returns a raw string for legacy custom
+            # fields configured to use "text" representation; fall back
+            # to the storage stripper which handles plain strings too.
+            if isinstance(body, str):
+                return storage_to_text(body)
+            return adf_to_text(body)
+        return storage_to_text(body)
 
 
-# --- auth ---------------------------------------------------------
+# ---------------------------------------------------------------------
+# JQL + parsing helpers
+# ---------------------------------------------------------------------
 
 
-def _build_auth_headers(cfg: JiraConfig) -> dict[str, str]:
-    if cfg.deployment == "dc":
-        return {"Authorization": f"Bearer {cfg.api_token}"}
-    # Cloud: HTTP basic auth `email:api_token`.
-    raw = f"{cfg.email}:{cfg.api_token}".encode()
-    return {"Authorization": f"Basic {base64.b64encode(raw).decode()}"}
+def _build_jql(project_key: str, since: str | None) -> str:
+    """Render the JQL string for incremental issue enumeration.
 
-
-# --- JQL ----------------------------------------------------------
-
-
-def _build_jql(projects: tuple[str, ...], cursor: Cursor | None) -> str:
-    clauses: list[str] = []
-    if projects:
-        rendered = ", ".join(f'"{p}"' for p in projects)
-        clauses.append(f"project in ({rendered})")
-    if cursor:
-        # Quote the timestamp so JQL accepts it verbatim.
-        clauses.append(f'updated >= "{cursor}"')
-    where = " AND ".join(clauses)
-    if where:
-        return f"{where} ORDER BY updated ASC"
-    return "ORDER BY updated ASC"
-
-
-# --- ADF → text ---------------------------------------------------
-
-
-# Node types whose end implies a structural newline.
-_BLOCK_NODES: frozenset[str] = frozenset(
-    {"paragraph", "heading", "listItem", "blockquote", "codeBlock"}
-)
-
-
-def adf_to_text(node: Any) -> str:
-    """Walk an ADF tree and emit plain text.
-
-    Concatenates every `text` node verbatim. Inserts a newline after
-    each block-level node (`paragraph`, `heading`, `listItem`, ...).
-    Unknown node types are descended unconditionally — this means a
-    new ADF node introduced by Atlassian still has its `text` children
-    extracted, even before this walker is updated.
+    `project = "X"` is quoted so a project key containing reserved
+    characters (legal in DC for legacy projects) does not produce a
+    syntax error. `updated >= "..."` uses Jira's documented timestamp
+    form. ASC ordering is required so the last issue we see is the
+    highest-updated, which feeds the next cursor.
     """
-    out: list[str] = []
-    _walk_adf(node, out)
-    # Collapse repeated blank lines so the output stays readable.
-    text = "".join(out)
-    # Trim trailing whitespace per line, drop trailing newlines.
-    return text.rstrip()
+    clauses = [f'project = "{project_key}"']
+    if since:
+        clauses.append(f'updated >= "{since}"')
+    return " AND ".join(clauses) + " ORDER BY updated ASC"
 
 
-def _walk_adf(node: Any, out: list[str]) -> None:
-    if node is None:
-        return
-    if isinstance(node, list):
-        for child in node:
-            _walk_adf(child, out)
-        return
-    if not isinstance(node, Mapping):
-        # Strings or other scalars at a non-text position — surface
-        # them verbatim. Defensive against malformed wire data.
-        if isinstance(node, str):
-            out.append(node)
-        return
-    ntype = node.get("type")
-    if ntype == "text":
-        text = node.get("text", "")
-        if isinstance(text, str):
-            out.append(text)
-        return
-    # Descend into any "content" array (the canonical ADF child slot).
-    content = node.get("content")
-    if content is not None:
-        _walk_adf(content, out)
-    if ntype in _BLOCK_NODES:
-        out.append("\n")
+def _decode_cursor(cursor: Cursor | None) -> str | None:
+    """Parse a JSON cursor and return `highest_updated` if present.
 
-
-# --- serialisation ------------------------------------------------
-
-
-def _serialise_issue(issue: Mapping[str, Any]) -> str:
-    fields = issue.get("fields", {}) or {}
-    summary = fields.get("summary", "") or ""
-    desc = fields.get("description")
-    desc_text = adf_to_text(desc) if desc else ""
-    parts: list[str] = []
-    parts.append(f"key={issue.get('key', '')}")
-    parts.append(f"summary={summary}")
-    if desc_text:
-        parts.append(f"description={desc_text}")
-    return "\n".join(parts)
-
-
-def _serialise_comment(comment: Mapping[str, Any]) -> str:
-    body = comment.get("body")
-    body_text = adf_to_text(body) if body else ""
-    author = comment.get("author") or {}
-    author_name = author.get("displayName") if isinstance(author, Mapping) else ""
-    parts: list[str] = []
-    parts.append(f"id={comment.get('id', '')}")
-    if author_name:
-        parts.append(f"author={author_name}")
-    if body_text:
-        parts.append(f"body={body_text}")
-    return "\n".join(parts)
-
-
-# --- helpers ------------------------------------------------------
-
-
-def _matches_any(s: str, patterns: tuple[str, ...]) -> bool:
-    return any(fnmatch(s, p) for p in patterns)
+    Cursor is `str` in the core API. We persist a JSON object and
+    silently fall back to None on any decode failure — the caller
+    sees a fresh full scan, never a crash on a stale cursor format.
+    Empty string also falls back to None (rather than treating "" as
+    a literal JQL value, which Jira would reject).
+    """
+    if not cursor:
+        return None
+    try:
+        decoded = json.loads(cursor)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(decoded, Mapping):
+        return None
+    value = decoded.get("highest_updated")
+    if isinstance(value, str) and value:
+        return value
+    return None
 
 
 def _parse_iso(value: Any) -> datetime | None:
+    """Best-effort ISO-8601 parse; None if value is missing or malformed.
+
+    Jira emits `2026-05-04T12:34:56.789+0000` — Python's
+    `datetime.fromisoformat` accepts the colon-bearing offset form
+    starting in 3.11; we normalise the offset to be safe across runtimes.
+    """
     if not isinstance(value, str) or not value:
         return None
-    # Jira Cloud emits ISO-8601 with `Z` suffix; DC emits a numeric
-    # offset without colon (`+0000`). Both round-trip through
-    # `fromisoformat` after the `Z`→`+00:00` rewrite on Py3.12, with
-    # `strptime` as a last-ditch fallback for the older format.
+    normalised = value
+    if "+" in normalised[19:] or "-" in normalised[19:]:
+        # Insert a colon into the offset if missing (`+0000` -> `+00:00`).
+        head, sep, tail = (
+            normalised.rpartition("+")
+            if "+" in normalised[19:]
+            else normalised.rpartition("-")
+        )
+        if sep and len(tail) == 4 and tail.isdigit():
+            normalised = f"{head}{sep}{tail[:2]}:{tail[2:]}"
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        pass
-    try:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
+        return datetime.fromisoformat(normalised.replace("Z", "+00:00"))
     except ValueError:
         return None
 
 
-def _issue_url(base_url: str, issue_key: str, *, comment_id: str | None = None) -> str:
-    base = base_url.rstrip("/")
-    if comment_id:
-        return f"{base}/browse/{issue_key}?focusedCommentId={comment_id}"
-    return f"{base}/browse/{issue_key}"
+def _issue_updated(issue: Mapping[str, Any]) -> str | None:
+    """Return the issue's `fields.updated` ISO timestamp, if present."""
+    fields = issue.get("fields")
+    if not isinstance(fields, Mapping):
+        return None
+    updated = fields.get("updated")
+    if isinstance(updated, str) and updated:
+        return updated
+    return None
 
 
-# --- factory / spec -----------------------------------------------
+def _named(field: Any) -> str:
+    """Pull `name` out of a `{name: ...}` Jira sub-object."""
+    if isinstance(field, Mapping):
+        name = field.get("name")
+        if isinstance(name, str):
+            return name
+    return ""
+
+
+def _display_name(field: Any) -> str:
+    """Pull `displayName` (Cloud + DC) out of a user sub-object.
+
+    Falls back to `name` (DC-only username) when displayName is
+    unavailable; Cloud removed `name` in 2019 for GDPR but DC still
+    exposes it.
+    """
+    if isinstance(field, Mapping):
+        for key in ("displayName", "name", "emailAddress", "accountId"):
+            v = field.get(key)
+            if isinstance(v, str) and v:
+                return v
+    return ""
+
+
+def _host_only(base_url: str) -> str:
+    """Extract the host portion of a base URL, stripping scheme + path."""
+    # Walk a tiny state machine rather than pulling in urllib for one
+    # field; keeps the package free of stdlib import cycles.
+    s = base_url
+    for prefix in ("https://", "http://"):
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    if "/" in s:
+        s = s.split("/", 1)[0]
+    return s
+
+
+def _matches_any(s: str, patterns: tuple[str, ...]) -> bool:
+    from fnmatch import fnmatch
+
+    return any(fnmatch(s, p) for p in patterns)
+
+
+# ---------------------------------------------------------------------
+# Factory + Spec
+# ---------------------------------------------------------------------
 
 
 def _factory(config: Mapping[str, Any]) -> SourceConnector:
+    """Build a connector from a plain config mapping.
+
+    Required keys: `flavor`, `base_url`, plus exactly one auth mode.
+    All other keys map to JiraConfig defaults.
+    """
+    flavor_raw = config.get("flavor")
+    if flavor_raw not in ("cloud", "datacenter"):
+        raise ValueError(
+            f"jira connector config['flavor'] must be 'cloud' or "
+            f"'datacenter'; got {flavor_raw!r}"
+        )
     if "base_url" not in config:
         raise ValueError("jira connector config requires 'base_url'")
-    if "api_token" not in config:
-        raise ValueError("jira connector config requires 'api_token'")
     return JiraConnector(
         JiraConfig(
+            flavor=flavor_raw,
             base_url=str(config["base_url"]),
-            email=str(config.get("email", "")),
-            api_token=str(config["api_token"]),
-            projects=tuple(str(p) for p in config.get("projects", ())),
+            email=_opt_str(config.get("email")),
+            api_token=_opt_str(config.get("api_token")),
+            access_token=_opt_str(config.get("access_token")),
+            username=_opt_str(config.get("username")),
+            password=_opt_str(config.get("password")),
+            projects=_string_tuple(config.get("projects")),
             include_comments=bool(config.get("include_comments", True)),
-            deployment=str(config.get("deployment", "cloud")),  # type: ignore[arg-type]
-            id=str(config["id"]) if config.get("id") is not None else None,
+            include_attachments=bool(config.get("include_attachments", True)),
+            request_timeout=float(
+                config.get("request_timeout", DEFAULT_TIMEOUT)
+            ),
+            id=_opt_str(config.get("id")),
         )
     )
 
 
+def _opt_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    s = str(value)
+    return s if s else None
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    """Accept list/tuple of strings; reject everything else loudly."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        # A bare string is almost certainly an operator typo (one key
+        # instead of a list); reject so they catch it before scan launch.
+        raise ValueError(
+            "jira connector list-typed configs (projects) must be a list, "
+            "not a bare string"
+        )
+    if not isinstance(value, Iterable):
+        raise ValueError(
+            "jira connector list-typed configs must be iterable"
+        )
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise ValueError(
+                "jira connector list-typed configs must contain non-empty strings"
+            )
+        out.append(item)
+    return tuple(out)
+
+
 SPEC = ConnectorSpec(
-    kind="jira",
+    kind=KIND,
     version="0.1.0",
     factory=_factory,
     capabilities=Capabilities(
@@ -488,13 +840,29 @@ SPEC = ConnectorSpec(
         max_concurrent_fetches=4,
         streaming=False,
     ),
-    required_scopes=("jira:read",),
+    required_scopes=(
+        # Cloud OAuth scope; DC PATs are scoped per-token in the admin
+        # UI rather than via API surface so this is an aspirational
+        # documentation hint for `connectors describe jira`.
+        "read:jira-work",
+        "read:jira-user",
+    ),
     description=(
-        "Atlassian Jira SourceConnector. Cloud + Data Center; paginates "
-        "/rest/api/3/search with JQL `updated >= <cursor>` for incremental "
-        "scans; walks ADF descriptions and comments into plain text."
+        "Atlassian Jira (Cloud + Data Center) connector. Single kind, two "
+        "wire flavors selected by config (`flavor=cloud|datacenter`). "
+        "Cloud: /rest/api/3 + ADF body conversion + 429 backoff. "
+        "DC: /rest/api/2 + storage-XHTML body conversion + 503 backoff. "
+        "Project enumeration with allow-list; JQL `updated >= cursor` "
+        "for incremental scan; comments + attachment refs included by "
+        "default; never downloads attachment bodies. ADR-0007 §13."
     ),
 )
 
 
-__all__ = ["JiraConfig", "JiraConnector", "SPEC", "adf_to_text"]
+__all__ = [
+    "KIND",
+    "SPEC",
+    "JiraConfig",
+    "JiraConnector",
+    "adf_to_text",
+]

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/storage.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/storage.py
@@ -1,0 +1,168 @@
+"""Storage XHTML -> plain-text converter for Data Center Jira.
+
+Data Center Jira (`/rest/api/2`) returns the issue `description` and
+comment bodies as a fragment of XHTML — wiki-style markup serialised
+into HTML for transport. We strip every tag and keep the text content
+so detectors see the same surface text a Jira reader would.
+
+Why a hand-rolled parser instead of `BeautifulSoup` / `lxml`:
+
+* The package goal is zero non-essential transitive dependencies; one
+  more wheel multiplies the supply-chain audit surface for enterprise
+  customers (ADR-0007 §13).
+* The input fragment is not a full HTML document — feeding it to a
+  full HTML5 parser invokes implicit `<html>`/`<body>` insertion that
+  changes the offsets we'd want for future highlight rendering.
+* The conversion is one-way and lossy on purpose; we only need the
+  textual leaves.
+
+The implementation uses Python's stdlib `html.parser.HTMLParser`,
+which is forgiving (treats unclosed tags as text), handles entities,
+and is part of the same security-update cycle as Python itself.
+"""
+
+from __future__ import annotations
+
+from html import unescape
+from html.parser import HTMLParser
+
+
+# Block-level tags that should produce a newline boundary so detectors
+# do not see neighbouring blocks as one run-on sentence. The list
+# matches the storage-XHTML elements Jira DC actually emits — extra
+# tags here cost nothing, missing ones merge sibling block text.
+_BLOCK_TAGS: frozenset[str] = frozenset(
+    {
+        "p",
+        "br",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "li",
+        "ul",
+        "ol",
+        "table",
+        "tr",
+        "blockquote",
+        "pre",
+        "hr",
+    }
+)
+
+
+# Tags whose text content we drop entirely. `<script>` / `<style>` are
+# defence in depth — Jira DC strips them server-side but a
+# misconfigured plugin or a custom field could let one through.
+_SKIP_TAGS: frozenset[str] = frozenset({"script", "style"})
+
+
+class _StorageStripper(HTMLParser):
+    """HTMLParser subclass that accumulates text content + block breaks.
+
+    `convert_charrefs=True` (the default in Python 3.5+) turns
+    `&amp;` into `&` automatically; we additionally call `html.unescape`
+    on the assembled output as a belt-and-suspenders measure for
+    references the parser might miss in malformed input.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        # Counter of currently-open `<script>` / `<style>` tags. We use
+        # a counter rather than a flag because nested skip tags (rare
+        # but legal) would otherwise unset on the inner `</script>` and
+        # re-emit the surrounding text.
+        self._skip_depth = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        del attrs
+        if tag in _SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if tag in _BLOCK_TAGS:
+            # Block boundary: ensure the previous run is followed by a
+            # newline so detector input has paragraph breaks.
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in _SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+            return
+        if tag in _BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        # Self-closing tags (`<br/>`, `<hr/>`) — treat as a block break.
+        del attrs
+        if tag in _BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth > 0:
+            return
+        self._parts.append(data)
+
+    def render(self) -> str:
+        # Collapse consecutive blank lines so a long stream of <br/>
+        # tags does not balloon the detector input. We keep one blank
+        # line as a paragraph separator; downstream NER batches on
+        # paragraph boundaries.
+        joined = unescape("".join(self._parts))
+        out_lines: list[str] = []
+        prev_blank = False
+        for line in joined.splitlines():
+            stripped = line.rstrip()
+            if not stripped:
+                if prev_blank:
+                    continue
+                prev_blank = True
+                out_lines.append("")
+            else:
+                prev_blank = False
+                out_lines.append(stripped)
+        return "\n".join(out_lines).strip()
+
+
+def storage_to_text(html: object) -> str:
+    """Render a Jira DC storage-XHTML fragment as plain text.
+
+    `html` is typed `object` because Jira's response shape varies:
+    some custom fields return `None`, some return raw strings, others
+    return a `{ "value": "...", "representation": "html" }` wrapper.
+    Callers can pass any of these and we fish out the string content.
+    """
+    if isinstance(html, str):
+        text = html
+    elif isinstance(html, dict):
+        # `body.storage.value` — both the comment storage shape and the
+        # custom-field storage shape land here.
+        v = html.get("value")
+        if isinstance(v, str):
+            text = v
+        else:
+            return ""
+    else:
+        return ""
+    if not text:
+        return ""
+    parser = _StorageStripper()
+    try:
+        parser.feed(text)
+        parser.close()
+    except Exception:
+        # HTMLParser raises on truly broken input (rare). Falling back
+        # to the unescape() of the raw string is better than dropping
+        # the entire body — detectors can still match on the raw text.
+        return unescape(text)
+    return parser.render()
+
+
+__all__ = ["storage_to_text"]

--- a/packages/pii-scanner-jira/tests/conftest.py
+++ b/packages/pii-scanner-jira/tests/conftest.py
@@ -1,0 +1,124 @@
+"""Shared hermetic-test fixtures for pleno-pii-scanner-jira.
+
+Tests never reach the real Jira API; every HTTP call is served by
+`httpx.MockTransport`. The `make_handler` helper builds a substring
+dispatcher so a single test can register canned responses for
+`/rest/api/3/project/search`, `/rest/api/2/search`, etc.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import httpx
+
+
+ResponseFactory = Callable[[httpx.Request], httpx.Response]
+
+
+def make_handler(
+    routes: Iterable[tuple[str, ResponseFactory]],
+) -> ResponseFactory:
+    """Build a routing handler from `(substring, response_fn)` tuples.
+
+    Routes are matched in order; the first containment match wins. An
+    unmatched URL raises `AssertionError` so a test never silently
+    receives a 200 for a URL it forgot to mock.
+    """
+    materialised = list(routes)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        for suffix, fn in materialised:
+            if suffix in url:
+                return fn(request)
+        raise AssertionError(
+            f"no route matches {request.method} {url}; "
+            f"routes={[r[0] for r in materialised]}"
+        )
+
+    return handler
+
+
+def queued(responses: Iterable[httpx.Response]) -> ResponseFactory:
+    """Pop the next pre-built response from `responses` per request."""
+    it = iter(responses)
+
+    def fn(_: httpx.Request) -> httpx.Response:
+        try:
+            return next(it)
+        except StopIteration as exc:
+            raise AssertionError("queued responses exhausted") from exc
+
+    return fn
+
+
+def json_response(payload: Any, *, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=payload)
+
+
+# --- ADF / storage fixture builders -------------------------------
+
+
+def adf_doc(*nodes: dict[str, Any]) -> dict[str, Any]:
+    """Wrap nodes into an ADF document root."""
+    return {"type": "doc", "version": 1, "content": list(nodes)}
+
+
+def adf_text(text: str, marks: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {"type": "text", "text": text}
+    if marks:
+        out["marks"] = marks
+    return out
+
+
+def cloud_issue(
+    key: str = "PROJ-1",
+    summary: str = "Investigate leak",
+    updated: str = "2026-05-04T00:00:00.000+0000",
+    description: dict[str, Any] | None = None,
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": "10000",
+        "key": key,
+        "fields": {
+            "summary": summary,
+            "updated": updated,
+            "status": {"name": "Open"},
+            "assignee": {"displayName": "Alice"},
+            "reporter": {"displayName": "Bob"},
+            "description": description or adf_doc(
+                {
+                    "type": "paragraph",
+                    "content": [adf_text("Hello, world.")],
+                }
+            ),
+            "attachment": attachments or [],
+        },
+    }
+
+
+def dc_issue(
+    key: str = "PROJ-1",
+    summary: str = "DC issue",
+    updated: str = "2026-05-04T00:00:00.000+0000",
+    description: str | None = None,
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": "10000",
+        "key": key,
+        "fields": {
+            "summary": summary,
+            "updated": updated,
+            "status": {"name": "Open"},
+            "assignee": {"displayName": "Alice", "name": "alice"},
+            "reporter": {"displayName": "Bob", "name": "bob"},
+            "description": (
+                description if description is not None else "<p>Hello, <b>world</b>.</p>"
+            ),
+            "attachment": attachments or [],
+        },
+    }

--- a/packages/pii-scanner-jira/tests/test_adf.py
+++ b/packages/pii-scanner-jira/tests/test_adf.py
@@ -1,0 +1,585 @@
+"""Hermetic tests for ADF -> plain-text conversion."""
+
+from __future__ import annotations
+
+from pleno_pii_scanner_jira.adf import (
+    DEPTH_TRUNCATED_MARKER,
+    MAX_DEPTH,
+    adf_to_text,
+)
+from tests.conftest import adf_doc, adf_text
+
+
+# --- input shape tolerance ----------------------------------------
+
+
+class TestInputShape:
+    def test_none_returns_empty(self) -> None:
+        assert adf_to_text(None) == ""
+
+    def test_int_returns_empty(self) -> None:
+        # Defensive against malformed responses where Jira hands back
+        # a number (e.g. for legacy custom fields).
+        assert adf_to_text(123) == ""
+
+    def test_bare_string_passes_through(self) -> None:
+        # When a raw string slips past the schema we still surface the
+        # text so the operator sees the leak.
+        assert adf_to_text("plain string") == "plain string"
+
+    def test_list_of_nodes(self) -> None:
+        # Some test setups pass `doc["content"]` directly.
+        out = adf_to_text(
+            [
+                {"type": "paragraph", "content": [adf_text("hi")]},
+                {"type": "paragraph", "content": [adf_text("world")]},
+            ]
+        )
+        assert "hi" in out
+        assert "world" in out
+
+    def test_doc_root(self) -> None:
+        doc = adf_doc({"type": "paragraph", "content": [adf_text("body")]})
+        assert "body" in adf_to_text(doc)
+
+
+# --- per-node-type rendering --------------------------------------
+
+
+class TestNodeTypes:
+    def test_paragraph(self) -> None:
+        doc = adf_doc({"type": "paragraph", "content": [adf_text("hello")]})
+        assert adf_to_text(doc).strip() == "hello"
+
+    def test_heading(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "heading",
+                "attrs": {"level": 1},
+                "content": [adf_text("Title")],
+            }
+        )
+        assert "Title" in adf_to_text(doc)
+
+    def test_bullet_list(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [adf_text("first")],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [adf_text("second")],
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+        out = adf_to_text(doc)
+        assert "first" in out and "second" in out
+
+    def test_ordered_list(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "orderedList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [adf_text("alpha")],
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+        assert "alpha" in adf_to_text(doc)
+
+    def test_code_block(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python"},
+                "content": [adf_text('password = "leak"')],
+            }
+        )
+        assert 'password = "leak"' in adf_to_text(doc)
+
+    def test_inline_code_node(self) -> None:
+        # Some ADF dialects emit a top-level `code` leaf.
+        out = adf_to_text({"type": "code", "text": "inline-leak"})
+        assert out == "inline-leak"
+
+    def test_inline_code_node_without_text(self) -> None:
+        assert adf_to_text({"type": "code"}) == ""
+
+    def test_mention_uses_attrs_text(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "mention",
+                        "attrs": {"id": "557058:abc", "text": "@Alice Smith"},
+                    }
+                ],
+            }
+        )
+        assert "@Alice Smith" in adf_to_text(doc)
+
+    def test_mention_falls_back_to_id(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "mention", "attrs": {"id": "557058:abc"}}
+                ],
+            }
+        )
+        assert "@557058:abc" in adf_to_text(doc)
+
+    def test_mention_without_attrs_is_empty(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [{"type": "mention"}],
+            }
+        )
+        assert adf_to_text(doc) == ""
+
+    def test_emoji_shortname(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "emoji", "attrs": {"shortName": ":+1:"}}
+                ],
+            }
+        )
+        assert ":+1:" in adf_to_text(doc)
+
+    def test_emoji_text_fallback(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [{"type": "emoji", "attrs": {"text": "thumbs"}}],
+            }
+        )
+        assert "thumbs" in adf_to_text(doc)
+
+    def test_emoji_without_attrs_empty(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [{"type": "emoji"}],
+            }
+        )
+        assert adf_to_text(doc) == ""
+
+    def test_hard_break_emits_newline(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    adf_text("a"),
+                    {"type": "hardBreak"},
+                    adf_text("b"),
+                ],
+            }
+        )
+        out = adf_to_text(doc)
+        assert "a" in out and "b" in out
+
+    def test_inline_card(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "inlineCard",
+                        "attrs": {"url": "https://example.com/leak?token=xyz"},
+                    }
+                ],
+            }
+        )
+        assert "https://example.com/leak?token=xyz" in adf_to_text(doc)
+
+    def test_inline_card_without_attrs_empty(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [{"type": "inlineCard"}],
+            }
+        )
+        assert adf_to_text(doc) == ""
+
+    def test_media_single_with_media_attrs(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "mediaSingle",
+                "content": [
+                    {
+                        "type": "media",
+                        "attrs": {
+                            "id": "abc",
+                            "collection": "MediaServicesSample",
+                            "alt": "screenshot.png",
+                        },
+                    }
+                ],
+            }
+        )
+        out = adf_to_text(doc)
+        assert "id=abc" in out
+        assert "alt=screenshot.png" in out
+
+    def test_media_no_attrs_empty(self) -> None:
+        doc = adf_doc({"type": "media"})
+        assert adf_to_text(doc) == ""
+
+    def test_panel(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "panel",
+                "attrs": {"panelType": "warning"},
+                "content": [
+                    {"type": "paragraph", "content": [adf_text("be careful")]}
+                ],
+            }
+        )
+        assert "be careful" in adf_to_text(doc)
+
+    def test_blockquote(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "blockquote",
+                "content": [
+                    {"type": "paragraph", "content": [adf_text("quoted")]}
+                ],
+            }
+        )
+        assert "quoted" in adf_to_text(doc)
+
+    def test_rule_no_crash(self) -> None:
+        doc = adf_doc(
+            {"type": "paragraph", "content": [adf_text("a")]},
+            {"type": "rule"},
+            {"type": "paragraph", "content": [adf_text("b")]},
+        )
+        out = adf_to_text(doc)
+        assert "a" in out and "b" in out
+
+    def test_table(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableHeader",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("name")],
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "tableHeader",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("ssn")],
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableCell",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("alice")],
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "tableCell",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("123-45-6789")],
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+        out = adf_to_text(doc)
+        assert "name\tssn" in out
+        assert "alice\t123-45-6789" in out
+
+    def test_expand(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "expand",
+                "attrs": {"title": "details"},
+                "content": [
+                    {"type": "paragraph", "content": [adf_text("hidden body")]}
+                ],
+            }
+        )
+        assert "hidden body" in adf_to_text(doc)
+
+
+# --- marks (link in particular) -----------------------------------
+
+
+class TestMarks:
+    def test_link_mark_renders_url(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    adf_text(
+                        "click",
+                        marks=[
+                            {
+                                "type": "link",
+                                "attrs": {
+                                    "href": "https://acme/?token=secret"
+                                },
+                            }
+                        ],
+                    )
+                ],
+            }
+        )
+        out = adf_to_text(doc)
+        assert "click" in out
+        assert "https://acme/?token=secret" in out
+
+    def test_link_mark_same_text_no_duplicate(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    adf_text(
+                        "https://acme",
+                        marks=[
+                            {
+                                "type": "link",
+                                "attrs": {"href": "https://acme"},
+                            }
+                        ],
+                    )
+                ],
+            }
+        )
+        out = adf_to_text(doc).strip()
+        assert out == "https://acme"
+
+    def test_bold_mark_dropped(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [adf_text("bold", marks=[{"type": "strong"}])],
+            }
+        )
+        assert adf_to_text(doc).strip() == "bold"
+
+    def test_text_without_marks_field(self) -> None:
+        # No marks at all — most common case.
+        assert (
+            adf_to_text({"type": "text", "text": "plain"}) == "plain"
+        )
+
+    def test_text_with_non_mapping_marks(self) -> None:
+        # Defensive: a malformed `marks` field.
+        out = adf_to_text(
+            {"type": "text", "text": "x", "marks": ["not a mapping"]}
+        )
+        assert out == "x"
+
+    def test_text_missing_text_field(self) -> None:
+        assert adf_to_text({"type": "text"}) == ""
+
+    def test_link_mark_without_attrs(self) -> None:
+        doc = adf_doc(
+            {
+                "type": "paragraph",
+                "content": [
+                    adf_text("click", marks=[{"type": "link"}])
+                ],
+            }
+        )
+        assert adf_to_text(doc).strip() == "click"
+
+
+# --- unknown nodes -------------------------------------------------
+
+
+class TestUnsupported:
+    def test_unknown_type_emits_marker(self) -> None:
+        out = adf_to_text({"type": "futureWidget"})
+        assert "<!-- unsupported: futureWidget -->" in out
+
+    def test_unknown_type_with_children_continues(self) -> None:
+        out = adf_to_text(
+            {
+                "type": "futureWidget",
+                "content": [
+                    {"type": "paragraph", "content": [adf_text("inside")]}
+                ],
+            }
+        )
+        assert "<!-- unsupported: futureWidget -->" in out
+        assert "inside" in out
+
+    def test_node_without_type_is_empty(self) -> None:
+        assert adf_to_text({"text": "no type"}) == ""
+
+    def test_non_mapping_in_sequence_skipped(self) -> None:
+        # Sequence with garbage entries is tolerated.
+        out = adf_to_text(
+            [
+                {"type": "paragraph", "content": [adf_text("a")]},
+                "string entry",
+                None,
+                {"type": "paragraph", "content": [adf_text("b")]},
+            ]
+        )
+        assert "a" in out and "b" in out
+
+
+# --- depth bounding ------------------------------------------------
+
+
+class TestDepthBound:
+    def test_truncates_deeply_nested_input(self) -> None:
+        # Build a chain of nested panels exceeding MAX_DEPTH.
+        node: dict = {"type": "paragraph", "content": [adf_text("leaf")]}
+        for _ in range(MAX_DEPTH + 5):
+            node = {"type": "panel", "content": [node]}
+        out = adf_to_text(node)
+        assert DEPTH_TRUNCATED_MARKER in out
+
+    def test_below_depth_renders_normally(self) -> None:
+        node: dict = {"type": "paragraph", "content": [adf_text("leaf")]}
+        for _ in range(5):
+            node = {"type": "panel", "content": [node]}
+        out = adf_to_text(node)
+        assert "leaf" in out
+        assert DEPTH_TRUNCATED_MARKER not in out
+
+    def test_custom_max_depth(self) -> None:
+        node: dict = {"type": "paragraph", "content": [adf_text("leaf")]}
+        for _ in range(10):
+            node = {"type": "panel", "content": [node]}
+        out = adf_to_text(node, max_depth=2)
+        assert DEPTH_TRUNCATED_MARKER in out
+
+
+# --- defensive container handling --------------------------------
+
+
+class TestDefensive:
+    def test_bullet_list_non_sequence_content(self) -> None:
+        # `content` field present but not a list — should render empty.
+        assert adf_to_text({"type": "bulletList", "content": "oops"}) == ""
+
+    def test_bullet_list_skips_non_mapping_children(self) -> None:
+        out = adf_to_text(
+            {"type": "bulletList", "content": ["bad", None, 5]}
+        )
+        assert out == ""
+
+    def test_bullet_list_skips_non_list_item(self) -> None:
+        out = adf_to_text(
+            {
+                "type": "bulletList",
+                "content": [
+                    {"type": "paragraph", "content": [adf_text("not item")]}
+                ],
+            }
+        )
+        assert out == ""
+
+    def test_table_non_sequence_content(self) -> None:
+        assert adf_to_text({"type": "table", "content": "oops"}) == ""
+
+    def test_table_row_non_sequence_content(self) -> None:
+        assert adf_to_text({"type": "tableRow", "content": "oops"}) == ""
+
+    def test_table_skips_non_table_row(self) -> None:
+        out = adf_to_text(
+            {
+                "type": "table",
+                "content": [
+                    {"type": "paragraph", "content": [adf_text("not row")]}
+                ],
+            }
+        )
+        assert out == ""
+
+    def test_table_skips_non_mapping_rows(self) -> None:
+        assert adf_to_text({"type": "table", "content": ["bad"]}) == ""
+
+    def test_table_row_skips_non_cell(self) -> None:
+        out = adf_to_text(
+            {
+                "type": "tableRow",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [adf_text("not cell")],
+                    }
+                ],
+            }
+        )
+        assert out == ""
+
+    def test_table_row_skips_non_mapping_cell(self) -> None:
+        out = adf_to_text({"type": "tableRow", "content": ["bad"]})
+        assert out == ""
+
+    def test_emoji_attrs_with_non_string_shortname(self) -> None:
+        # shortName is non-string → skip; falls through to text fallback.
+        out = adf_to_text(
+            {"type": "emoji", "attrs": {"shortName": 5, "text": "ok"}}
+        )
+        assert out == "ok"
+
+    def test_emoji_attrs_neither_string(self) -> None:
+        assert adf_to_text({"type": "emoji", "attrs": {"shortName": 5}}) == ""
+
+    def test_inline_card_non_string_url(self) -> None:
+        assert adf_to_text({"type": "inlineCard", "attrs": {"url": 5}}) == ""
+
+    def test_inline_code_non_string_text(self) -> None:
+        assert adf_to_text({"type": "code", "text": 5}) == ""
+
+    def test_mention_non_string_text_and_id(self) -> None:
+        assert adf_to_text({"type": "mention", "attrs": {"text": 5, "id": 6}}) == ""

--- a/packages/pii-scanner-jira/tests/test_api.py
+++ b/packages/pii-scanner-jira/tests/test_api.py
@@ -1,0 +1,392 @@
+"""Hermetic tests for JiraApi (auth header, throttle, error path)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from pleno_pii_scanner_jira.api import (
+    BasicAuth,
+    BearerAuth,
+    JiraApi,
+    JiraApiError,
+)
+
+
+class TestAuthHeaders:
+    def test_basic_header_format(self) -> None:
+        auth = BasicAuth(username="alice@acme", password="tok")
+        # `Basic ` + base64("alice@acme:tok")
+        assert auth.header_value().startswith("Basic ")
+        # Defensive: secret value never appears in plaintext in header.
+        assert "tok" not in auth.header_value()
+
+    def test_bearer_header_format(self) -> None:
+        assert BearerAuth(token="abc").header_value() == "Bearer abc"
+
+
+class TestApiPrefix:
+    async def test_cloud_uses_v3(self) -> None:
+        observed: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(request.url.path)
+            return httpx.Response(200, json={"ok": True})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.get("/myself")
+            assert observed == ["/rest/api/3/myself"]
+        finally:
+            await api.aclose()
+
+    async def test_datacenter_uses_v2(self) -> None:
+        observed: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(request.url.path)
+            return httpx.Response(200, json={"ok": True})
+
+        api = JiraApi(
+            flavor="datacenter",
+            base_url="https://jira.acme.internal",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.get("/myself")
+            assert observed == ["/rest/api/2/myself"]
+        finally:
+            await api.aclose()
+
+    async def test_rest_path_passes_through(self) -> None:
+        observed: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(request.url.path)
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.get("/rest/auth/1/session")
+            assert observed == ["/rest/auth/1/session"]
+        finally:
+            await api.aclose()
+
+    async def test_path_without_leading_slash_normalised(self) -> None:
+        observed: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(request.url.path)
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.get("myself")  # no leading slash
+            assert observed == ["/rest/api/3/myself"]
+        finally:
+            await api.aclose()
+
+    async def test_absolute_url_passes_through(self) -> None:
+        observed: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(str(request.url))
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.get("https://other.example/x")
+            assert observed == ["https://other.example/x"]
+        finally:
+            await api.aclose()
+
+    def test_properties_exposed(self) -> None:
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net/",
+            auth=BearerAuth(token="t"),
+        )
+        try:
+            assert api.flavor == "cloud"
+            assert api.base_url == "https://acme.atlassian.net"
+            assert api.api_prefix == "/rest/api/3"
+        finally:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(api.aclose()) if False else None
+
+
+class TestRejectedFlavor:
+    def test_invalid_flavor(self) -> None:
+        with pytest.raises(ValueError, match="unsupported jira flavor"):
+            JiraApi(
+                flavor="server",  # type: ignore[arg-type]
+                base_url="x",
+                auth=BearerAuth(token="t"),
+            )
+
+
+class TestErrorMapping:
+    async def test_404_returns_empty_dict(self) -> None:
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"errorMessages": ["nope"]})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            assert await api.get("/issue/X-1") == {}
+        finally:
+            await api.aclose()
+
+    async def test_400_raises(self) -> None:
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="bad jql")
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            with pytest.raises(JiraApiError, match="400"):
+                await api.get("/search")
+        finally:
+            await api.aclose()
+
+    async def test_no_token_leak_in_error_message(self) -> None:
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="internal")
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="super-secret-token-xyz"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            with pytest.raises(JiraApiError) as exc:
+                await api.get("/myself")
+            assert "super-secret-token-xyz" not in str(exc.value)
+        finally:
+            await api.aclose()
+
+
+class TestThrottle:
+    async def test_429_then_200(self) -> None:
+        attempts = {"n": 0}
+        slept: list[float] = []
+
+        async def fake_sleep(t: float) -> None:
+            slept.append(t)
+
+        def handler(_r: httpx.Request) -> httpx.Response:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(429, headers={"Retry-After": "0.01"})
+            return httpx.Response(200, json={"ok": True})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            body = await api.get("/myself")
+            assert body == {"ok": True}
+            assert slept == [0.01]
+        finally:
+            await api.aclose()
+
+    async def test_503_dc_then_200(self) -> None:
+        attempts = {"n": 0}
+
+        async def fake_sleep(_t: float) -> None:
+            return None
+
+        def handler(_r: httpx.Request) -> httpx.Response:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(503, headers={"Retry-After": "0.01"})
+            return httpx.Response(200, json={"ok": True})
+
+        api = JiraApi(
+            flavor="datacenter",
+            base_url="https://jira.acme.internal",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            body = await api.get("/myself")
+            assert body == {"ok": True}
+        finally:
+            await api.aclose()
+
+    async def test_503_cloud_propagates(self) -> None:
+        # Cloud flavor must NOT treat 503 as a throttle; it should raise.
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, text="upstream")
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            with pytest.raises(JiraApiError):
+                await api.get("/myself")
+        finally:
+            await api.aclose()
+
+    async def test_persistent_throttle_propagates(self) -> None:
+        async def fake_sleep(_t: float) -> None:
+            return None
+
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers={"Retry-After": "0.01"})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            with pytest.raises(JiraApiError, match="persistent throttle"):
+                await api.get("/myself")
+        finally:
+            await api.aclose()
+
+    async def test_retry_after_missing_uses_default(self) -> None:
+        slept: list[float] = []
+
+        async def fake_sleep(t: float) -> None:
+            slept.append(t)
+
+        attempts = {"n": 0}
+
+        def handler(_r: httpx.Request) -> httpx.Response:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(429)
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            await api.get("/myself")
+            assert slept and slept[0] == 30.0
+        finally:
+            await api.aclose()
+
+    async def test_retry_after_capped(self) -> None:
+        slept: list[float] = []
+
+        async def fake_sleep(t: float) -> None:
+            slept.append(t)
+
+        attempts = {"n": 0}
+
+        def handler(_r: httpx.Request) -> httpx.Response:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(429, headers={"Retry-After": "3600"})
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            await api.get("/myself")
+            assert slept[0] == 60.0
+        finally:
+            await api.aclose()
+
+    async def test_retry_after_garbage_uses_default(self) -> None:
+        slept: list[float] = []
+
+        async def fake_sleep(t: float) -> None:
+            slept.append(t)
+
+        attempts = {"n": 0}
+
+        def handler(_r: httpx.Request) -> httpx.Response:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return httpx.Response(
+                    429, headers={"Retry-After": "not-a-number"}
+                )
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            await api.get("/myself")
+            assert slept[0] == 30.0
+        finally:
+            await api.aclose()
+
+
+class TestParamsSanitisation:
+    async def test_drops_none_param_values(self) -> None:
+        observed: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(dict(request.url.params))
+            return httpx.Response(200, json={})
+
+        api = JiraApi(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            auth=BearerAuth(token="t"),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.get("/x", params={"a": "1", "b": None})
+            assert observed == [{"a": "1"}]
+        finally:
+            await api.aclose()

--- a/packages/pii-scanner-jira/tests/test_connector.py
+++ b/packages/pii-scanner-jira/tests/test_connector.py
@@ -1,9 +1,10 @@
-"""Tests for JiraConnector — uses httpx.MockTransport doubles."""
+"""Tests for JiraConnector — separate TestCloud + TestDatacenter classes."""
 
 from __future__ import annotations
 
 import base64
-from collections.abc import Callable
+import json
+from typing import Any
 
 import httpx
 import pytest
@@ -17,15 +18,25 @@ from pleno_pii_scanner.sources import (
     register,
 )
 from pleno_pii_scanner.sources import registry as _registry_mod
+from pleno_pii_scanner.sources.base import DocumentRef
+
 from pleno_pii_scanner_jira import (
+    SPEC,
     JiraConfig,
     JiraConnector,
-    SPEC,
 )
-from pleno_pii_scanner_jira.connector import (
-    _build_jql,
-    adf_to_text,
+from tests.conftest import (
+    adf_doc,
+    adf_text,
+    cloud_issue,
+    dc_issue,
+    json_response,
 )
+
+
+# ------------------------------------------------------------------
+# fixtures
+# ------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
@@ -36,163 +47,130 @@ def _isolated_registry(monkeypatch: pytest.MonkeyPatch):
     _registry_mod._reset_for_tests()
 
 
-def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
-    return httpx.AsyncClient(
+def _cloud_config(**overrides: Any) -> JiraConfig:
+    base = dict(
+        flavor="cloud",
         base_url="https://acme.atlassian.net",
-        transport=httpx.MockTransport(handler),
+        email="alice@acme.com",
+        api_token="api-token-xyz",
     )
+    base.update(overrides)
+    return JiraConfig(**base)  # type: ignore[arg-type]
 
 
-# --- ADF samples --------------------------------------------------
+def _dc_config(**overrides: Any) -> JiraConfig:
+    base = dict(
+        flavor="datacenter",
+        base_url="https://jira.acme.internal",
+        access_token="dc-pat-token",
+    )
+    base.update(overrides)
+    return JiraConfig(**base)  # type: ignore[arg-type]
 
 
-def _adf_paragraph(text: str) -> dict:
-    return {
-        "type": "doc",
-        "content": [
-            {
-                "type": "paragraph",
-                "content": [{"type": "text", "text": text}],
-            }
-        ],
-    }
-
-
-def _adf_complex() -> dict:
-    return {
-        "type": "doc",
-        "content": [
-            {
-                "type": "heading",
-                "attrs": {"level": 2},
-                "content": [{"type": "text", "text": "Title"}],
-            },
-            {
-                "type": "paragraph",
-                "content": [
-                    {"type": "text", "text": "hello "},
-                    {
-                        "type": "text",
-                        "text": "world",
-                        "marks": [{"type": "strong"}],
-                    },
-                ],
-            },
-            {
-                "type": "bulletList",
-                "content": [
-                    {
-                        "type": "listItem",
-                        "content": [
-                            {
-                                "type": "paragraph",
-                                "content": [{"type": "text", "text": "one"}],
-                            }
-                        ],
-                    },
-                    {
-                        "type": "listItem",
-                        "content": [
-                            {
-                                "type": "paragraph",
-                                "content": [
-                                    {"type": "text", "text": "two "},
-                                    {
-                                        "type": "text",
-                                        "text": "deep",
-                                        "marks": [{"type": "em"}],
-                                    },
-                                ],
-                            }
-                        ],
-                    },
-                ],
-            },
-        ],
-    }
-
-
-def _issue(
-    key: str = "SEC-1",
-    *,
-    project: str = "SEC",
-    updated: str = "2026-05-01T10:00:00.000+0000",
-    description: dict | None = None,
-    summary: str = "secret leaked",
-) -> dict:
-    return {
-        "id": f"id-{key}",
-        "key": key,
-        "fields": {
-            "summary": summary,
-            "description": description if description is not None else _adf_paragraph(
-                "AKIA12345 was here"
-            ),
-            "updated": updated,
-            "project": {"key": project},
-        },
-    }
-
-
-# --- config --------------------------------------------------------
+# ------------------------------------------------------------------
+# config
+# ------------------------------------------------------------------
 
 
 class TestConfig:
-    def test_rejects_empty_base_url(self) -> None:
-        with pytest.raises(ValueError, match="base_url"):
-            JiraConfig(base_url="", email="e", api_token="t")
-
-    def test_rejects_empty_api_token(self) -> None:
-        with pytest.raises(ValueError, match="api_token"):
-            JiraConfig(base_url="https://x", email="e", api_token="")
-
-    def test_rejects_invalid_deployment(self) -> None:
-        with pytest.raises(ValueError, match="deployment"):
+    def test_rejects_invalid_flavor(self) -> None:
+        with pytest.raises(ValueError, match="flavor"):
             JiraConfig(
+                flavor="server",  # type: ignore[arg-type]
                 base_url="https://x",
-                email="e",
-                api_token="t",
-                deployment="server",  # type: ignore[arg-type]
+                access_token="t",
             )
 
-    def test_explicit_id(self) -> None:
-        cfg = JiraConfig(
-            base_url="https://x", email="e", api_token="t", id="custom"
-        )
+    def test_rejects_empty_base_url(self) -> None:
+        with pytest.raises(ValueError, match="base_url"):
+            JiraConfig(flavor="cloud", base_url="", access_token="t")
+
+    def test_rejects_non_http_base_url(self) -> None:
+        with pytest.raises(ValueError, match="http"):
+            JiraConfig(
+                flavor="cloud", base_url="ftp://x", access_token="t"
+            )
+
+    def test_rejects_no_auth(self) -> None:
+        with pytest.raises(ValueError, match="one of"):
+            JiraConfig(
+                flavor="cloud", base_url="https://acme.atlassian.net"
+            )
+
+    def test_rejects_two_auth_modes(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            JiraConfig(
+                flavor="cloud",
+                base_url="https://acme.atlassian.net",
+                access_token="t",
+                email="a@b",
+                api_token="x",
+            )
+
+    def test_resolved_id_explicit(self) -> None:
+        cfg = _cloud_config(id="custom")
         assert cfg.resolved_id() == "custom"
 
-    def test_default_id_no_token_leak(self) -> None:
-        cfg = JiraConfig(
-            base_url="https://x",
-            email="e",
-            api_token="VERYSECRET",
-            projects=("a", "b"),
-        )
+    def test_resolved_id_default_no_secret(self) -> None:
+        cfg = _cloud_config(api_token="this-must-not-leak")
         rid = cfg.resolved_id()
-        assert "VERYSECRET" not in rid
-        assert rid.startswith("jira:")
+        assert "this-must-not-leak" not in rid
+        assert rid == "jira-cloud:acme.atlassian.net"
 
-    def test_default_id_order_independent(self) -> None:
-        a = JiraConfig(
-            base_url="https://x", email="e", api_token="t", projects=("a", "b")
+    def test_resolved_id_dc(self) -> None:
+        cfg = _dc_config(access_token="this-must-not-leak")
+        rid = cfg.resolved_id()
+        assert "this-must-not-leak" not in rid
+        assert rid == "jira-datacenter:jira.acme.internal"
+
+    def test_build_auth_basic_cloud(self) -> None:
+        from pleno_pii_scanner_jira.api import BasicAuth
+
+        cfg = _cloud_config()
+        auth = cfg.build_auth()
+        assert isinstance(auth, BasicAuth)
+        assert auth.username == "alice@acme.com"
+
+    def test_build_auth_bearer(self) -> None:
+        from pleno_pii_scanner_jira.api import BearerAuth
+
+        cfg = JiraConfig(
+            flavor="cloud",
+            base_url="https://acme.atlassian.net",
+            access_token="oauth-tok",
         )
-        b = JiraConfig(
-            base_url="https://x", email="e", api_token="t", projects=("b", "a")
+        auth = cfg.build_auth()
+        assert isinstance(auth, BearerAuth)
+        assert auth.token == "oauth-tok"
+
+    def test_build_auth_dc_basic(self) -> None:
+        from pleno_pii_scanner_jira.api import BasicAuth
+
+        cfg = JiraConfig(
+            flavor="datacenter",
+            base_url="https://jira.acme.internal",
+            username="svc",
+            password="p@55",
         )
-        assert a.resolved_id() == b.resolved_id()
+        auth = cfg.build_auth()
+        assert isinstance(auth, BasicAuth)
 
 
-# --- protocol ------------------------------------------------------
+# ------------------------------------------------------------------
+# protocol surface
+# ------------------------------------------------------------------
 
 
 class TestProtocol:
     def test_runtime_isinstance(self) -> None:
-        c = JiraConnector(JiraConfig(base_url="https://x", email="e", api_token="t"))
+        c = JiraConnector(_cloud_config())
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
-        c = JiraConnector(JiraConfig(base_url="https://x", email="e", api_token="t"))
-        assert c.capabilities() == Capabilities(
+        c = JiraConnector(_cloud_config())
+        caps = c.capabilities()
+        assert caps == Capabilities(
             incremental=True,
             binary=False,
             content_hash_delta=False,
@@ -201,998 +179,1728 @@ class TestProtocol:
         )
 
 
-# --- auth ----------------------------------------------------------
+# ------------------------------------------------------------------
+# Cloud
+# ------------------------------------------------------------------
 
 
-class TestAuth:
-    async def test_cloud_basic_auth_header(self) -> None:
-        seen = {"auth": ""}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            seen["auth"] = request.headers.get("Authorization", "")
-            return httpx.Response(200, json={"issues": []})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="ops@acme.example",
-                    api_token="secrettoken",
-                    deployment="cloud",
-                ),
-                client=client,
-            )
-            try:
-                _ = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert seen["auth"].startswith("Basic ")
-        decoded = base64.b64decode(seen["auth"].split(" ", 1)[1]).decode()
-        assert decoded == "ops@acme.example:secrettoken"
-
-    async def test_dc_bearer_header(self) -> None:
-        seen = {"auth": ""}
+class TestCloud:
+    async def test_basic_auth_header_present(self) -> None:
+        seen_headers: list[str] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
-            seen["auth"] = request.headers.get("Authorization", "")
-            return httpx.Response(200, json={"issues": [], "total": 0})
+            seen_headers.append(request.headers.get("Authorization", ""))
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="ignored",
-                    api_token="patpat",
-                    deployment="dc",
-                ),
-                client=client,
-            )
-            try:
-                _ = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert seen["auth"] == "Bearer patpat"
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert seen_headers
+            assert seen_headers[0].startswith("Basic ")
+            expected = "Basic " + base64.b64encode(
+                b"alice@acme.com:api-token-xyz"
+            ).decode()
+            assert seen_headers[0] == expected
+        finally:
+            await c.close()
 
-
-# --- ADF walker ----------------------------------------------------
-
-
-class TestAdfWalker:
-    def test_paragraph(self) -> None:
-        out = adf_to_text(_adf_paragraph("hello world"))
-        assert out == "hello world"
-
-    def test_heading_paragraph_bullet_list(self) -> None:
-        out = adf_to_text(_adf_complex())
-        # All text segments must surface, in order.
-        for token in ("Title", "hello world", "one", "two deep"):
-            assert token in out
-        # Block boundaries should produce newlines so adjacent
-        # paragraphs don't run together.
-        assert "Title\n" in out
-        assert "hello world\n" in out
-
-    def test_none_input(self) -> None:
-        assert adf_to_text(None) == ""
-
-    def test_string_input(self) -> None:
-        # Defensive: a bare string at a non-text position is surfaced.
-        assert adf_to_text("plain text") == "plain text"
-
-    def test_non_mapping_non_list_scalar(self) -> None:
-        # Numbers / booleans drop silently; we don't crash.
-        assert adf_to_text(42) == ""
-
-    def test_text_node_with_non_string_text(self) -> None:
-        # Defensive: malformed text node should drop silently.
-        out = adf_to_text({"type": "text", "text": 42})
-        assert out == ""
-
-    def test_block_node_without_content(self) -> None:
-        # Empty paragraph: no `content` key, but type is block —
-        # exercise the `content is None` + block-newline branch.
-        out = adf_to_text({"type": "paragraph"})
-        # Newline rstrip-ed away, so the result is empty but the
-        # walker did not crash.
-        assert out == ""
-
-
-# --- end-to-end discover ------------------------------------------
-
-
-class TestDiscover:
-    async def test_cloud_pagination_two_pages(self) -> None:
-        page1 = {
-            "issues": [_issue("SEC-1", updated="2026-05-01T10:00:00.000+0000")],
-            "nextPageToken": "tok2",
-        }
-        page2 = {
-            "issues": [_issue("SEC-2", updated="2026-05-02T10:00:00.000+0000")],
-            # No nextPageToken — end of stream.
-        }
-
-        calls: list[dict[str, str]] = []
+    async def test_oauth_bearer_header(self) -> None:
+        seen: list[str] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
-            assert "/rest/api/3/search" in request.url.path
-            params = dict(request.url.params)
-            calls.append(params)
-            if "nextPageToken" not in params:
-                return httpx.Response(200, json=page1)
-            assert params["nextPageToken"] == "tok2"
-            return httpx.Response(200, json=page2)
+            seen.append(request.headers.get("Authorization", ""))
+            if request.url.path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert [r.path for r in refs] == ["SEC/SEC-1", "SEC/SEC-2"]
-        assert len(calls) == 2
+        c = JiraConnector(
+            JiraConfig(
+                flavor="cloud",
+                base_url="https://acme.atlassian.net",
+                access_token="oauth-xyz",
+            ),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert seen[0] == "Bearer oauth-xyz"
+        finally:
+            await c.close()
 
-    async def test_dc_pagination_uses_start_at(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            params = dict(request.url.params)
-            start_at = int(params.get("startAt", "0"))
-            if start_at == 0:
-                return httpx.Response(
-                    200,
-                    json={
-                        "issues": [_issue("DC-1")],
-                        "total": 2,
-                        "maxResults": 1,
-                        "startAt": 0,
-                    },
-                )
-            return httpx.Response(
-                200,
-                json={
-                    "issues": [_issue("DC-2", project="DC")],
-                    "total": 2,
-                    "maxResults": 1,
-                    "startAt": 1,
-                },
-            )
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    deployment="dc",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert {r.path for r in refs} == {"SEC/DC-1", "DC/DC-2"}
-
-    async def test_dc_terminates_on_empty_page(self) -> None:
-        # No `total` field — connector must stop on empty response.
-        seen = {"calls": 0}
+    async def test_project_enumeration_pagination(self) -> None:
+        # Two-page project list: first {isLast: false, 2 values}, second
+        # {isLast: true, 1 value}. Confirms startAt/isLast handling.
+        seen_starts: list[str] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
-            seen["calls"] += 1
-            if seen["calls"] == 1:
-                return httpx.Response(200, json={"issues": [_issue("X-1", project="X")]})
-            return httpx.Response(200, json={"issues": []})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    deployment="dc",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert [r.path for r in refs] == ["X/X-1"]
-        assert seen["calls"] == 2
-
-    async def test_projects_allowlist_injects_jql(self) -> None:
-        seen_jql: dict[str, str] = {}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            seen_jql["jql"] = request.url.params.get("jql", "")
-            return httpx.Response(200, json={"issues": []})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    projects=("SEC", "INFRA"),
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                _ = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert 'project in ("SEC", "INFRA")' in seen_jql["jql"]
-        assert "ORDER BY updated ASC" in seen_jql["jql"]
-
-
-# --- include_comments ---------------------------------------------
-
-
-class TestComments:
-    async def test_comments_yielded(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(
-                    200,
-                    json={
-                        "comments": [
-                            {
-                                "id": "10001",
-                                "author": {"displayName": "alice"},
-                                "body": _adf_paragraph("AKIA-IN-COMMENT"),
-                                "updated": "2026-05-03T11:00:00.000+0000",
-                            }
-                        ],
-                        "total": 1,
-                    },
-                )
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=True,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-                paths = [r.path for r in refs]
-                assert "SEC/SEC-1" in paths
-                assert "SEC/SEC-1/comments/10001" in paths
-                comment_ref = next(
-                    r for r in refs if r.metadata["kind"] == "comment"
-                )
-                docs = [d async for d in c.fetch(comment_ref)]
-                assert isinstance(docs[0], Document)
-                assert "AKIA-IN-COMMENT" in docs[0].text
-                assert "alice" in docs[0].text
-            finally:
-                await c.close()
-
-    async def test_include_comments_false_skips_comment_endpoint(self) -> None:
-        seen = {"comment_hit": False}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                seen["comment_hit"] = True
-                return httpx.Response(500)
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert all(r.metadata["kind"] == "issue" for r in refs)
-        assert not seen["comment_hit"]
-
-    async def test_comment_pagination(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                start_at = int(request.url.params.get("startAt", "0"))
-                if start_at == 0:
-                    return httpx.Response(
-                        200,
-                        json={
-                            "comments": [
-                                {"id": "1", "body": _adf_paragraph("a")}
-                            ],
-                            "total": 2,
-                        },
+            path = request.url.path
+            if path.endswith("/project/search"):
+                start = request.url.params.get("startAt", "0")
+                seen_starts.append(start)
+                if start == "0":
+                    return json_response(
+                        {
+                            "values": [{"key": "A"}, {"key": "B"}],
+                            "isLast": False,
+                        }
                     )
-                return httpx.Response(
-                    200,
-                    json={
-                        "comments": [
-                            {"id": "2", "body": _adf_paragraph("b")}
-                        ],
-                        "total": 2,
-                    },
+                return json_response(
+                    {"values": [{"key": "C"}], "isLast": True}
                 )
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
+            if path.endswith("/search"):
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=True,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        comment_paths = {
-            r.path for r in refs if r.metadata["kind"] == "comment"
-        }
-        assert comment_paths == {
-            "SEC/SEC-1/comments/1",
-            "SEC/SEC-1/comments/2",
-        }
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert seen_starts == ["0", "2"]
+        finally:
+            await c.close()
 
-    async def test_comment_terminates_on_empty_page(self) -> None:
-        # No `total` field — empty page must stop the loop.
+    async def test_project_enumeration_empty_page_terminates(self) -> None:
+        # Edge: page reports `isLast=false` but `values=[]`. Must stop.
+        seen_starts: list[str] = []
+
         def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
+            path = request.url.path
+            if path.endswith("/project/search"):
+                start = request.url.params.get("startAt", "0")
+                seen_starts.append(start)
+                return json_response({"values": [], "isLast": False})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=True,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert all(r.metadata["kind"] == "issue" for r in refs)
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert seen_starts == ["0"]
+        finally:
+            await c.close()
 
+    async def test_project_allow_list_skips_enumeration(self) -> None:
+        called = {"projects": False}
 
-# --- cursor --------------------------------------------------------
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                called["projects"] = True
+                return json_response({"values": [], "isLast": True})
+            if path.endswith("/search"):
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
 
+        c = JiraConnector(
+            _cloud_config(projects=("ENG",)),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert not called["projects"]
+        finally:
+            await c.close()
 
-class TestCursor:
-    async def test_cursor_round_trip(self) -> None:
-        # First scan: returns one issue at t1, advancing the high-water mark.
-        first_issues = [
-            _issue("SEC-1", updated="2026-05-01T10:00:00.000+0000"),
-            _issue("SEC-2", updated="2026-05-02T10:00:00.000+0000"),
-        ]
-        # Second scan: server gets a JQL with `updated >=` filter, returns
-        # only the newer issue.
-        second_issues = [_issue("SEC-3", updated="2026-05-03T10:00:00.000+0000")]
-
-        # Run 1
+    async def test_filter_include_exclude_on_projects(self) -> None:
         seen_jql: list[str] = []
 
-        def handler1(request: httpx.Request) -> httpx.Response:
-            seen_jql.append(request.url.params.get("jql", ""))
-            return httpx.Response(200, json={"issues": first_issues})
-
-        async with _client(handler1) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                _ = [r async for r in c.discover(SourceFilter(), None)]
-                cursor = c.cursor_after_run()
-            finally:
-                await c.close()
-        assert cursor == "2026-05-02T10:00:00.000+0000"
-        assert "updated >=" not in seen_jql[0]
-
-        # Run 2
-        def handler2(request: httpx.Request) -> httpx.Response:
-            seen_jql.append(request.url.params.get("jql", ""))
-            return httpx.Response(200, json={"issues": second_issues})
-
-        async with _client(handler2) as client2:
-            c2 = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client2,
-            )
-            try:
-                refs = [r async for r in c2.discover(SourceFilter(), cursor)]
-                cursor2 = c2.cursor_after_run()
-            finally:
-                await c2.close()
-        assert [r.path for r in refs] == ["SEC/SEC-3"]
-        assert cursor2 == "2026-05-03T10:00:00.000+0000"
-        assert f'updated >= "{cursor}"' in seen_jql[-1]
-
-    async def test_cursor_after_run_none_when_empty(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={"issues": []})
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            if path.endswith("/search"):
+                seen_jql.append(request.url.params.get("jql", ""))
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client,
-            )
-            try:
-                _ = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert c.cursor_after_run() is None
+        # include=("A",) — only A is searched
+        c = JiraConnector(
+            _cloud_config(projects=("A", "B")),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [
+                r
+                async for r in c.discover(SourceFilter(include=("A",)), None)
+            ]
+            assert any('project = "A"' in j for j in seen_jql)
+            assert not any('project = "B"' in j for j in seen_jql)
+        finally:
+            await c.close()
 
-    async def test_high_water_only_advances_forward(self) -> None:
-        # Server returns issues out of timestamp order — high water
-        # must be the maximum, not the last seen.
+        # exclude=("A",) — only B is searched
+        seen_jql.clear()
+        c2 = JiraConnector(
+            _cloud_config(projects=("A", "B")),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [
+                r
+                async for r in c2.discover(SourceFilter(exclude=("A",)), None)
+            ]
+            assert not any('project = "A"' in j for j in seen_jql)
+            assert any('project = "B"' in j for j in seen_jql)
+        finally:
+            await c2.close()
+
+    async def test_jql_pagination_two_pages(self) -> None:
+        seen_starts: list[str] = []
+
         def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                200,
-                json={
-                    "issues": [
-                        _issue("SEC-1", updated="2026-05-05T10:00:00.000+0000"),
-                        _issue("SEC-2", updated="2026-05-03T10:00:00.000+0000"),
-                    ]
-                },
-            )
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                _ = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert c.cursor_after_run() == "2026-05-05T10:00:00.000+0000"
-
-
-# --- filter --------------------------------------------------------
-
-
-class TestFilter:
-    async def test_include_pattern_keeps_matching_issues(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            return httpx.Response(
-                200,
-                json={
-                    "issues": [
-                        _issue("SEC-1", project="SEC"),
-                        _issue("INFRA-9", project="INFRA"),
-                    ]
-                },
-            )
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("SEC/*",)), None
-                    )
-                ]
-            finally:
-                await c.close()
-        assert [r.path for r in refs] == ["SEC/SEC-1"]
-
-    async def test_exclude_pattern_drops_matching_issues(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            return httpx.Response(
-                200,
-                json={
-                    "issues": [
-                        _issue("SEC-1", project="SEC"),
-                        _issue("INFRA-9", project="INFRA"),
-                    ]
-                },
-            )
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(exclude=("INFRA/*",)), None
-                    )
-                ]
-            finally:
-                await c.close()
-        assert [r.path for r in refs] == ["SEC/SEC-1"]
-
-    async def test_comment_filter_include_exclude(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(
-                    200,
-                    json={
-                        "comments": [
-                            {"id": "1", "body": _adf_paragraph("ok")},
-                            {"id": "2", "body": _adf_paragraph("ok")},
-                        ],
-                        "total": 2,
-                    },
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
                 )
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
-
-        # exclude one comment
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client,
-            )
-            try:
-                refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(exclude=("*/comments/2",)), None
-                    )
-                ]
-            finally:
-                await c.close()
-        comment_paths = {
-            r.path for r in refs if r.metadata["kind"] == "comment"
-        }
-        assert comment_paths == {"SEC/SEC-1/comments/1"}
-
-        # include only one comment + one issue
-        async with _client(handler) as client2:
-            c2 = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client2,
-            )
-            try:
-                refs2 = [
-                    r
-                    async for r in c2.discover(
-                        SourceFilter(
-                            include=("SEC/SEC-1", "SEC/SEC-1/comments/2")
-                        ),
-                        None,
-                    )
-                ]
-            finally:
-                await c2.close()
-        assert {r.path for r in refs2} == {
-            "SEC/SEC-1",
-            "SEC/SEC-1/comments/2",
-        }
-
-
-# --- fetch edges --------------------------------------------------
-
-
-class TestFetch:
-    async def test_fetch_yields_full_document(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            return httpx.Response(
-                200,
-                json={
-                    "issues": [
-                        _issue(
-                            "SEC-1",
-                            description=_adf_complex(),
-                            summary="hot finding",
+            if path.endswith("/search"):
+                start = request.url.params.get("startAt", "0")
+                seen_starts.append(start)
+                if start == "0":
+                    issues = [
+                        cloud_issue(
+                            key=f"P-{i}",
+                            updated=f"2026-05-04T00:00:0{i}.000+0000",
                         )
+                        for i in range(100)
                     ]
-                },
-            )
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-                docs = [d async for d in c.fetch(refs[0])]
-            finally:
-                await c.close()
-        assert isinstance(docs[0], Document)
-        assert "summary=hot finding" in docs[0].text
-        assert "Title" in docs[0].text
-        assert "two deep" in docs[0].text
-
-    async def test_fetch_unknown_path_returns_empty(self) -> None:
-        from pleno_pii_scanner.sources.base import DocumentRef
-
-        async with _client(lambda _r: httpx.Response(200, json={"issues": []})) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client,
-            )
-            try:
-                ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="x")
-                docs = [d async for d in c.fetch(ref)]
-                assert docs == []
-            finally:
-                await c.close()
-
-    async def test_issue_without_description(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            issue = _issue("SEC-1")
-            issue["fields"]["description"] = None
-            return httpx.Response(200, json={"issues": [issue]})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-                docs = [d async for d in c.fetch(refs[0])]
-            finally:
-                await c.close()
-        assert "description=" not in docs[0].text
-        assert "summary=secret leaked" in docs[0].text
-
-    async def test_comment_without_body_or_author(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(
-                    200,
-                    json={
-                        "comments": [{"id": "99"}],
-                        "total": 1,
-                    },
+                    return json_response(
+                        {"issues": issues, "total": 101, "startAt": 0}
+                    )
+                return json_response(
+                    {
+                        "issues": [
+                            cloud_issue(
+                                key="P-100",
+                                updated="2026-05-04T00:01:00.000+0000",
+                            )
+                        ],
+                        "total": 101,
+                        "startAt": 100,
+                    }
                 )
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-                comment_ref = next(
-                    r for r in refs if r.metadata["kind"] == "comment"
+        c = JiraConnector(
+            _cloud_config(include_comments=False),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert len(refs) == 101
+            assert seen_starts == ["0", "100"]
+        finally:
+            await c.close()
+
+    async def test_jql_pagination_terminates_on_short_page(self) -> None:
+        # `total` larger than what we actually see — should still stop.
+        seen_starts: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
                 )
-                docs = [d async for d in c.fetch(comment_ref)]
-            finally:
-                await c.close()
-        assert "id=99" in docs[0].text
-        assert "author=" not in docs[0].text
-        assert "body=" not in docs[0].text
+            if path.endswith("/search"):
+                start = request.url.params.get("startAt", "0")
+                seen_starts.append(start)
+                return json_response(
+                    {
+                        "issues": [cloud_issue(key="P-1")],
+                        "total": 9999,
+                    }
+                )
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
 
+        c = JiraConnector(
+            _cloud_config(include_comments=False),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert len(refs) == 1
+            assert seen_starts == ["0"]
+        finally:
+            await c.close()
 
-# --- malformed shapes ---------------------------------------------
-
-
-class TestMalformed:
-    async def test_issue_without_project_key_falls_back_to_key_prefix(self) -> None:
+    async def test_adf_description_serialised(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            issue = _issue("FOO-7")
-            issue["fields"]["project"] = {}  # empty mapping
-            return httpx.Response(200, json={"issues": [issue]})
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                issue = cloud_issue(
+                    description=adf_doc(
+                        {
+                            "type": "paragraph",
+                            "content": [adf_text("leak: AKIA1234567890")],
+                        }
+                    )
+                )
+                return json_response({"issues": [issue], "total": 1})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert refs[0].path == "FOO/FOO-7"
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert len(refs) == 1
+            docs = [d async for d in c.fetch(refs[0])]
+            assert len(docs) == 1
+            assert isinstance(docs[0], Document)
+            text = docs[0].text or ""
+            assert "key=PROJ-1" in text
+            assert "summary=Investigate leak" in text
+            assert "status=Open" in text
+            assert "assignee=Alice" in text
+            assert "reporter=Bob" in text
+            assert "AKIA1234567890" in text
+        finally:
+            await c.close()
 
-    async def test_comment_with_non_mapping_author(self) -> None:
+    async def test_comment_fetch_and_paginate(self) -> None:
+        seen_starts: list[str] = []
+
         def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(
-                    200,
-                    json={
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                start = request.url.params.get("startAt", "0")
+                seen_starts.append(start)
+                if start == "0":
+                    comments = [
+                        {
+                            "id": str(i),
+                            "author": {"displayName": "Carol"},
+                            "body": adf_doc(
+                                {
+                                    "type": "paragraph",
+                                    "content": [adf_text(f"comment-{i}")],
+                                }
+                            ),
+                        }
+                        for i in range(100)
+                    ]
+                    return json_response(
+                        {"comments": comments, "total": 101}
+                    )
+                return json_response(
+                    {
                         "comments": [
                             {
-                                "id": "1",
-                                "author": "not-a-mapping",
-                                "body": _adf_paragraph("hi"),
+                                "id": "100",
+                                "author": {"displayName": "Carol"},
+                                "body": adf_doc(
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("comment-100")],
+                                    }
+                                ),
+                            }
+                        ],
+                        "total": 101,
+                    }
+                )
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert seen_starts == ["0", "100"]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "comment[0]=Carol: comment-0" in text
+            assert "comment[100]=Carol: comment-100" in text
+        finally:
+            await c.close()
+
+    async def test_attachments_serialised_no_body_download(self) -> None:
+        downloaded: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                issue = cloud_issue(
+                    attachments=[
+                        {
+                            "filename": "leak.txt",
+                            "content": "https://acme.atlassian.net/secure/attachment/100/leak.txt",
+                        }
+                    ]
+                )
+                return json_response({"issues": [issue], "total": 1})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            # Any attempt to GET an attachment URL would land here.
+            downloaded.append(path)
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert (
+                "attachment=leak.txt, url=https://acme.atlassian.net/secure/attachment/100/leak.txt"
+                in text
+            )
+            assert downloaded == []
+        finally:
+            await c.close()
+
+    async def test_attachments_disabled_when_flag_off(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                issue = cloud_issue(
+                    attachments=[{"filename": "x", "content": "u"}]
+                )
+                return json_response({"issues": [issue], "total": 1})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(include_attachments=False),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "attachment=" not in text
+        finally:
+            await c.close()
+
+    async def test_comment_disabled_when_flag_off(self) -> None:
+        called = {"comment": False}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                called["comment"] = True
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(include_comments=False),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert not called["comment"]
+        finally:
+            await c.close()
+
+    async def test_cursor_round_trip(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                issues = [
+                    cloud_issue(
+                        key="P-1",
+                        updated="2026-05-04T00:00:00.000+0000",
+                    ),
+                    cloud_issue(
+                        key="P-2",
+                        updated="2026-05-04T01:00:00.000+0000",
+                    ),
+                ]
+                return json_response({"issues": issues, "total": 2})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(include_comments=False),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            cursor = c.cursor_after_run()
+            assert cursor is not None
+            decoded = json.loads(cursor)
+            assert decoded["highest_updated"] == "2026-05-04T01:00:00.000+0000"
+        finally:
+            await c.close()
+
+    async def test_cursor_uses_jql_since(self) -> None:
+        seen_jql: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                seen_jql.append(request.url.params.get("jql", ""))
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
+
+        prior = json.dumps(
+            {"highest_updated": "2026-05-01T00:00:00.000+0000"}
+        )
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), prior)]
+            assert any(
+                'updated >= "2026-05-01T00:00:00.000+0000"' in j
+                for j in seen_jql
+            )
+        finally:
+            await c.close()
+
+    async def test_malformed_cursor_silently_ignored(self) -> None:
+        seen_jql: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                seen_jql.append(request.url.params.get("jql", ""))
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
+
+        for bad in (
+            "not-json",
+            '"a string"',
+            "[]",
+            '{"other": "x"}',
+            '{"highest_updated": ""}',
+            '{"highest_updated": 5}',
+        ):
+            c = JiraConnector(
+                _cloud_config(),
+                transport=httpx.MockTransport(handler),
+            )
+            seen_jql.clear()
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), bad)]
+                # No JQL clause for `updated >= ...` when cursor is bad.
+                assert all("updated >=" not in j for j in seen_jql)
+            finally:
+                await c.close()
+
+    async def test_filter_since_overrides_cursor(self) -> None:
+        from datetime import datetime, timezone
+
+        seen_jql: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                seen_jql.append(request.url.params.get("jql", ""))
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
+
+        prior = json.dumps(
+            {"highest_updated": "2026-05-01T00:00:00.000+0000"}
+        )
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            since_dt = datetime(2026, 5, 3, tzinfo=timezone.utc)
+            _ = [
+                r
+                async for r in c.discover(
+                    SourceFilter(since=since_dt), prior
+                )
+            ]
+            assert any("2026-05-03" in j for j in seen_jql)
+            assert not any("2026-05-01" in j for j in seen_jql)
+        finally:
+            await c.close()
+
+    async def test_cursor_none_when_nothing_observed(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert c.cursor_after_run() is None
+        finally:
+            await c.close()
+
+    async def test_429_backoff(self) -> None:
+        attempts = {"n": 0}
+
+        async def fake_sleep(_t: float) -> None:
+            return None
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    return httpx.Response(
+                        429, headers={"Retry-After": "0.01"}
+                    )
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert attempts["n"] == 2
+        finally:
+            await c.close()
+
+    async def test_issue_without_key_skipped(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                # Missing `key` — third-party Jira-compatible servers
+                # have been seen to omit it.
+                bad = {"id": "1", "fields": {"summary": "x", "updated": "x"}}
+                ok = cloud_issue(key="P-1")
+                return json_response({"issues": [bad, ok], "total": 2})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            keys = [r.metadata["key"] for r in refs]
+            assert keys == ["P-1"]
+        finally:
+            await c.close()
+
+    async def test_fetch_unknown_ref_falls_back_to_live_issue(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if "/issue/PROJ-99" in path and "/comment" not in path:
+                return json_response(cloud_issue(key="PROJ-99"))
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="jira://PROJ/PROJ-99",
+                metadata={"key": "PROJ-99"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert len(docs) == 1
+        finally:
+            await c.close()
+
+    async def test_fetch_without_metadata_returns_empty(self) -> None:
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="x")
+            docs = [d async for d in c.fetch(ref)]
+            assert docs == []
+        finally:
+            await c.close()
+
+    async def test_fetch_missing_issue_returns_empty(self) -> None:
+        def handler(_r: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="jira://A/MISSING-1",
+                metadata={"key": "MISSING-1"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert docs == []
+        finally:
+            await c.close()
+
+
+# ------------------------------------------------------------------
+# Data Center
+# ------------------------------------------------------------------
+
+
+class TestDatacenter:
+    async def test_basic_auth_dc(self) -> None:
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.headers.get("Authorization", ""))
+            if request.url.path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
+
+        c = JiraConnector(
+            JiraConfig(
+                flavor="datacenter",
+                base_url="https://jira.acme.internal",
+                username="svc",
+                password="p@55",
+            ),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            expected = "Basic " + base64.b64encode(b"svc:p@55").decode()
+            assert seen[0] == expected
+        finally:
+            await c.close()
+
+    async def test_pat_bearer_dc(self) -> None:
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.headers.get("Authorization", ""))
+            if request.url.path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
+
+        c = JiraConnector(
+            _dc_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert seen[0] == "Bearer dc-pat-token"
+        finally:
+            await c.close()
+
+    async def test_v2_path_used(self) -> None:
+        observed: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            observed.append(request.url.path)
+            if request.url.path.endswith("/project/search"):
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
+
+        c = JiraConnector(
+            _dc_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert any("/rest/api/2/" in p for p in observed)
+            assert not any("/rest/api/3/" in p for p in observed)
+        finally:
+            await c.close()
+
+    async def test_storage_xhtml_description(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                issue = dc_issue(
+                    description=(
+                        "<p>SSN: <b>123-45-6789</b></p>"
+                        "<p>see <a href='https://acme'>link</a></p>"
+                    )
+                )
+                return json_response({"issues": [issue], "total": 1})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _dc_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "SSN: 123-45-6789" in text
+            assert "<b>" not in text
+            assert "<p>" not in text
+        finally:
+            await c.close()
+
+    async def test_storage_xhtml_comment_body(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response({"issues": [dc_issue()], "total": 1})
+            if "/comment" in path:
+                return json_response(
+                    {
+                        "comments": [
+                            {
+                                "id": "5",
+                                "author": {"displayName": "Carol"},
+                                "body": "<p>see <em>here</em></p>",
                             }
                         ],
                         "total": 1,
-                    },
+                    }
                 )
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-                comment_ref = next(
-                    r for r in refs if r.metadata["kind"] == "comment"
-                )
-                docs = [d async for d in c.fetch(comment_ref)]
-            finally:
-                await c.close()
-        # Non-mapping author silently dropped; body still surfaces.
-        assert "author=" not in docs[0].text
-        assert "hi" in docs[0].text
-
-    async def test_updated_field_missing_does_not_advance_high_water(self) -> None:
-        # `updated` is not a string → high water must stay None and the
-        # ref still emit successfully.
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            issue = _issue("SEC-1")
-            issue["fields"]["updated"] = None
-            return httpx.Response(200, json={"issues": [issue]})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        assert len(refs) == 1
-        assert c.cursor_after_run() is None
-
-    async def test_updated_with_unparseable_iso_value(self) -> None:
-        def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(200, json={"comments": []})
-            issue = _issue("SEC-1", updated="not-an-iso-timestamp")
-            return httpx.Response(200, json={"issues": [issue]})
-
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net",
-                    email="e",
-                    api_token="t",
-                    include_comments=False,
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        # last_modified silently None for unparseable input.
-        assert refs[0].last_modified is None
-
-
-# --- jql builder --------------------------------------------------
-
-
-class TestJqlBuilder:
-    def test_no_projects_no_cursor(self) -> None:
-        assert _build_jql((), None) == "ORDER BY updated ASC"
-
-    def test_projects_only(self) -> None:
-        assert _build_jql(("A",), None) == 'project in ("A") ORDER BY updated ASC'
-
-    def test_cursor_only(self) -> None:
-        assert (
-            _build_jql((), "2026-05-01T00:00:00.000+0000")
-            == 'updated >= "2026-05-01T00:00:00.000+0000" ORDER BY updated ASC'
+        c = JiraConnector(
+            _dc_config(),
+            transport=httpx.MockTransport(handler),
         )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "comment[5]=Carol: see here" in text
+        finally:
+            await c.close()
 
-    def test_projects_and_cursor(self) -> None:
-        out = _build_jql(("SEC",), "2026-05-01T00:00:00.000+0000")
-        assert out == (
-            'project in ("SEC") AND '
-            'updated >= "2026-05-01T00:00:00.000+0000" ORDER BY updated ASC'
-        )
+    async def test_503_backoff(self) -> None:
+        attempts = {"n": 0}
 
+        async def fake_sleep(_t: float) -> None:
+            return None
 
-# --- native_url ---------------------------------------------------
-
-
-class TestNativeUrl:
-    async def test_issue_url_set(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
-            if "/comment" in request.url.path:
-                return httpx.Response(
-                    200,
-                    json={
-                        "comments": [
-                            {"id": "55", "body": _adf_paragraph("c")}
-                        ],
-                        "total": 1,
-                    },
-                )
-            return httpx.Response(200, json={"issues": [_issue("SEC-1")]})
+            path = request.url.path
+            if path.endswith("/project/search"):
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    return httpx.Response(
+                        503, headers={"Retry-After": "0.01"}
+                    )
+                return json_response({"values": [], "isLast": True})
+            return json_response({})
 
-        async with _client(handler) as client:
-            c = JiraConnector(
-                JiraConfig(
-                    base_url="https://acme.atlassian.net/",
-                    email="e",
-                    api_token="t",
-                ),
-                client=client,
-            )
-            try:
-                refs = [r async for r in c.discover(SourceFilter(), None)]
-            finally:
-                await c.close()
-        issue_ref = next(r for r in refs if r.metadata["kind"] == "issue")
-        comment_ref = next(r for r in refs if r.metadata["kind"] == "comment")
-        assert issue_ref.native_url == "https://acme.atlassian.net/browse/SEC-1"
-        assert comment_ref.native_url == (
-            "https://acme.atlassian.net/browse/SEC-1?focusedCommentId=55"
+        c = JiraConnector(
+            _dc_config(),
+            transport=httpx.MockTransport(handler),
+            sleep=fake_sleep,
         )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            assert attempts["n"] == 2
+        finally:
+            await c.close()
 
 
-# --- spec / factory -----------------------------------------------
+# ------------------------------------------------------------------
+# Factory + Spec
+# ------------------------------------------------------------------
 
 
 class TestSpec:
     def test_metadata(self) -> None:
         assert SPEC.kind == "jira"
         assert SPEC.version == "0.1.0"
-        assert "jira:read" in SPEC.required_scopes
         assert SPEC.capabilities.incremental is True
-        assert SPEC.capabilities.max_concurrent_fetches == 4
 
-    def test_factory_minimal(self) -> None:
-        register(SPEC)
-        c = create(
-            "jira",
-            {"base_url": "https://x", "email": "e", "api_token": "t"},
-        )
-        assert isinstance(c, JiraConnector)
-
-    def test_factory_full(self) -> None:
+    def test_factory_minimal_cloud(self) -> None:
         register(SPEC)
         c = create(
             "jira",
             {
-                "base_url": "https://x",
-                "email": "e",
-                "api_token": "t",
-                "projects": ["A", "B"],
-                "include_comments": False,
-                "deployment": "dc",
-                "id": "explicit",
+                "flavor": "cloud",
+                "base_url": "https://acme.atlassian.net",
+                "access_token": "tok",
             },
         )
-        assert c.id == "explicit"
+        assert isinstance(c, JiraConnector)
+
+    def test_factory_minimal_dc(self) -> None:
+        register(SPEC)
+        c = create(
+            "jira",
+            {
+                "flavor": "datacenter",
+                "base_url": "https://jira.acme.internal",
+                "access_token": "pat",
+            },
+        )
+        assert isinstance(c, JiraConnector)
+
+    def test_factory_full_options(self) -> None:
+        register(SPEC)
+        c = create(
+            "jira",
+            {
+                "flavor": "cloud",
+                "base_url": "https://acme.atlassian.net",
+                "email": "a@b",
+                "api_token": "tok",
+                "projects": ["A", "B"],
+                "include_comments": False,
+                "include_attachments": False,
+                "request_timeout": 60.0,
+                "id": "x",
+            },
+        )
+        assert c.id == "x"
+        assert c.config.projects == ("A", "B")
+
+    def test_factory_rejects_invalid_flavor(self) -> None:
+        with pytest.raises(ValueError, match="flavor"):
+            SPEC.factory(
+                {
+                    "flavor": "server",
+                    "base_url": "x",
+                    "access_token": "t",
+                }
+            )
 
     def test_factory_rejects_missing_base_url(self) -> None:
         with pytest.raises(ValueError, match="base_url"):
-            SPEC.factory({"api_token": "t"})
+            SPEC.factory({"flavor": "cloud", "access_token": "t"})
 
-    def test_factory_rejects_missing_api_token(self) -> None:
-        with pytest.raises(ValueError, match="api_token"):
-            SPEC.factory({"base_url": "https://x"})
+    def test_factory_rejects_bare_string_projects(self) -> None:
+        with pytest.raises(ValueError, match="bare string"):
+            SPEC.factory(
+                {
+                    "flavor": "cloud",
+                    "base_url": "https://acme.atlassian.net",
+                    "access_token": "t",
+                    "projects": "ENG",
+                }
+            )
 
+    def test_factory_rejects_non_iterable_projects(self) -> None:
+        with pytest.raises(ValueError, match="iterable"):
+            SPEC.factory(
+                {
+                    "flavor": "cloud",
+                    "base_url": "https://acme.atlassian.net",
+                    "access_token": "t",
+                    "projects": 5,
+                }
+            )
 
-# --- close --------------------------------------------------------
+    def test_factory_rejects_empty_string_in_projects(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            SPEC.factory(
+                {
+                    "flavor": "cloud",
+                    "base_url": "https://acme.atlassian.net",
+                    "access_token": "t",
+                    "projects": [""],
+                }
+            )
 
-
-class TestClose:
-    async def test_close_owns_client(self) -> None:
-        c = JiraConnector(JiraConfig(base_url="https://x", email="e", api_token="t"))
-        await c.close()
-
-    async def test_close_external_client_not_closed(self) -> None:
-        client = httpx.AsyncClient()
-        c = JiraConnector(
-            JiraConfig(base_url="https://x", email="e", api_token="t"),
-            client=client,
+    def test_factory_no_token_in_resolved_id(self) -> None:
+        register(SPEC)
+        c = create(
+            "jira",
+            {
+                "flavor": "cloud",
+                "base_url": "https://acme.atlassian.net",
+                "access_token": "leak-token-xyz",
+            },
         )
+        assert "leak-token-xyz" not in c.id
+
+
+# ------------------------------------------------------------------
+# Lifecycle
+# ------------------------------------------------------------------
+
+
+class TestLifecycle:
+    async def test_close_idempotent(self) -> None:
+        c = JiraConnector(_cloud_config())
         await c.close()
-        assert not client.is_closed
-        await client.aclose()
+        await c.close()
+
+    async def test_close_releases_client(self) -> None:
+        # Verify the underlying httpx client is closed.
+        c = JiraConnector(_cloud_config())
+        client = c.api._client  # type: ignore[attr-defined]
+        await c.close()
+        assert client.is_closed
+
+
+# ------------------------------------------------------------------
+# Helpers + edge cases
+# ------------------------------------------------------------------
+
+
+class TestSerialiserEdges:
+    """Branches in `_serialise_issue` for missing / weird fields."""
+
+    async def test_issue_without_fields_renders_only_key(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {
+                        "issues": [{"id": "1", "key": "P-1"}],
+                        "total": 1,
+                    }
+                )
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert text == "key=P-1"
+        finally:
+            await c.close()
+
+    async def test_issue_with_no_summary_assignee(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                # Missing summary, status, assignee, reporter.
+                return json_response(
+                    {
+                        "issues": [
+                            {
+                                "id": "1",
+                                "key": "P-1",
+                                "fields": {
+                                    "updated": "2026-05-04T00:00:00.000+0000"
+                                },
+                            }
+                        ],
+                        "total": 1,
+                    }
+                )
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert text == "key=P-1"
+        finally:
+            await c.close()
+
+    async def test_comment_without_author_renders_only_body(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                return json_response(
+                    {
+                        "comments": [
+                            {
+                                "id": "9",
+                                # no author
+                                "body": adf_doc(
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("anon")],
+                                    }
+                                ),
+                            }
+                        ],
+                        "total": 1,
+                    }
+                )
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "comment[9]=anon" in text
+        finally:
+            await c.close()
+
+    async def test_comment_without_id_renders_with_default_label(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                return json_response(
+                    {
+                        "comments": [
+                            {
+                                "body": adf_doc(
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("xx")],
+                                    }
+                                )
+                            }
+                        ],
+                        "total": 1,
+                    }
+                )
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "comment=xx" in text
+        finally:
+            await c.close()
+
+    async def test_comment_with_empty_body_is_skipped(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                return json_response(
+                    {
+                        "comments": [
+                            {"id": "9", "body": None},
+                            {"id": "10"},
+                        ],
+                        "total": 2,
+                    }
+                )
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "comment[9]" not in text
+            assert "comment[10]" not in text
+        finally:
+            await c.close()
+
+    async def test_attachment_non_mapping_skipped(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                issue = cloud_issue(
+                    attachments=["bad", {"filename": "x", "content": "u"}]
+                )
+                return json_response({"issues": [issue], "total": 1})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "attachment=x, url=u" in text
+            assert text.count("attachment=") == 1
+        finally:
+            await c.close()
+
+    async def test_attachment_with_only_name_or_only_url(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                # Skip an entry with neither name nor url.
+                issue = cloud_issue(
+                    attachments=[
+                        {"filename": "named.txt"},
+                        {"contentUrl": "http://only.url"},
+                        {"name": "n2"},
+                        {},
+                    ]
+                )
+                return json_response({"issues": [issue], "total": 1})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "attachment=named.txt" in text
+            assert "url=http://only.url" in text
+            assert "attachment=n2" in text
+        finally:
+            await c.close()
+
+    async def test_serialise_no_text_yields_nothing(self) -> None:
+        # An issue with no key, no summary, no description, no comments
+        # → serialiser produces empty string → fetch yields nothing.
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if "/issue/X" in path and "/comment" not in path:
+                # Empty body for the live-fetch path.
+                return json_response({})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="x",
+                metadata={"key": "X"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert docs == []
+        finally:
+            await c.close()
+
+    async def test_serialise_truthy_issue_no_text_yields_nothing(
+        self,
+    ) -> None:
+        # Live-fetch path: 200 with a non-empty body but no extractable
+        # text — every field is junk. _serialise_issue returns "" and
+        # fetch must yield nothing rather than emit a blank Document
+        # (which would fail the text/binary XOR invariant).
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if "/issue/X" in path and "/comment" not in path:
+                return json_response({"junk": True})
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            ref = DocumentRef(
+                source_id=c.id,
+                source_kind=c.kind,
+                path="x",
+                metadata={"key": "X"},
+            )
+            docs = [d async for d in c.fetch(ref)]
+            assert docs == []
+        finally:
+            await c.close()
+
+    async def test_comment_pagination_short_page_terminates(self) -> None:
+        # First page is full (100 items), second page is short (1 item).
+        # The short-page check must terminate before a third request.
+        request_count = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                request_count["n"] += 1
+                if request_count["n"] == 1:
+                    return json_response(
+                        {
+                            "comments": [
+                                {
+                                    "id": str(i),
+                                    "body": adf_doc(
+                                        {
+                                            "type": "paragraph",
+                                            "content": [adf_text("x")],
+                                        }
+                                    ),
+                                }
+                                for i in range(100)
+                            ],
+                            # Lie: total is much larger than what we'll return.
+                            "total": 10_000,
+                        }
+                    )
+                return json_response(
+                    {
+                        "comments": [
+                            {
+                                "id": "100",
+                                "body": adf_doc(
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("x")],
+                                    }
+                                ),
+                            }
+                        ],
+                        "total": 10_000,
+                    }
+                )
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            # Should stop after second comment page (short-page guard).
+            assert request_count["n"] == 2
+        finally:
+            await c.close()
+
+    def test_convert_body_dc_with_dict(self) -> None:
+        # DC flavor + dict body (custom-field shape).
+        c = JiraConnector(_dc_config())
+        try:
+            out = c._convert_body({"value": "<p>hello</p>"})
+            assert out == "hello"
+        finally:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(c.close()) if False else None
+
+    def test_convert_body_empty_string(self) -> None:
+        c = JiraConnector(_cloud_config())
+        try:
+            assert c._convert_body("") == ""
+            assert c._convert_body(None) == ""
+        finally:
+            pass
+
+    def test_named_handles_non_mapping(self) -> None:
+        from pleno_pii_scanner_jira.connector import _named
+
+        assert _named(None) == ""
+        assert _named({"name": 5}) == ""
+
+    def test_display_name_handles_non_mapping(self) -> None:
+        from pleno_pii_scanner_jira.connector import _display_name
+
+        assert _display_name(None) == ""
+        # Falls back across keys.
+        assert _display_name({"emailAddress": "a@b"}) == "a@b"
+        assert _display_name({"accountId": "x"}) == "x"
+
+    def test_host_only_handles_no_scheme(self) -> None:
+        from pleno_pii_scanner_jira.connector import _host_only
+
+        assert _host_only("acme.atlassian.net") == "acme.atlassian.net"
+        assert _host_only("http://x/y") == "x"
+
+    def test_issue_updated_handles_missing_or_bad(self) -> None:
+        from pleno_pii_scanner_jira.connector import _issue_updated
+
+        assert _issue_updated({"fields": "x"}) is None
+        assert _issue_updated({"fields": {"updated": 5}}) is None
+        assert _issue_updated({"fields": {}}) is None
+
+    def test_parse_iso_handles_garbage(self) -> None:
+        from pleno_pii_scanner_jira.connector import _parse_iso
+
+        assert _parse_iso(None) is None
+        assert _parse_iso("") is None
+        assert _parse_iso("not-iso-format") is None
+
+    def test_parse_iso_negative_offset_normalised(self) -> None:
+        from pleno_pii_scanner_jira.connector import _parse_iso
+
+        # `-0500` (no colon) — normalisation must insert the colon.
+        out = _parse_iso("2026-05-04T12:00:00.000-0500")
+        assert out is not None
+        assert out.utcoffset() is not None
+
+    def test_parse_iso_already_colon_offset(self) -> None:
+        from pleno_pii_scanner_jira.connector import _parse_iso
+
+        out = _parse_iso("2026-05-04T12:00:00.000+00:00")
+        assert out is not None
+
+    def test_decode_cursor_non_string_value(self) -> None:
+        from pleno_pii_scanner_jira.connector import _decode_cursor
+
+        # `highest_updated` is not a string → ignored.
+        assert _decode_cursor('{"highest_updated": 5}') is None
+
+    async def test_project_search_404_returns_empty(self) -> None:
+        # 404 -> api returns empty dict -> _list_all_projects returns [].
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return httpx.Response(404)
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert refs == []
+        finally:
+            await c.close()
+
+    async def test_search_404_returns_empty(self) -> None:
+        # /search returning 404 → empty body → iterator stops.
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return httpx.Response(404)
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert refs == []
+        finally:
+            await c.close()
+
+    async def test_issues_with_non_mapping_entries_skipped(self) -> None:
+        # Defensive: an `issues` array with garbage entries is filtered.
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {
+                        "issues": ["bad", None, cloud_issue(key="P-1")],
+                        "total": 3,
+                    }
+                )
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert [r.metadata["key"] for r in refs] == ["P-1"]
+        finally:
+            await c.close()
+
+    async def test_comments_404_returns_empty_list(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                return httpx.Response(404)
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert len(refs) == 1
+            assert refs[0].metadata["comment_count"] == "0"
+        finally:
+            await c.close()
+
+    async def test_comments_with_non_mapping_entries(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {"issues": [cloud_issue()], "total": 1}
+                )
+            if "/comment" in path:
+                return json_response(
+                    {
+                        "comments": [
+                            "bad",
+                            None,
+                            {
+                                "id": "1",
+                                "body": adf_doc(
+                                    {
+                                        "type": "paragraph",
+                                        "content": [adf_text("ok")],
+                                    }
+                                ),
+                            },
+                        ],
+                        "total": 3,
+                    }
+                )
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "comment[1]" in text
+        finally:
+            await c.close()
+
+    async def test_project_search_skips_non_mapping_project(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": ["bad", {"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response({"issues": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            _ = [r async for r in c.discover(SourceFilter(), None)]
+            # No crash → success.
+        finally:
+            await c.close()
+
+    async def test_cloud_string_description_falls_through_to_storage(
+        self,
+    ) -> None:
+        # Cloud + raw-string description (legacy custom-field shape).
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {
+                        "issues": [
+                            cloud_issue(
+                                description="<p>raw <b>html</b></p>",  # type: ignore[arg-type]
+                            )
+                        ],
+                        "total": 1,
+                    }
+                )
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            docs = [d async for d in c.fetch(refs[0])]
+            text = docs[0].text or ""
+            assert "raw html" in text
+        finally:
+            await c.close()
+
+    async def test_issue_to_ref_without_summary(self) -> None:
+        # Missing `summary` -> size=None on DocumentRef.
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/project/search"):
+                return json_response(
+                    {"values": [{"key": "P"}], "isLast": True}
+                )
+            if path.endswith("/search"):
+                return json_response(
+                    {
+                        "issues": [
+                            {
+                                "id": "1",
+                                "key": "P-1",
+                                "fields": {
+                                    "updated": "2026-05-04T00:00:00.000+0000"
+                                },
+                            }
+                        ],
+                        "total": 1,
+                    }
+                )
+            if "/comment" in path:
+                return json_response({"comments": [], "total": 0})
+            return json_response({})
+
+        c = JiraConnector(
+            _cloud_config(),
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            refs = [r async for r in c.discover(SourceFilter(), None)]
+            assert refs[0].size is None
+            assert refs[0].native_url is not None
+        finally:
+            await c.close()

--- a/packages/pii-scanner-jira/tests/test_storage.py
+++ b/packages/pii-scanner-jira/tests/test_storage.py
@@ -1,0 +1,116 @@
+"""Hermetic tests for Data Center storage-XHTML -> plain-text conversion."""
+
+from __future__ import annotations
+
+from pleno_pii_scanner_jira.storage import storage_to_text
+
+
+class TestInputShape:
+    def test_none_returns_empty(self) -> None:
+        assert storage_to_text(None) == ""
+
+    def test_int_returns_empty(self) -> None:
+        assert storage_to_text(123) == ""
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert storage_to_text("") == ""
+
+    def test_dict_with_value_field(self) -> None:
+        # Custom-field shape: `{ "value": "...", "representation": "..." }`.
+        assert storage_to_text({"value": "<p>hi</p>"}) == "hi"
+
+    def test_dict_without_value_returns_empty(self) -> None:
+        assert storage_to_text({"representation": "html"}) == ""
+
+    def test_dict_value_non_string_returns_empty(self) -> None:
+        assert storage_to_text({"value": 123}) == ""
+
+
+class TestRendering:
+    def test_strips_simple_tags(self) -> None:
+        out = storage_to_text("<p>Hello, <b>world</b>!</p>")
+        assert out == "Hello, world!"
+
+    def test_paragraphs_separated_by_blank_line(self) -> None:
+        out = storage_to_text("<p>one</p><p>two</p>")
+        assert "one" in out and "two" in out
+        # newline separator preserved
+        assert "\n" in out
+
+    def test_lists(self) -> None:
+        out = storage_to_text("<ul><li>a</li><li>b</li></ul>")
+        assert "a" in out and "b" in out
+
+    def test_br_tag(self) -> None:
+        out = storage_to_text("first<br/>second")
+        assert "first" in out and "second" in out
+
+    def test_self_closing_block_tag(self) -> None:
+        out = storage_to_text("a<hr/>b")
+        assert "a" in out and "b" in out
+
+    def test_entities_decoded(self) -> None:
+        out = storage_to_text("<p>tom&amp;jerry &lt;3</p>")
+        assert "tom&jerry <3" in out
+
+    def test_script_content_dropped(self) -> None:
+        out = storage_to_text(
+            "<p>visible</p><script>password = 'leak'</script>"
+        )
+        assert "visible" in out
+        assert "password" not in out
+
+    def test_style_content_dropped(self) -> None:
+        out = storage_to_text("<style>body{color:red}</style><p>text</p>")
+        assert "color" not in out
+        assert "text" in out
+
+    def test_collapses_consecutive_blank_lines(self) -> None:
+        out = storage_to_text("<p>a</p><p></p><p></p><p>b</p>")
+        # At most one blank line between content lines.
+        assert "\n\n\n" not in out
+
+    def test_non_block_tags_keep_text(self) -> None:
+        out = storage_to_text("<span>inline <em>text</em></span>")
+        assert out == "inline text"
+
+    def test_table_rows(self) -> None:
+        out = storage_to_text(
+            "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>"
+        )
+        assert "a" in out and "b" in out and "c" in out
+
+    def test_unclosed_tag_does_not_crash(self) -> None:
+        # HTMLParser is forgiving — verify we don't crash.
+        out = storage_to_text("<p>open paragraph forever")
+        assert "open paragraph forever" in out
+
+    def test_table_with_storage_value_wrapper(self) -> None:
+        out = storage_to_text({"value": "<table><tr><td>x</td></tr></table>"})
+        assert "x" in out
+
+    def test_nested_skip_tag(self) -> None:
+        out = storage_to_text(
+            "<style><style>x</style></style><p>visible</p>"
+        )
+        assert "visible" in out
+        assert "x" not in out
+
+    def test_parser_exception_falls_back_to_unescape(
+        self, monkeypatch
+    ) -> None:
+        # Force the parser to raise on `feed`; the fallback unescape()
+        # branch should still surface the raw body.
+        from pleno_pii_scanner_jira import storage as storage_mod
+
+        class BoomParser:
+            def feed(self, _: str) -> None:
+                raise RuntimeError("boom")
+
+            def close(self) -> None:  # pragma: no cover
+                pass
+
+        monkeypatch.setattr(storage_mod, "_StorageStripper", BoomParser)
+        out = storage_to_text("<p>tom&amp;jerry</p>")
+        # `tom&jerry` because unescape() resolves `&amp;`.
+        assert "tom&jerry" in out


### PR DESCRIPTION
Expands the merged stub from PR #115 with:

- dedicated adf.py (ADF JSON tree → text, all standard node types + MAX_DEPTH=100)
- storage.py (DC storage XHTML stripper via stdlib HTMLParser)
- api.py (httpx wrapper with 429/503 backoff + Retry-After cap)

179 tests passing, 99% coverage.