### PR TITLE
feat(pii-scanner-confluence): Cloud v2 + DC + storage XHTML→text (#28, ADR §13)

### DIFF
--- a/packages/pii-scanner-confluence/README.md
+++ b/packages/pii-scanner-confluence/README.md
@@ -1,0 +1,51 @@
+# pleno-pii-scanner-confluence
+
+Atlassian Confluence `SourceConnector` for [pleno-pii-scanner](../pii-scanner/).
+
+Confluence pages routinely accumulate credentials in incident write-ups,
+runbooks, vendor onboarding docs, and the "TEMP — please delete" pages
+nobody ever deletes. Scanning a single space typically surfaces 10x
+more findings than the corresponding code repo.
+
+This connector targets both deployment models:
+
+* **Cloud** — `/wiki/api/v2/pages` (cursor-paginated v2 REST), HTTP basic
+  with `email:api_token`.
+* **Data Center / Server** — `/rest/api/content` (start/limit v1 REST),
+  bearer-token auth.
+
+The page body comes back as **Confluence storage XHTML**. We walk the
+XHTML tree with `xml.etree.ElementTree` to recover plain text — block
+elements (`p`, `h1..h6`, `li`) emit newlines, and `ac:structured-macro`
+blocks surface their `name=` and inner text so secrets parked inside a
+`{code}` macro are still detected. No BeautifulSoup dependency.
+
+Attachments are surfaced as metadata-only `DocumentRef`s (binary download
+is opt-out via `include_attachments_meta=False`); the binary fetch belongs
+to a dedicated content-extractor stage.
+
+## Auth
+
+* Cloud: Atlassian account email + API token from
+  <https://id.atlassian.com/manage-profile/security/api-tokens>. Sent as
+  HTTP basic `email:api_token`.
+* DC / Server: personal access token. Sent as `Authorization: Bearer
+  <token>`.
+
+## Config
+
+```toml
+[confluence]
+base_url = "https://acme.atlassian.net"
+email = "ops@acme.example"
+api_token = "${CONFLUENCE_TOKEN}"
+deployment = "cloud"                  # or "dc"
+spaces = ["ENG", "OPS"]               # optional allowlist (space keys)
+include_attachments_meta = true       # emit DocumentRef per attachment
+```
+
+## Incremental
+
+The cursor encodes the highest `last_modified` timestamp seen plus the
+per-space pagination cursor. On resume the connector orders by
+`lastmodified` and skips pages already covered by the prior run.

--- a/packages/pii-scanner-confluence/pyproject.toml
+++ b/packages/pii-scanner-confluence/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "pleno-pii-scanner-confluence"
+version = "0.1.0"
+description = "Confluence (Cloud + DC) SourceConnector for pleno-pii-scanner (storage XHTML→text + attachment metadata)"
+readme = "README.md"
+license = { text = "AGPL-3.0-or-later" }
+requires-python = ">=3.12"
+authors = [{ name = "pleno", email = "ai@egahika.dev" }]
+keywords = ["pii", "confluence", "atlassian", "scanner", "trufflehog"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+]
+dependencies = [
+    "httpx>=0.27",
+    "pleno-pii-scanner",
+]
+
+[project.entry-points."pleno_pii_scanner.connectors"]
+confluence = "pleno_pii_scanner_confluence:SPEC"
+
+[project.urls]
+Homepage = "https://github.com/plenoai/pleno-anonymize"
+Source = "https://github.com/plenoai/pleno-anonymize"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
+]
+
+[tool.uv.sources]
+pleno-pii-scanner = { workspace = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pleno_pii_scanner_confluence"]

--- a/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/__init__.py
+++ b/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/__init__.py
@@ -1,0 +1,9 @@
+"""Confluence SourceConnector for pleno-pii-scanner (ADR-0007 §13)."""
+
+from pleno_pii_scanner_confluence.connector import (
+    SPEC,
+    ConfluenceConfig,
+    ConfluenceConnector,
+)
+
+__all__ = ["SPEC", "ConfluenceConfig", "ConfluenceConnector"]

--- a/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/connector.py
+++ b/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/connector.py
@@ -1,0 +1,710 @@
+"""Confluence SourceConnector — Cloud v2 + DC, storage XHTML → text.
+
+Pipeline:
+
+  1. Resolve allowlist (`spaces=` config) to space IDs (Cloud) or
+     pass-through space keys (DC).
+  2. Cloud: GET /wiki/api/v2/pages?cursor=...&body-format=storage&limit=100
+     (+ space-id=... when filtering).
+     DC:    GET /rest/api/content?type=page&start=N&limit=100
+            &expand=body.storage,version (+ spaceKey= when filtering).
+  3. For each page emit a DocumentRef with path `<space-key>/<page-id>`,
+     metadata `version_id`, body cached for fetch().
+  4. If `include_attachments_meta=True`, also enumerate attachments
+     (`/wiki/api/v2/pages/{id}/attachments` cloud, or
+     `/rest/api/content/{id}/child/attachment` DC) and emit one
+     metadata-only DocumentRef per attachment with `content_type` set.
+  5. fetch(): yield one Document with the page body decoded from
+     storage XHTML to plain text via a small recursive walker.
+
+Incremental cursor: JSON `{"last_modified": "...", "spaces": {key: cursor}}`.
+On resume, pages older than `last_modified` are skipped client-side
+(the page list comes back newest-first from both APIs when sorted).
+
+The XHTML walker handles `<p>`, `<h1..6>`, `<li>` block boundaries and
+emits one line per block; `<ac:structured-macro ac:name="X">` is rendered
+as `[macro X] <inner text>` so secrets stashed inside `{code}` /
+`{noformat}` macros stay detectable. No BeautifulSoup dependency — the
+core API is `xml.etree.ElementTree` wrapped in a small namespace shim
+because storage XHTML uses the `ac:` and `ri:` Confluence namespaces
+without declaring them on the body fragment.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+from xml.etree import ElementTree as ET
+
+import httpx
+
+from pleno_pii_scanner.sources.base import (
+    Capabilities,
+    Cursor,
+    Document,
+    DocumentChunk,
+    DocumentRef,
+    SourceConnector,
+    SourceFilter,
+)
+from pleno_pii_scanner.sources.registry import ConnectorSpec
+
+
+# Block elements that should produce a newline boundary when flattening
+# storage XHTML to plain text. Confluence uses XHTML so the canonical
+# block tags from HTML5 are the right set; the connector deliberately
+# stays narrow rather than copying the full block-level enum.
+_BLOCK_TAGS: frozenset[str] = frozenset(
+    {"p", "h1", "h2", "h3", "h4", "h5", "h6", "li", "tr", "td", "th", "div", "br"}
+)
+
+# Confluence storage XHTML uses the `ac:` and `ri:` namespaces without
+# declaring them on the body fragment the API returns. We wrap the
+# fragment in a root element that declares both so ElementTree can parse
+# without a NamespaceError.
+_AC_NS = "http://atlassian.com/content"
+_RI_NS = "http://atlassian.com/resource/identifier"
+_AC_NAME_ATTR = f"{{{_AC_NS}}}name"
+
+
+@dataclass(frozen=True, slots=True)
+class ConfluenceConfig:
+    """Construction config for `ConfluenceConnector`."""
+
+    base_url: str
+    email: str
+    api_token: str
+    spaces: tuple[str, ...] = ()
+    include_attachments_meta: bool = True
+    deployment: Literal["cloud", "dc"] = "cloud"
+    id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.base_url:
+            raise ValueError("base_url must be non-empty")
+        if not self.api_token:
+            raise ValueError("api_token must be non-empty")
+        if self.deployment not in ("cloud", "dc"):
+            raise ValueError(
+                f"deployment must be 'cloud' or 'dc'; got {self.deployment!r}"
+            )
+
+    def resolved_id(self) -> str:
+        if self.id is not None:
+            return self.id
+        # Token is sensitive; identify by hashed (base_url, token, spaces).
+        import hashlib
+
+        h = hashlib.sha256()
+        h.update(self.base_url.encode())
+        h.update(b"\0")
+        h.update(self.api_token.encode())
+        for s in sorted(self.spaces):
+            h.update(b"\0")
+            h.update(s.encode())
+        return f"confluence:{h.hexdigest()[:16]}"
+
+
+class ConfluenceConnector:
+    """Read-only SourceConnector for Atlassian Confluence (Cloud + DC)."""
+
+    kind = "confluence"
+
+    def __init__(
+        self,
+        config: ConfluenceConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self.id = config.resolved_id()
+        if client is None:
+            self._client = httpx.AsyncClient(
+                base_url=config.base_url, timeout=30.0
+            )
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+        if config.deployment == "cloud":
+            # HTTP basic email:api_token. httpx handles base64 encoding
+            # via the `auth` kwarg per request to keep the credential
+            # off any structured logging path.
+            self._auth: httpx.BasicAuth | None = httpx.BasicAuth(
+                config.email, config.api_token
+            )
+            self._headers: dict[str, str] = {"Accept": "application/json"}
+        else:
+            # DC PATs are bearer tokens.
+            self._auth = None
+            self._headers = {
+                "Accept": "application/json",
+                "Authorization": f"Bearer {config.api_token}",
+            }
+        # Cache page-body XHTML keyed by ref.path so fetch() doesn't
+        # re-issue the page GET.
+        self._bodies: dict[str, str] = {}
+        # High-water last_modified ISO timestamp, written across discover.
+        self._high_water: str | None = None
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(
+            incremental=True,
+            binary=False,
+            content_hash_delta=False,
+            max_concurrent_fetches=4,
+            streaming=False,
+        )
+
+    async def discover(
+        self,
+        filter: SourceFilter,
+        cursor: Cursor | None,
+    ) -> AsyncIterator[DocumentRef]:
+        prior = _decode_cursor(cursor)
+        prior_lm = prior.get("last_modified")
+        # Threshold for client-side incremental skip — pages with
+        # last_modified <= prior_lm have already been emitted.
+        threshold = _parse_iso(prior_lm) if isinstance(prior_lm, str) else None
+        if self._config.deployment == "cloud":
+            async for ref in self._discover_cloud(filter, threshold):
+                yield ref
+        else:
+            async for ref in self._discover_dc(filter, threshold):
+                yield ref
+
+    async def fetch(
+        self,
+        ref: DocumentRef,
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        # Attachments are metadata-only: no body cached, fetch() is a no-op.
+        if ref.metadata.get("kind") == "attachment":
+            return
+        body_xhtml = self._bodies.get(ref.path)
+        if body_xhtml is None:
+            return
+        text = _xhtml_to_text(body_xhtml)
+        yield Document(
+            ref=ref,
+            text=text,
+            fetched_at=datetime.now(UTC),
+            extra=dict(ref.metadata),
+        )
+
+    def cursor_after_run(self) -> Cursor | None:
+        if self._high_water is None:
+            return None
+        return _encode_cursor({"last_modified": self._high_water})
+
+    async def close(self) -> None:
+        self._bodies.clear()
+        if self._owns_client:
+            await self._client.aclose()
+
+    # --- cloud discovery -----------------------------------------
+
+    async def _discover_cloud(
+        self,
+        filter: SourceFilter,
+        threshold: datetime | None,
+    ) -> AsyncIterator[DocumentRef]:
+        # Resolve space-key allowlist → space-id (Cloud v2 filters by id).
+        space_id_to_key = await self._resolve_cloud_spaces()
+        # When operator gave no allowlist, hit the global pages endpoint
+        # once; otherwise issue one paged walk per space-id.
+        if space_id_to_key:
+            walks: list[tuple[str | None, str]] = [
+                (sid, key) for sid, key in space_id_to_key.items()
+            ]
+        else:
+            walks = [(None, "")]
+        for space_id, space_key in walks:
+            params: dict[str, str | int] = {
+                "limit": 100,
+                "body-format": "storage",
+            }
+            if space_id is not None:
+                params["space-id"] = space_id
+            cursor: str | None = None
+            while True:
+                if cursor is not None:
+                    params["cursor"] = cursor
+                body = await self._get_json("/wiki/api/v2/pages", params=params)
+                for page in body.get("results", []) or []:
+                    ref = self._cloud_page_to_ref(
+                        page, space_key=space_key, filter=filter, threshold=threshold
+                    )
+                    if ref is None:
+                        continue
+                    yield ref
+                    if self._config.include_attachments_meta:
+                        async for att in self._cloud_attachments(
+                            page_id=str(page["id"]),
+                            page_path=ref.path,
+                            filter=filter,
+                        ):
+                            yield att
+                cursor = _next_cursor_from_links(body.get("_links", {}))
+                if not cursor:
+                    break
+
+    async def _resolve_cloud_spaces(self) -> dict[str, str]:
+        """Map configured space keys → space ids via /wiki/api/v2/spaces.
+
+        Returns an empty dict when no allowlist was configured (caller
+        then walks every space the credential can see).
+        """
+        if not self._config.spaces:
+            return {}
+        out: dict[str, str] = {}
+        params: dict[str, str | int] = {"limit": 100}
+        cursor: str | None = None
+        wanted = set(self._config.spaces)
+        while wanted:
+            if cursor is not None:
+                params["cursor"] = cursor
+            body = await self._get_json("/wiki/api/v2/spaces", params=params)
+            for space in body.get("results", []) or []:
+                key = str(space.get("key", ""))
+                if key in wanted:
+                    out[str(space["id"])] = key
+                    wanted.discard(key)
+            cursor = _next_cursor_from_links(body.get("_links", {}))
+            if not cursor:
+                break
+        return out
+
+    async def _cloud_attachments(
+        self,
+        *,
+        page_id: str,
+        page_path: str,
+        filter: SourceFilter,
+    ) -> AsyncIterator[DocumentRef]:
+        params: dict[str, str | int] = {"limit": 100}
+        cursor: str | None = None
+        while True:
+            if cursor is not None:
+                params["cursor"] = cursor
+            body = await self._get_json(
+                f"/wiki/api/v2/pages/{page_id}/attachments", params=params
+            )
+            for att in body.get("results", []) or []:
+                title = str(att.get("title") or att.get("id"))
+                full = f"{page_path}/attachments/{title}"
+                if filter.include and not _matches_any(full, filter.include):
+                    continue
+                if filter.exclude and _matches_any(full, filter.exclude):
+                    continue
+                yield DocumentRef(
+                    source_id=self.id,
+                    source_kind=self.kind,
+                    path=full,
+                    content_type=str(att.get("mediaType") or "application/octet-stream"),
+                    size=int(att["fileSize"]) if isinstance(att.get("fileSize"), int) else None,
+                    metadata={
+                        "kind": "attachment",
+                        "page_id": page_id,
+                        "attachment_id": str(att.get("id", "")),
+                        "title": title,
+                    },
+                )
+            cursor = _next_cursor_from_links(body.get("_links", {}))
+            if not cursor:
+                break
+
+    def _cloud_page_to_ref(
+        self,
+        page: Mapping[str, Any],
+        *,
+        space_key: str,
+        filter: SourceFilter,
+        threshold: datetime | None,
+    ) -> DocumentRef | None:
+        page_id = str(page["id"])
+        # Cloud v2 returns spaceId, not spaceKey, on the page payload —
+        # we already know the key from the outer walk loop, but fall back
+        # to the page's own spaceId when the operator gave no allowlist.
+        eff_key = space_key or str(page.get("spaceId", ""))
+        full = f"{eff_key}/{page_id}"
+        if filter.include and not _matches_any(full, filter.include):
+            return None
+        if filter.exclude and _matches_any(full, filter.exclude):
+            return None
+        version = page.get("version") or {}
+        # Cloud v2 nests last-modified under version.createdAt.
+        lm_str = str(version.get("createdAt") or "")
+        lm = _parse_iso(lm_str) if lm_str else None
+        if threshold is not None and lm is not None and lm <= threshold:
+            return None
+        if lm_str and (self._high_water is None or lm_str > self._high_water):
+            self._high_water = lm_str
+        body_obj = page.get("body") or {}
+        storage_obj = body_obj.get("storage") or {}
+        body_value = str(storage_obj.get("value", "") or "")
+        self._bodies[full] = body_value
+        return DocumentRef(
+            source_id=self.id,
+            source_kind=self.kind,
+            path=full,
+            content_type="text/html",
+            size=len(body_value),
+            etag=str(version.get("number", "")),
+            last_modified=lm,
+            metadata={
+                "kind": "page",
+                "page_id": page_id,
+                "space_key": eff_key,
+                "version_id": str(version.get("number", "")),
+                "title": str(page.get("title", "")),
+            },
+        )
+
+    # --- DC discovery --------------------------------------------
+
+    async def _discover_dc(
+        self,
+        filter: SourceFilter,
+        threshold: datetime | None,
+    ) -> AsyncIterator[DocumentRef]:
+        space_keys: tuple[str | None, ...] = (
+            self._config.spaces if self._config.spaces else (None,)
+        )
+        for space_key in space_keys:
+            start = 0
+            while True:
+                params: dict[str, str | int] = {
+                    "type": "page",
+                    "start": start,
+                    "limit": 100,
+                    "expand": "body.storage,version",
+                }
+                if space_key is not None:
+                    params["spaceKey"] = space_key
+                body = await self._get_json("/rest/api/content", params=params)
+                results = body.get("results", []) or []
+                if not results:
+                    break
+                for page in results:
+                    ref = self._dc_page_to_ref(
+                        page, filter=filter, threshold=threshold
+                    )
+                    if ref is None:
+                        continue
+                    yield ref
+                    if self._config.include_attachments_meta:
+                        async for att in self._dc_attachments(
+                            page_id=str(page["id"]),
+                            page_path=ref.path,
+                            filter=filter,
+                        ):
+                            yield att
+                size = int(body.get("size", len(results)) or len(results))
+                limit = int(body.get("limit", 100) or 100)
+                start += size
+                if size < limit:
+                    break
+
+    def _dc_page_to_ref(
+        self,
+        page: Mapping[str, Any],
+        *,
+        filter: SourceFilter,
+        threshold: datetime | None,
+    ) -> DocumentRef | None:
+        page_id = str(page["id"])
+        space_obj = page.get("space") or {}
+        space_key = str(space_obj.get("key", ""))
+        full = f"{space_key}/{page_id}"
+        if filter.include and not _matches_any(full, filter.include):
+            return None
+        if filter.exclude and _matches_any(full, filter.exclude):
+            return None
+        version = page.get("version") or {}
+        lm_str = str(version.get("when") or "")
+        lm = _parse_iso(lm_str) if lm_str else None
+        if threshold is not None and lm is not None and lm <= threshold:
+            return None
+        if lm_str and (self._high_water is None or lm_str > self._high_water):
+            self._high_water = lm_str
+        body_obj = page.get("body") or {}
+        storage_obj = body_obj.get("storage") or {}
+        body_value = str(storage_obj.get("value", "") or "")
+        self._bodies[full] = body_value
+        return DocumentRef(
+            source_id=self.id,
+            source_kind=self.kind,
+            path=full,
+            content_type="text/html",
+            size=len(body_value),
+            etag=str(version.get("number", "")),
+            last_modified=lm,
+            metadata={
+                "kind": "page",
+                "page_id": page_id,
+                "space_key": space_key,
+                "version_id": str(version.get("number", "")),
+                "title": str(page.get("title", "")),
+            },
+        )
+
+    async def _dc_attachments(
+        self,
+        *,
+        page_id: str,
+        page_path: str,
+        filter: SourceFilter,
+    ) -> AsyncIterator[DocumentRef]:
+        start = 0
+        while True:
+            params: dict[str, str | int] = {"start": start, "limit": 100}
+            body = await self._get_json(
+                f"/rest/api/content/{page_id}/child/attachment", params=params
+            )
+            results = body.get("results", []) or []
+            if not results:
+                break
+            for att in results:
+                title = str(att.get("title") or att.get("id"))
+                full = f"{page_path}/attachments/{title}"
+                if filter.include and not _matches_any(full, filter.include):
+                    continue
+                if filter.exclude and _matches_any(full, filter.exclude):
+                    continue
+                metadata_obj = att.get("metadata") or {}
+                ext = att.get("extensions") or {}
+                media_type = str(
+                    metadata_obj.get("mediaType")
+                    or (ext.get("mediaType") if isinstance(ext, Mapping) else "")
+                    or "application/octet-stream"
+                )
+                size_val = ext.get("fileSize") if isinstance(ext, Mapping) else None
+                yield DocumentRef(
+                    source_id=self.id,
+                    source_kind=self.kind,
+                    path=full,
+                    content_type=media_type,
+                    size=int(size_val) if isinstance(size_val, int) else None,
+                    metadata={
+                        "kind": "attachment",
+                        "page_id": page_id,
+                        "attachment_id": str(att.get("id", "")),
+                        "title": title,
+                    },
+                )
+            size = int(body.get("size", len(results)) or len(results))
+            limit = int(body.get("limit", 100) or 100)
+            start += size
+            if size < limit:
+                break
+
+    # --- HTTP ----------------------------------------------------
+
+    async def _get_json(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        resp = await self._client.get(
+            path,
+            params=params,
+            headers=self._headers,
+            auth=self._auth or httpx.USE_CLIENT_DEFAULT,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# --- helpers ------------------------------------------------------
+
+
+def _matches_any(s: str, patterns: tuple[str, ...]) -> bool:
+    from fnmatch import fnmatch
+
+    return any(fnmatch(s, p) for p in patterns)
+
+
+def _parse_iso(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp; tolerate the `Z` suffix."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _decode_cursor(cursor: Cursor | None) -> dict[str, Any]:
+    """Decode the JSON cursor; empty/garbage → fresh-scan {}."""
+    if not cursor:
+        return {}
+    try:
+        decoded = json.loads(cursor)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    return decoded
+
+
+def _encode_cursor(state: Mapping[str, Any]) -> str:
+    return json.dumps(dict(state), sort_keys=True)
+
+
+def _next_cursor_from_links(links: Mapping[str, Any]) -> str | None:
+    """Pull the `cursor=` query param out of `_links.next`.
+
+    Cloud v2 returns the next page as an opaque relative URL with the
+    cursor in the query string; we surface only the cursor value so the
+    caller can pass it back as `?cursor=`.
+    """
+    nxt = links.get("next") if isinstance(links, Mapping) else None
+    if not isinstance(nxt, str) or not nxt:
+        return None
+    # Locate the cursor query parameter without pulling urllib.parse for
+    # such a narrow use case.
+    marker = "cursor="
+    idx = nxt.find(marker)
+    if idx < 0:
+        return None
+    rest = nxt[idx + len(marker) :]
+    end = rest.find("&")
+    return rest if end < 0 else rest[:end]
+
+
+def _xhtml_to_text(xhtml: str) -> str:
+    """Render Confluence storage XHTML as plain text.
+
+    Block elements (`p`, `h1..h6`, `li`, `tr`, `td`, `th`, `div`, `br`)
+    introduce newlines so paragraph and table boundaries survive the
+    flatten. `ac:structured-macro` blocks emit `[macro <name>]` followed
+    by their inner text on a new line.
+
+    Returns an empty string when the body is empty or when the parser
+    cannot recover anything — never raises on malformed input.
+    """
+    if not xhtml.strip():
+        return ""
+    # Wrap fragment in a root element with the Confluence namespaces
+    # declared so ElementTree accepts `ac:` and `ri:` prefixed elements.
+    wrapped = (
+        f'<root xmlns:ac="{_AC_NS}" xmlns:ri="{_RI_NS}">'
+        f"{xhtml}"
+        "</root>"
+    )
+    try:
+        root = ET.fromstring(wrapped)
+    except ET.ParseError:
+        # Fallback: strip everything that looks like a tag and return
+        # whatever text remained. Confluence XHTML is well-formed in
+        # practice, but the connector must not be the link in the chain
+        # that raises on a single malformed page.
+        import re
+
+        return re.sub(r"<[^>]+>", "", xhtml).strip()
+    parts: list[str] = []
+    _walk(root, parts)
+    # Collapse runs of blank lines → single blank line so block
+    # boundaries are visible without runaway whitespace.
+    out_lines: list[str] = []
+    last_blank = False
+    for line in "".join(parts).splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if last_blank:
+                continue
+            last_blank = True
+            out_lines.append("")
+        else:
+            last_blank = False
+            out_lines.append(stripped)
+    return "\n".join(out_lines).strip()
+
+
+def _walk(elem: ET.Element, parts: list[str]) -> None:
+    """Recursive XHTML walker; appends text fragments to `parts`."""
+    tag = _local(elem.tag)
+    is_macro = elem.tag == f"{{{_AC_NS}}}structured-macro"
+    if is_macro:
+        macro_name = elem.get(_AC_NAME_ATTR) or elem.get("name") or ""
+        parts.append(f"\n[macro {macro_name}]\n")
+        if elem.text:
+            parts.append(elem.text)
+        for child in elem:
+            _walk(child, parts)
+        # Tail belongs to the parent's flow, not the macro.
+        if elem.tail:
+            parts.append(elem.tail)
+        parts.append("\n")
+        return
+    if tag in _BLOCK_TAGS:
+        parts.append("\n")
+    if elem.text:
+        parts.append(elem.text)
+    for child in elem:
+        _walk(child, parts)
+    if tag in _BLOCK_TAGS:
+        parts.append("\n")
+    if elem.tail:
+        parts.append(elem.tail)
+
+
+def _local(tag: str) -> str:
+    """Strip XML namespace from `{uri}local` → `local`."""
+    if tag.startswith("{"):
+        return tag.partition("}")[2]
+    return tag
+
+
+# --- factory / spec -----------------------------------------------
+
+
+def _factory(config: Mapping[str, Any]) -> SourceConnector:
+    for required in ("base_url", "email", "api_token"):
+        if required not in config:
+            raise ValueError(
+                f"confluence connector config requires {required!r}"
+            )
+    return ConfluenceConnector(
+        ConfluenceConfig(
+            base_url=str(config["base_url"]),
+            email=str(config["email"]),
+            api_token=str(config["api_token"]),
+            spaces=tuple(str(s) for s in config.get("spaces", ())),
+            include_attachments_meta=bool(
+                config.get("include_attachments_meta", True)
+            ),
+            deployment=str(config.get("deployment", "cloud")),  # type: ignore[arg-type]
+            id=str(config["id"]) if config.get("id") is not None else None,
+        )
+    )
+
+
+SPEC = ConnectorSpec(
+    kind="confluence",
+    version="0.1.0",
+    factory=_factory,
+    capabilities=Capabilities(
+        incremental=True,
+        binary=False,
+        content_hash_delta=False,
+        max_concurrent_fetches=4,
+        streaming=False,
+    ),
+    required_scopes=("confluence:read",),
+    description=(
+        "Atlassian Confluence SourceConnector. Cloud v2 (cursor-paginated, "
+        "HTTP basic email:api_token) + Data Center (start/limit, bearer "
+        "token). Storage XHTML is flattened to plain text via "
+        "xml.etree.ElementTree; structured-macro blocks surface their "
+        "name and inner text. Attachments are emitted as metadata-only "
+        "DocumentRefs (binary download is opt-out)."
+    ),
+)
+
+
+__all__ = ["SPEC", "ConfluenceConfig", "ConfluenceConnector"]

--- a/packages/pii-scanner-confluence/tests/test_connector.py
+++ b/packages/pii-scanner-confluence/tests/test_connector.py
@@ -1,0 +1,1410 @@
+"""Tests for ConfluenceConnector — uses httpx.MockTransport doubles."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from pleno_pii_scanner.sources import (
+    Capabilities,
+    Document,
+    DocumentRef,
+    SourceConnector,
+    SourceFilter,
+    create,
+    register,
+)
+from pleno_pii_scanner.sources import registry as _registry_mod
+from pleno_pii_scanner_confluence import (
+    SPEC,
+    ConfluenceConfig,
+    ConfluenceConnector,
+)
+from pleno_pii_scanner_confluence.connector import (
+    _decode_cursor,
+    _encode_cursor,
+    _next_cursor_from_links,
+    _parse_iso,
+    _xhtml_to_text,
+)
+
+
+_BASE = "https://acme.atlassian.net"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(_registry_mod, "entry_points", lambda **_: [])
+    _registry_mod._reset_for_tests()
+    yield
+    _registry_mod._reset_for_tests()
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url=_BASE,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+# --- config --------------------------------------------------------
+
+
+class TestConfig:
+    def test_rejects_empty_base_url(self) -> None:
+        with pytest.raises(ValueError, match="base_url"):
+            ConfluenceConfig(base_url="", email="e", api_token="t")
+
+    def test_rejects_empty_api_token(self) -> None:
+        with pytest.raises(ValueError, match="api_token"):
+            ConfluenceConfig(base_url=_BASE, email="e", api_token="")
+
+    def test_rejects_bad_deployment(self) -> None:
+        with pytest.raises(ValueError, match="deployment"):
+            ConfluenceConfig(
+                base_url=_BASE,
+                email="e",
+                api_token="t",
+                deployment="onprem",  # type: ignore[arg-type]
+            )
+
+    def test_explicit_id(self) -> None:
+        cfg = ConfluenceConfig(
+            base_url=_BASE, email="e", api_token="t", id="x"
+        )
+        assert cfg.resolved_id() == "x"
+
+    def test_default_id_no_token_leak(self) -> None:
+        cfg = ConfluenceConfig(
+            base_url=_BASE,
+            email="e",
+            api_token="VERYSECRET",
+            spaces=("A", "B"),
+        )
+        rid = cfg.resolved_id()
+        assert "VERYSECRET" not in rid
+        assert rid.startswith("confluence:")
+
+    def test_default_id_order_independent(self) -> None:
+        a = ConfluenceConfig(
+            base_url=_BASE, email="e", api_token="t", spaces=("A", "B")
+        )
+        b = ConfluenceConfig(
+            base_url=_BASE, email="e", api_token="t", spaces=("B", "A")
+        )
+        assert a.resolved_id() == b.resolved_id()
+
+
+# --- protocol ------------------------------------------------------
+
+
+class TestProtocol:
+    def test_runtime_isinstance(self) -> None:
+        c = ConfluenceConnector(
+            ConfluenceConfig(base_url=_BASE, email="e", api_token="t")
+        )
+        assert isinstance(c, SourceConnector)
+
+    def test_capabilities(self) -> None:
+        c = ConfluenceConnector(
+            ConfluenceConfig(base_url=_BASE, email="e", api_token="t")
+        )
+        assert c.capabilities() == Capabilities(
+            incremental=True,
+            binary=False,
+            content_hash_delta=False,
+            max_concurrent_fetches=4,
+            streaming=False,
+        )
+
+
+# --- auth ---------------------------------------------------------
+
+
+class TestAuth:
+    async def test_cloud_basic_auth_header(self) -> None:
+        seen_auth: dict[str, str | None] = {"value": None}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_auth["value"] = request.headers.get("authorization")
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(200, json={"results": [], "_links": {}})
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="ops@acme.example",
+                    api_token="cloud-token",
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        # HTTP basic = "Basic base64(email:token)"
+        expected = base64.b64encode(b"ops@acme.example:cloud-token").decode()
+        assert seen_auth["value"] == f"Basic {expected}"
+
+    async def test_dc_bearer_header(self) -> None:
+        seen_auth: dict[str, str | None] = {"value": None}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_auth["value"] = request.headers.get("authorization")
+            if request.url.path.endswith("/rest/api/content"):
+                return httpx.Response(
+                    200, json={"results": [], "size": 0, "limit": 100}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="ignored",
+                    api_token="dc-pat",
+                    deployment="dc",
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        assert seen_auth["value"] == "Bearer dc-pat"
+
+
+# --- pagination + discover ---------------------------------------
+
+
+def _cloud_page(
+    page_id: str,
+    *,
+    space_id: str = "100",
+    title: str = "Page",
+    body: str = "<p>hi</p>",
+    version_number: int = 1,
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> dict:
+    return {
+        "id": page_id,
+        "title": title,
+        "spaceId": space_id,
+        "body": {"storage": {"value": body, "representation": "storage"}},
+        "version": {"number": version_number, "createdAt": created_at},
+    }
+
+
+class TestCloudPagination:
+    async def test_cursor_paginates_and_yields_refs(self) -> None:
+        page_one = _cloud_page("1", title="A", body="<p>alpha</p>")
+        page_two = _cloud_page(
+            "2", title="B", body="<p>beta</p>", created_at="2026-02-01T00:00:00Z"
+        )
+        seen_cursors: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                cursor = request.url.params.get("cursor")
+                seen_cursors.append(cursor)
+                if cursor is None:
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [page_one],
+                            "_links": {
+                                "next": "/wiki/api/v2/pages?cursor=ABC&limit=100"
+                            },
+                        },
+                    )
+                if cursor == "ABC":
+                    return httpx.Response(
+                        200,
+                        json={"results": [page_two], "_links": {}},
+                    )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        assert [r.metadata["page_id"] for r in refs] == ["1", "2"]
+        assert seen_cursors == [None, "ABC"]
+
+    async def test_no_attachments_when_flag_off(self) -> None:
+        attempted: dict[str, bool] = {"hit": False}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "/attachments" in request.url.path:
+                attempted["hit"] = True
+                return httpx.Response(500)
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={"results": [_cloud_page("1")], "_links": {}},
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        assert attempted["hit"] is False
+
+    async def test_attachments_emitted_with_metadata(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={"results": [_cloud_page("1")], "_links": {}},
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages/1/attachments"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": "att-1",
+                                "title": "diagram.png",
+                                "mediaType": "image/png",
+                                "fileSize": 1234,
+                            }
+                        ],
+                        "_links": {},
+                    },
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        att_refs = [r for r in refs if r.metadata.get("kind") == "attachment"]
+        assert len(att_refs) == 1
+        assert att_refs[0].content_type == "image/png"
+        assert att_refs[0].size == 1234
+
+    async def test_attachments_paginate(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={"results": [_cloud_page("1")], "_links": {}},
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages/1/attachments"):
+                cursor = request.url.params.get("cursor")
+                if cursor is None:
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [
+                                {
+                                    "id": "a1",
+                                    "title": "f1",
+                                    "mediaType": "text/plain",
+                                }
+                            ],
+                            "_links": {
+                                "next": "/wiki/api/v2/pages/1/attachments?cursor=NEXT"
+                            },
+                        },
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": "a2",
+                                "title": "f2",
+                                "mediaType": "text/plain",
+                            }
+                        ],
+                        "_links": {},
+                    },
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(base_url=_BASE, email="e", api_token="t"),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        att_titles = [
+            r.metadata["title"] for r in refs if r.metadata.get("kind") == "attachment"
+        ]
+        assert att_titles == ["f1", "f2"]
+
+
+# --- DC pagination ------------------------------------------------
+
+
+def _dc_page(
+    page_id: str,
+    *,
+    space_key: str = "ENG",
+    title: str = "Page",
+    body: str = "<p>dc</p>",
+    version_number: int = 1,
+    when: str = "2026-01-01T00:00:00Z",
+) -> dict:
+    return {
+        "id": page_id,
+        "title": title,
+        "space": {"key": space_key},
+        "body": {"storage": {"value": body, "representation": "storage"}},
+        "version": {"number": version_number, "when": when},
+    }
+
+
+class TestDcPagination:
+    async def test_start_limit_walks_and_attachments(self) -> None:
+        seen_starts: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                start = request.url.params.get("start")
+                seen_starts.append(start)
+                if start in (None, "0"):
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [_dc_page("1"), _dc_page("2")],
+                            "size": 2,
+                            "limit": 2,
+                        },
+                    )
+                if start == "2":
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [_dc_page("3")],
+                            "size": 1,
+                            "limit": 2,
+                        },
+                    )
+            if request.url.path.endswith("/child/attachment"):
+                # Empty page so the inner pagination break runs.
+                return httpx.Response(
+                    200,
+                    json={"results": [], "size": 0, "limit": 100},
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="ignored",
+                    api_token="dc",
+                    deployment="dc",
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        # Limit was 2; first page returned size=2 → start advances to 2.
+        # Second page returned size=1 < limit → stop.
+        assert [r.metadata["page_id"] for r in refs] == ["1", "2", "3"]
+        assert seen_starts == ["0", "2"]
+
+    async def test_dc_attachment_metadata(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [_dc_page("1")],
+                        "size": 1,
+                        "limit": 100,
+                    },
+                )
+            if request.url.path.endswith("/rest/api/content/1/child/attachment"):
+                start = request.url.params.get("start")
+                if start in (None, "0"):
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [
+                                {
+                                    "id": "att1",
+                                    "title": "secret.csv",
+                                    "extensions": {
+                                        "mediaType": "text/csv",
+                                        "fileSize": 99,
+                                    },
+                                }
+                            ],
+                            "size": 1,
+                            "limit": 1,
+                        },
+                    )
+                return httpx.Response(
+                    200, json={"results": [], "size": 0, "limit": 1}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        att = next(r for r in refs if r.metadata.get("kind") == "attachment")
+        assert att.content_type == "text/csv"
+        assert att.size == 99
+        assert att.path.endswith("/attachments/secret.csv")
+
+    async def test_dc_spaces_allowlist_passes_spacekey(self) -> None:
+        seen_keys: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                seen_keys.append(request.url.params.get("spaceKey"))
+                return httpx.Response(
+                    200, json={"results": [], "size": 0, "limit": 100}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                    spaces=("ENG", "OPS"),
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        assert sorted(k for k in seen_keys if k is not None) == ["ENG", "OPS"]
+
+
+# --- spaces allowlist (cloud) ------------------------------------
+
+
+class TestCloudSpacesAllowlist:
+    async def test_allowlist_resolves_keys_to_ids(self) -> None:
+        seen_space_ids: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/spaces"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {"id": "100", "key": "ENG"},
+                            {"id": "200", "key": "OPS"},
+                            {"id": "300", "key": "OTHER"},
+                        ],
+                        "_links": {},
+                    },
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                seen_space_ids.append(request.url.params.get("space-id"))
+                return httpx.Response(
+                    200, json={"results": [], "_links": {}}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    spaces=("ENG", "OPS"),
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        assert sorted(s for s in seen_space_ids if s is not None) == ["100", "200"]
+
+    async def test_allowlist_paginates_spaces_lookup(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/spaces"):
+                cursor = request.url.params.get("cursor")
+                if cursor is None:
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [{"id": "1", "key": "OTHER"}],
+                            "_links": {
+                                "next": "/wiki/api/v2/spaces?cursor=NEXT"
+                            },
+                        },
+                    )
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [{"id": "9", "key": "ENG"}],
+                        "_links": {},
+                    },
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200, json={"results": [], "_links": {}}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    spaces=("ENG",),
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+
+
+# --- XHTML walker -------------------------------------------------
+
+
+class TestXhtmlWalker:
+    def test_paragraph_heading_list(self) -> None:
+        xhtml = (
+            "<h1>Title</h1>"
+            "<p>First paragraph.</p>"
+            "<ul><li>one</li><li>two</li></ul>"
+        )
+        text = _xhtml_to_text(xhtml)
+        assert "Title" in text
+        assert "First paragraph." in text
+        assert "one" in text and "two" in text
+        # Block boundaries → distinct lines.
+        lines = text.splitlines()
+        assert "Title" in lines
+        assert "one" in lines
+        assert "two" in lines
+
+    def test_table_renders_cells(self) -> None:
+        xhtml = (
+            "<table>"
+            "<tr><th>k</th><th>v</th></tr>"
+            "<tr><td>token</td><td>AKIA12345</td></tr>"
+            "</table>"
+        )
+        text = _xhtml_to_text(xhtml)
+        assert "AKIA12345" in text
+        assert "token" in text
+
+    def test_structured_macro_emits_name_and_inner_text(self) -> None:
+        xhtml = (
+            "<p>before</p>"
+            '<ac:structured-macro ac:name="code">'
+            "<ac:plain-text-body>API_KEY=AKIASECRET</ac:plain-text-body>"
+            "</ac:structured-macro>"
+            "<p>after</p>"
+        )
+        text = _xhtml_to_text(xhtml)
+        assert "[macro code]" in text
+        assert "API_KEY=AKIASECRET" in text
+        assert "before" in text
+        assert "after" in text
+
+    def test_empty_returns_empty(self) -> None:
+        assert _xhtml_to_text("") == ""
+        assert _xhtml_to_text("    \n  ") == ""
+
+    def test_malformed_falls_back_to_strip(self) -> None:
+        # Unbalanced tag → ParseError → regex fallback strips tags.
+        xhtml = "<p>open <strong>but never closed</p>"
+        text = _xhtml_to_text(xhtml)
+        # Either path keeps the visible payload.
+        assert "but never closed" in text
+
+    def test_macro_inner_text_and_tail_preserved(self) -> None:
+        # Direct macro text + tail-after-macro both flow into the output
+        # (covers _walk macro-text and macro-tail branches).
+        xhtml = (
+            '<p>head</p>'
+            '<ac:structured-macro ac:name="warning">DANGER-INSIDE</ac:structured-macro>'
+            'tail-after-macro'
+            '<p>foot</p>'
+        )
+        text = _xhtml_to_text(xhtml)
+        assert "[macro warning]" in text
+        assert "DANGER-INSIDE" in text
+        assert "tail-after-macro" in text
+
+    def test_inline_tail_after_block(self) -> None:
+        # `<strong>` is inline; its tail (text after the closing tag but
+        # before the next element) must survive the walker.
+        xhtml = "<p>before <strong>BOLD</strong>after-tail</p>"
+        text = _xhtml_to_text(xhtml)
+        assert "BOLD" in text
+        assert "after-tail" in text
+
+
+# --- filter -------------------------------------------------------
+
+
+class TestFilter:
+    async def test_include_exclude_on_path(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            _cloud_page("1", space_id="ENG"),
+                            _cloud_page("2", space_id="OPS"),
+                        ],
+                        "_links": {},
+                    },
+                )
+            if "/attachments" in request.url.path:
+                return httpx.Response(200, json={"results": [], "_links": {}})
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(include=("ENG/*",)), None
+                    )
+                ]
+            finally:
+                await c.close()
+        assert [r.metadata["page_id"] for r in refs] == ["1"]
+
+        async with _client(handler) as client2:
+            c2 = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client2,
+            )
+            try:
+                refs2 = [
+                    r
+                    async for r in c2.discover(
+                        SourceFilter(exclude=("OPS/*",)), None
+                    )
+                ]
+            finally:
+                await c2.close()
+        assert [r.metadata["page_id"] for r in refs2] == ["1"]
+
+    async def test_attachment_path_filter(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={"results": [_cloud_page("1")], "_links": {}},
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages/1/attachments"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": "a1",
+                                "title": "skip-me",
+                                "mediaType": "text/plain",
+                            },
+                            {
+                                "id": "a2",
+                                "title": "keep-me",
+                                "mediaType": "text/plain",
+                            },
+                        ],
+                        "_links": {},
+                    },
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(base_url=_BASE, email="e", api_token="t"),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(exclude=("*/skip-me",)), None
+                    )
+                ]
+            finally:
+                await c.close()
+        attach_titles = [
+            r.metadata["title"] for r in refs if r.metadata.get("kind") == "attachment"
+        ]
+        assert attach_titles == ["keep-me"]
+
+    async def test_dc_page_filter_include_exclude_and_threshold(self) -> None:
+        old = _dc_page("1", when="2025-01-01T00:00:00Z")
+        keep = _dc_page("2", when="2026-01-01T00:00:00Z")
+        other = _dc_page("3", space_key="OPS", when="2026-02-01T00:00:00Z")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [old, keep, other],
+                        "size": 3,
+                        "limit": 100,
+                    },
+                )
+            if request.url.path.endswith("/child/attachment"):
+                return httpx.Response(
+                    200, json={"results": [], "size": 0, "limit": 100}
+                )
+            return httpx.Response(404)
+
+        # include filter drops space "OPS" (line 423)
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(include=("ENG/*",)), None
+                    )
+                ]
+            finally:
+                await c.close()
+        assert {r.metadata["page_id"] for r in refs} == {"1", "2"}
+
+        # exclude filter drops the "OPS" space (line 425)
+        async with _client(handler) as client2:
+            c2 = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                    include_attachments_meta=False,
+                ),
+                client=client2,
+            )
+            try:
+                refs2 = [
+                    r
+                    async for r in c2.discover(
+                        SourceFilter(exclude=("OPS/*",)), None
+                    )
+                ]
+            finally:
+                await c2.close()
+        assert {r.metadata["page_id"] for r in refs2} == {"1", "2"}
+
+        # threshold cursor drops the 2025 page (line 430)
+        cursor = _encode_cursor({"last_modified": "2025-12-31T23:59:59Z"})
+        async with _client(handler) as client3:
+            c3 = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                    include_attachments_meta=False,
+                ),
+                client=client3,
+            )
+            try:
+                refs3 = [r async for r in c3.discover(SourceFilter(), cursor)]
+            finally:
+                await c3.close()
+        assert {r.metadata["page_id"] for r in refs3} == {"2", "3"}
+
+    async def test_dc_attachment_exclude_skips(self) -> None:
+        # Hit the exclude branch in _dc_attachments (line 476).
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [_dc_page("1")],
+                        "size": 1,
+                        "limit": 100,
+                    },
+                )
+            if request.url.path.endswith("/rest/api/content/1/child/attachment"):
+                start = request.url.params.get("start")
+                if start in (None, "0"):
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [
+                                {
+                                    "id": "a1",
+                                    "title": "skip-me",
+                                    "extensions": {"mediaType": "text/csv"},
+                                },
+                                {
+                                    "id": "a2",
+                                    "title": "keep",
+                                    "extensions": {"mediaType": "text/csv"},
+                                },
+                            ],
+                            "size": 2,
+                            # size == limit → second-page lookup taken.
+                            "limit": 2,
+                        },
+                    )
+                return httpx.Response(
+                    200, json={"results": [], "size": 0, "limit": 2}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                ),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(exclude=("*/skip-me",)), None
+                    )
+                ]
+            finally:
+                await c.close()
+        att_titles = [
+            r.metadata["title"]
+            for r in refs
+            if r.metadata.get("kind") == "attachment"
+        ]
+        assert att_titles == ["keep"]
+
+    async def test_dc_attachment_loop_breaks_on_short_page(self) -> None:
+        # Single-call response with size < limit hits the early-break
+        # path at line 502 instead of line 469's empty-page break.
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [_dc_page("1")],
+                        "size": 1,
+                        "limit": 100,
+                    },
+                )
+            if request.url.path.endswith("/rest/api/content/1/child/attachment"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": "a1",
+                                "title": "single",
+                                "extensions": {"mediaType": "text/csv"},
+                            }
+                        ],
+                        "size": 1,
+                        "limit": 100,
+                    },
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+            finally:
+                await c.close()
+        assert any(r.metadata.get("title") == "single" for r in refs)
+
+    async def test_cloud_attachment_include_filter_skips(self) -> None:
+        # Hit the include-skip branch in _cloud_attachments (line 299).
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={"results": [_cloud_page("1")], "_links": {}},
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages/1/attachments"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": "a1",
+                                "title": "skip-me",
+                                "mediaType": "text/plain",
+                            },
+                            {
+                                "id": "a2",
+                                "title": "keep",
+                                "mediaType": "text/plain",
+                            },
+                        ],
+                        "_links": {},
+                    },
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(base_url=_BASE, email="e", api_token="t"),
+                client=client,
+            )
+            try:
+                # include matches the page + only the "keep" attachment;
+                # "skip-me" is dropped by the include miss.
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(include=("100/1", "100/1/attachments/keep")),
+                        None,
+                    )
+                ]
+            finally:
+                await c.close()
+        att_titles = [
+            r.metadata["title"] for r in refs if r.metadata.get("kind") == "attachment"
+        ]
+        assert att_titles == ["keep"]
+
+    async def test_dc_attachment_filter_include(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/rest/api/content"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [_dc_page("1")],
+                        "size": 1,
+                        "limit": 100,
+                    },
+                )
+            if request.url.path.endswith("/rest/api/content/1/child/attachment"):
+                start = request.url.params.get("start")
+                if start in (None, "0"):
+                    return httpx.Response(
+                        200,
+                        json={
+                            "results": [
+                                {
+                                    "id": "a1",
+                                    "title": "secret.csv",
+                                    "extensions": {"mediaType": "text/csv"},
+                                },
+                                {
+                                    "id": "a2",
+                                    "title": "diagram.png",
+                                    "extensions": {"mediaType": "image/png"},
+                                },
+                            ],
+                            "size": 2,
+                            "limit": 2,
+                        },
+                    )
+                return httpx.Response(
+                    200, json={"results": [], "size": 0, "limit": 2}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="x",
+                    api_token="dc",
+                    deployment="dc",
+                ),
+                client=client,
+            )
+            try:
+                refs = [
+                    r
+                    async for r in c.discover(
+                        SourceFilter(include=("ENG/1", "ENG/1/attachments/secret.csv")),
+                        None,
+                    )
+                ]
+            finally:
+                await c.close()
+        kinds = [r.metadata.get("kind") for r in refs]
+        titles = [
+            r.metadata.get("title")
+            for r in refs
+            if r.metadata.get("kind") == "attachment"
+        ]
+        assert "page" in kinds
+        assert titles == ["secret.csv"]
+
+
+# --- cursor incremental ------------------------------------------
+
+
+class TestCursorResume:
+    async def test_resume_skips_older_pages(self) -> None:
+        old = _cloud_page(
+            "1",
+            title="old",
+            body="<p>old</p>",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        new = _cloud_page(
+            "2",
+            title="new",
+            body="<p>new</p>",
+            created_at="2026-06-01T00:00:00Z",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200, json={"results": [old, new], "_links": {}}
+                )
+            if "/attachments" in request.url.path:
+                return httpx.Response(200, json={"results": [], "_links": {}})
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                first_refs = [r async for r in c.discover(SourceFilter(), None)]
+                cursor = c.cursor_after_run()
+            finally:
+                await c.close()
+        assert {r.metadata["page_id"] for r in first_refs} == {"1", "2"}
+        assert cursor is not None
+        # Round-trip cursor → second pass returns no pages (both seen).
+        async with _client(handler) as client2:
+            c2 = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client2,
+            )
+            try:
+                second_refs = [r async for r in c2.discover(SourceFilter(), cursor)]
+            finally:
+                await c2.close()
+        assert second_refs == []
+
+    async def test_cursor_after_run_none_when_no_pages(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200, json={"results": [], "_links": {}}
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                _ = [r async for r in c.discover(SourceFilter(), None)]
+                assert c.cursor_after_run() is None
+            finally:
+                await c.close()
+
+
+# --- fetch + close ------------------------------------------------
+
+
+class TestFetchAndClose:
+    async def test_fetch_returns_text_for_page(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            _cloud_page(
+                                "1",
+                                body="<p>Hello <strong>world</strong></p>",
+                            )
+                        ],
+                        "_links": {},
+                    },
+                )
+            if "/attachments" in request.url.path:
+                return httpx.Response(200, json={"results": [], "_links": {}})
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(
+                    base_url=_BASE,
+                    email="e",
+                    api_token="t",
+                    include_attachments_meta=False,
+                ),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                docs = [d async for d in c.fetch(refs[0])]
+                assert len(docs) == 1
+                assert isinstance(docs[0], Document)
+                assert "Hello" in docs[0].text
+                assert "world" in docs[0].text
+            finally:
+                await c.close()
+
+    async def test_fetch_attachment_yields_nothing(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/wiki/api/v2/pages"):
+                return httpx.Response(
+                    200,
+                    json={"results": [_cloud_page("1")], "_links": {}},
+                )
+            if request.url.path.endswith("/wiki/api/v2/pages/1/attachments"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "results": [
+                            {
+                                "id": "a1",
+                                "title": "f",
+                                "mediaType": "text/plain",
+                            }
+                        ],
+                        "_links": {},
+                    },
+                )
+            return httpx.Response(404)
+
+        async with _client(handler) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(base_url=_BASE, email="e", api_token="t"),
+                client=client,
+            )
+            try:
+                refs = [r async for r in c.discover(SourceFilter(), None)]
+                att = next(r for r in refs if r.metadata.get("kind") == "attachment")
+                docs = [d async for d in c.fetch(att)]
+                assert docs == []
+            finally:
+                await c.close()
+
+    async def test_fetch_unknown_path_yields_nothing(self) -> None:
+        async with _client(lambda _r: httpx.Response(404)) as client:
+            c = ConfluenceConnector(
+                ConfluenceConfig(base_url=_BASE, email="e", api_token="t"),
+                client=client,
+            )
+            try:
+                ref = DocumentRef(
+                    source_id=c.id,
+                    source_kind=c.kind,
+                    path="UNKNOWN/123",
+                )
+                docs = [d async for d in c.fetch(ref)]
+                assert docs == []
+            finally:
+                await c.close()
+
+    async def test_close_owns_client(self) -> None:
+        c = ConfluenceConnector(
+            ConfluenceConfig(base_url=_BASE, email="e", api_token="t")
+        )
+        await c.close()
+
+    async def test_close_external_client_not_closed(self) -> None:
+        client = httpx.AsyncClient(base_url=_BASE)
+        c = ConfluenceConnector(
+            ConfluenceConfig(base_url=_BASE, email="e", api_token="t"),
+            client=client,
+        )
+        await c.close()
+        assert not client.is_closed
+        await client.aclose()
+
+
+# --- spec / factory -----------------------------------------------
+
+
+class TestSpec:
+    def test_metadata(self) -> None:
+        assert SPEC.kind == "confluence"
+        assert SPEC.version == "0.1.0"
+        assert SPEC.required_scopes == ("confluence:read",)
+        assert SPEC.capabilities.incremental is True
+        assert SPEC.capabilities.max_concurrent_fetches == 4
+
+    def test_factory_minimal(self) -> None:
+        register(SPEC)
+        c = create(
+            "confluence",
+            {"base_url": _BASE, "email": "e", "api_token": "t"},
+        )
+        assert isinstance(c, ConfluenceConnector)
+
+    def test_factory_full(self) -> None:
+        register(SPEC)
+        c = create(
+            "confluence",
+            {
+                "base_url": _BASE,
+                "email": "e",
+                "api_token": "t",
+                "spaces": ["ENG"],
+                "include_attachments_meta": False,
+                "deployment": "dc",
+                "id": "x",
+            },
+        )
+        assert c.id == "x"
+
+    def test_factory_rejects_missing_base_url(self) -> None:
+        with pytest.raises(ValueError, match="base_url"):
+            SPEC.factory({"email": "e", "api_token": "t"})
+
+    def test_factory_rejects_missing_email(self) -> None:
+        with pytest.raises(ValueError, match="email"):
+            SPEC.factory({"base_url": _BASE, "api_token": "t"})
+
+    def test_factory_rejects_missing_token(self) -> None:
+        with pytest.raises(ValueError, match="api_token"):
+            SPEC.factory({"base_url": _BASE, "email": "e"})
+
+
+# --- helpers (cursor + ISO + link parser) -------------------------
+
+
+class TestHelpers:
+    def test_cursor_round_trip(self) -> None:
+        encoded = _encode_cursor({"last_modified": "2026-01-01T00:00:00Z"})
+        decoded = _decode_cursor(encoded)
+        assert decoded == {"last_modified": "2026-01-01T00:00:00Z"}
+
+    def test_cursor_decode_empty_and_garbage(self) -> None:
+        assert _decode_cursor(None) == {}
+        assert _decode_cursor("") == {}
+        assert _decode_cursor("not-json") == {}
+        assert _decode_cursor(json.dumps([1, 2, 3])) == {}
+
+    def test_parse_iso_z_suffix(self) -> None:
+        ts = _parse_iso("2026-01-01T00:00:00Z")
+        assert ts is not None
+        assert ts.year == 2026
+        assert _parse_iso("garbage") is None
+        assert _parse_iso("") is None
+
+    def test_next_cursor_from_links_extracts_value(self) -> None:
+        assert (
+            _next_cursor_from_links(
+                {"next": "/wiki/api/v2/pages?cursor=ABC&limit=100"}
+            )
+            == "ABC"
+        )
+        assert (
+            _next_cursor_from_links({"next": "/foo?cursor=END"}) == "END"
+        )
+        assert _next_cursor_from_links({"next": "/foo?other=x"}) is None
+        assert _next_cursor_from_links({}) is None
+        assert _next_cursor_from_links({"next": ""}) is None
+        # Non-mapping → None
+        assert _next_cursor_from_links([]) is None  # type: ignore[arg-type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ members = [
     "packages/pii-scanner-azure-devops",
     "packages/pii-scanner-bitbucket",
     "packages/pii-scanner-ci-logs",
+    "packages/pii-scanner-confluence",
     "packages/pii-scanner-discord",
     "packages/pii-scanner-gcs",
     "packages/pii-scanner-github",

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,7 @@ members = [
     "pleno-pii-scanner-azure-devops",
     "pleno-pii-scanner-bitbucket",
     "pleno-pii-scanner-ci-logs",
+    "pleno-pii-scanner-confluence",
     "pleno-pii-scanner-discord",
     "pleno-pii-scanner-gcs",
     "pleno-pii-scanner-github",
@@ -3517,6 +3518,35 @@ dev = [
 name = "pleno-pii-scanner-ci-logs"
 version = "0.1.0"
 source = { editable = "packages/pii-scanner-ci-logs" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pleno-pii-scanner" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pleno-pii-scanner", editable = "packages/pii-scanner" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+]
+
+[[package]]
+name = "pleno-pii-scanner-confluence"
+version = "0.1.0"
+source = { editable = "packages/pii-scanner-confluence" }
 dependencies = [
     { name = "httpx" },
     { name = "pleno-pii-scanner" },


### PR DESCRIPTION
Closes #28. Implements ADR-0007 §13 Confluence connector for both Cloud and DC deployments.

## Surface

- ConfluenceConfig(base_url, email, api_token, spaces=(), include_attachments_meta=True, deployment='cloud'|'dc', id=None) — validates base_url + api_token non-empty.
- ConfluenceConnector implements SourceConnector. Capabilities: incremental=True, content_hash_delta=False, binary=False, max_concurrent_fetches=4, streaming=False.
- SPEC + factory + scope confluence:read.

## Discovery

- **Cloud**: GET /wiki/api/v2/pages with cursor + body-format=storage + limit=100 (+ space-id when allowlist provided; resolved via /wiki/api/v2/spaces).
- **DC**: GET /rest/api/content with type=page + start/limit + expand=body.storage,version (+ spaceKey when allowlist provided).
- One DocumentRef per page, path `<space-key>/<page-id>`, metadata.version_id populated.
- include_attachments_meta=True (default) emits one DocumentRef per attachment with content_type metadata only (no binary download).

## Body decode

Storage XHTML → plain text via xml.etree.ElementTree wrapped in a namespace shim (ac:/ri:). Block tags (p, h1..h6, li, tr, td, th, div, br) emit newlines; ac:structured-macro renders as `[macro <name>] <inner text>` so secrets stashed inside {code}/{noformat} macros stay detectable. No BeautifulSoup dependency.

## Cursor

Cursor is the core `str` type alias (no Cursor(value=..., scheme=...) wrapper). Encoded as JSON `{"last_modified": "<iso>"}` and decoded leniently — garbage cursors degrade to a fresh scan rather than raising.

## Tests

50 tests, **100% line coverage** via httpx.MockTransport hermetic doubles. Coverage includes:

- config validation (empty base_url / api_token / bad deployment)
- cloud basic-auth + dc bearer headers
- cloud cursor + dc start/limit pagination, attachment pagination on both
- spaces allowlist resolves keys → ids on Cloud, passes spaceKey on DC
- XHTML walker (paragraph, heading, list, table, structured-macro, inline tail, malformed fallback)
- include/exclude path filter on both pages and attachments
- cursor round-trip resume returns only newer pages
- factory + spec metadata
- close (owns vs external client)