### PR TITLE
feat(pii-scanner): incremental scan cache (sub-source + document level)

### DIFF
--- a/packages/pii-scanner/pyproject.toml
+++ b/packages/pii-scanner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pleno-pii-scanner"
-version = "0.2.5"
+version = "0.3.0"
 description = "Japanese-first PII scanner for source repositories with gitleaks/trufflehog-like UX"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/pii-scanner/src/pleno_pii_scanner/cli_scan.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cli_scan.py
@@ -26,6 +26,7 @@ import click
 
 from pleno_pii_scanner.scheduler import (
     GlobalRateLimiter,
+    IncrementalRunner,
     Scheduler,
     SchedulerConfig,
     SourcePlan,
@@ -40,6 +41,11 @@ from pleno_pii_scanner.sources.registry import (
     UnknownConnectorError,
     create,
     list_kinds,
+)
+from pleno_pii_scanner.state import (
+    SqliteScanCache,
+    default_cache_path,
+    schema_version,
 )
 
 
@@ -91,6 +97,30 @@ def scan_group() -> None:
     default="text",
     show_default=True,
 )
+@click.option(
+    "--cache/--no-cache",
+    "use_cache",
+    default=True,
+    show_default=True,
+    help=(
+        "Enable the incremental scan cache. Sub-source level skip "
+        "(unchanged repos / channels / drives) plus document-level skip "
+        "(unchanged file payloads) reuse prior findings instead of "
+        "re-running the detector pipeline. Disable when investigating "
+        "false negatives or after a recognizer update."
+    ),
+)
+@click.option(
+    "--cache-path",
+    "cache_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Override the SQLite cache file path. Default lives under "
+        "$XDG_STATE_HOME/pleno/cache/scan_cache.sqlite and is shared "
+        "across scan_ids."
+    ),
+)
 def cmd_run(
     kind: str,
     config_path: Path | None,
@@ -100,6 +130,8 @@ def cmd_run(
     max_size: int | None,
     scan_id: str,
     report_format: str,
+    use_cache: bool,
+    cache_path: Path | None,
 ) -> None:
     """Run a single-source scan via the registered connector for KIND.
 
@@ -118,15 +150,26 @@ def cmd_run(
         exclude=tuple(exclude),
         max_size=max_size,
     )
-    summary = asyncio.run(_drive_scan(connector, sf, scan_id))
+    summary = asyncio.run(
+        _drive_scan(connector, sf, scan_id, use_cache, cache_path)
+    )
     if report_format == "json":
         click.echo(json.dumps(summary, indent=2))
     else:
+        cache = summary.get("cache")
+        cache_blurb = ""
+        if cache is not None:
+            cache_blurb = (
+                f" cache=sub({cache['subsource_hits']}/"
+                f"{cache['subsource_total']})/"
+                f"doc({cache['document_hits']}/"
+                f"{cache['document_total']})"
+            )
         click.echo(
             f"scan {kind}: refs_seen={summary['refs_seen']} "
             f"docs_fetched={summary['docs_fetched']} "
             f"findings_emitted={summary['findings_emitted']} "
-            f"error={summary['error']}",
+            f"error={summary['error']}{cache_blurb}",
             err=True,
         )
     if summary["error"]:
@@ -169,19 +212,63 @@ def _load_config(path: Path | None, inline_json: str | None) -> dict[str, Any]:
 
 
 async def _drive_scan(
-    connector: Any, sf: SourceFilter, scan_id: str
+    connector: Any,
+    sf: SourceFilter,
+    scan_id: str,
+    use_cache: bool,
+    cache_path: Path | None,
 ) -> dict[str, Any]:
-    """Run one SourcePlan through the Scheduler and return its summary."""
+    """Run one SourcePlan through the Scheduler and return its summary.
+
+    With `use_cache=True` the scan is layered behind an
+    `IncrementalRunner` so unchanged sub-sources / documents replay
+    cached findings instead of re-detecting. The detector wiring is
+    still the stub `_count_only_detector` until the regex_pass /
+    ner_pass / verify pipeline is bridged through this CLI — bringing
+    the cache up first means the bridge will land *with* incremental
+    semantics already in place rather than as a follow-up.
+    """
     plan = SourcePlan(connector=connector, filter=sf)
     rl = GlobalRateLimiter()
     sch = Scheduler(config=SchedulerConfig(), rate_limiter=rl)
+    if not use_cache:
+        try:
+            results = await sch.run(
+                [plan], scan_id=scan_id, scan_fn=_count_only_scan_fn
+            )
+        finally:
+            await sch.close()
+        return _summary_from_result(results[0])
+
+    cache = await SqliteScanCache.open(path=cache_path)
     try:
-        results = await sch.run(
-            [plan], scan_id=scan_id, scan_fn=_count_only_scan_fn
+        runner = IncrementalRunner(
+            sch, cache, schema_version=schema_version()
+        )
+        inc_results = await runner.run(
+            [plan],
+            scan_id=scan_id,
+            detector=_count_only_detector,
+            on_findings=_swallow_findings,
         )
     finally:
         await sch.close()
-    [r] = results
+        await cache.close()
+    inc = inc_results[0]
+    summary = _summary_from_result(inc.source_result)
+    summary["cache"] = {
+        "subsource_total": inc.cache_stats.subsource_total,
+        "subsource_hits": inc.cache_stats.subsource_hits,
+        "subsource_misses": inc.cache_stats.subsource_misses,
+        "document_total": inc.cache_stats.document_total,
+        "document_hits": inc.cache_stats.document_hits,
+        "document_misses": inc.cache_stats.document_misses,
+        "path": str(cache_path or default_cache_path()),
+    }
+    return summary
+
+
+def _summary_from_result(r: Any) -> dict[str, Any]:
     return {
         "source_id": r.source_id,
         "source_kind": r.source_kind,
@@ -207,6 +294,30 @@ async def _count_only_scan_fn(
     a transient hack we'd then have to undo.
     """
     return 0
+
+
+async def _count_only_detector(
+    _ref: DocumentRef, _doc: Document | DocumentChunk
+) -> tuple[int, bytes]:
+    """Stub `DetectorFn` paired with `_count_only_scan_fn`.
+
+    Returns `(0, b"")` — same observable behaviour as the no-cache
+    path. Once the detector pipeline lands on this CLI it returns
+    `(len(findings), serialize(findings))` and cache hits start
+    skipping real work.
+    """
+    return (0, b"")
+
+
+async def _swallow_findings(
+    _source_id: str,
+    _sub_id: str | None,
+    _count: int,
+    _payload: bytes,
+    _replayed: bool,
+) -> None:
+    """No-op `OnFindingsFn`. Replaced when the detector pipeline lands."""
+    return None
 
 
 __all__ = ["scan_group"]

--- a/packages/pii-scanner/src/pleno_pii_scanner/scheduler/__init__.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/scheduler/__init__.py
@@ -12,6 +12,14 @@ from pleno_pii_scanner.scheduler.core import (
     Scheduler,
     SchedulerConfig,
     SourcePlan,
+    SourceResult,
+)
+from pleno_pii_scanner.scheduler.incremental import (
+    DetectorFn,
+    IncrementalResult,
+    IncrementalRunner,
+    IncrementalStats,
+    OnFindingsFn,
 )
 from pleno_pii_scanner.scheduler.rate_limit import (
     AdaptiveTokenBucket,
@@ -28,12 +36,18 @@ from pleno_pii_scanner.scheduler.retry import (
 __all__ = [
     "AdaptiveTokenBucket",
     "BucketKey",
+    "DetectorFn",
     "GlobalRateLimiter",
+    "IncrementalResult",
+    "IncrementalRunner",
+    "IncrementalStats",
+    "OnFindingsFn",
     "RateLimited",
     "RetryConfig",
     "RetryError",
     "Scheduler",
     "SchedulerConfig",
     "SourcePlan",
+    "SourceResult",
     "retry_async",
 ]

--- a/packages/pii-scanner/src/pleno_pii_scanner/scheduler/incremental.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/scheduler/incremental.py
@@ -1,0 +1,475 @@
+"""IncrementalRunner — two-tier cache wrapper around `Scheduler`.
+
+The plain `Scheduler` always re-walks every source from scratch. For
+long-running multi-source scans (a nightly org-scan over hundreds of
+repos, a daily Confluence sweep, an hourly database export), most of
+that work is wasted on content that has not changed since the last run.
+
+`IncrementalRunner` short-circuits two layers, in order:
+
+    1. **Sub-source level** — connectors that implement
+       `IncrementalSourceConnector` enumerate sub-units cheaply
+       (typically one network call per repo / channel / drive) and tag
+       each with a content fingerprint. Sub-units whose fingerprint
+       matches the ScanCache are skipped entirely; their prior findings
+       are replayed via `on_findings` without any download or detector
+       work.
+
+    2. **Document level** — within sub-units that *are* re-scanned (and
+       for connectors that present a flat namespace), each fetched
+       document is keyed on its `content_hash` (or, when missing, a
+       SHA-256 of the body). Hits short-circuit the detector callback
+       and replay cached findings; misses run the detector and store
+       the result for the next scan.
+
+Both layers share the same `ScanCache` and a caller-supplied
+`schema_version` that ties cached findings to the detector pipeline
+that produced them — bumping the regex pack or NER model auto-
+invalidates every cached entry on the next scan.
+
+The runner is connector-agnostic: any future connector (Slack,
+SharePoint, Postgres, ...) gets sub-source caching by implementing
+`IncrementalSourceConnector` and gets document caching for free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from hashlib import sha256
+
+from pleno_pii_scanner.scheduler.core import (
+    Scheduler,
+    SourcePlan,
+    SourceResult,
+)
+from pleno_pii_scanner.sources.base import (
+    SUBSOURCE_METADATA_KEY,
+    Document,
+    DocumentChunk,
+    DocumentRef,
+    IncrementalSourceConnector,
+    Subsource,
+)
+from pleno_pii_scanner.state.scan_cache import CacheLookup, ScanCache
+
+
+# Caller-supplied detector. Returns `(count, payload)` where:
+#   * `count`   — number of findings emitted; surfaces in `SourceResult`
+#                 so cached replays still report accurate totals.
+#   * `payload` — opaque bytes the caller serializes (JSON, msgpack, ...).
+#                 The runner stores them verbatim and replays them
+#                 verbatim on hit; no internal parsing.
+DetectorFn = Callable[
+    [DocumentRef, Document | DocumentChunk],
+    Awaitable[tuple[int, bytes]],
+]
+
+
+# Notification callback. Fired for every findings batch — fresh-
+# detected or cache-replayed alike — so the caller's findings sink
+# (FindingsStore, OTLP exporter, dashboards) sees a uniform stream
+# regardless of cache state.
+#
+#   source_id : the connector's id
+#   sub_id    : SUBSOURCE_METADATA_KEY value if present, else None
+#   count     : number of findings in `payload`
+#   payload   : caller-defined wire format
+#   replayed  : True when `payload` came from the cache
+OnFindingsFn = Callable[
+    [str, str | None, int, bytes, bool],
+    Awaitable[None],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class IncrementalStats:
+    """Per-plan cache-effectiveness telemetry. Surfaces in
+    `IncrementalResult` so operators can see how much work the cache
+    actually saved this run.
+    """
+
+    subsource_total: int = 0
+    subsource_hits: int = 0
+    subsource_misses: int = 0
+    document_total: int = 0
+    document_hits: int = 0
+    document_misses: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class IncrementalResult:
+    """`SourceResult` plus per-plan cache hit/miss breakdown."""
+
+    source_result: SourceResult
+    cache_stats: IncrementalStats
+
+
+@dataclass(slots=True)
+class _MutableStats:
+    """Counter that becomes an immutable `IncrementalStats` at freeze."""
+
+    subsource_total: int = 0
+    subsource_hits: int = 0
+    subsource_misses: int = 0
+    document_total: int = 0
+    document_hits: int = 0
+    document_misses: int = 0
+
+    def freeze(self) -> IncrementalStats:
+        return IncrementalStats(
+            subsource_total=self.subsource_total,
+            subsource_hits=self.subsource_hits,
+            subsource_misses=self.subsource_misses,
+            document_total=self.document_total,
+            document_hits=self.document_hits,
+            document_misses=self.document_misses,
+        )
+
+
+@dataclass(slots=True)
+class _SubsourceBuffer:
+    """Per-sub-source rollup so a successful scan caches its full result.
+
+    `payloads` accumulates each fresh-detected document's payload bytes.
+    On clean plan completion, the runner concatenates them into a single
+    rollup blob keyed on `(source_id, sub_id, fingerprint)`, ready for
+    the next run to replay as a single tier-1 cache hit.
+    """
+
+    fingerprint: str
+    count: int = 0
+    payloads: list[bytes] = field(default_factory=list)
+
+
+# Wire format for cached findings:
+#   bytes 0..7  : count (uint64, big-endian)
+#   bytes 8..   : caller-defined payload bytes
+#
+# A fixed-width prefix lets the runner round-trip `(count, payload)`
+# through the bytes-only ScanCache without inventing yet another framing
+# protocol. 8 bytes covers any plausible finding count for one document
+# or sub-source rollup.
+_COUNT_PREFIX_BYTES = 8
+
+
+def _encode(count: int, payload: bytes) -> bytes:
+    return count.to_bytes(_COUNT_PREFIX_BYTES, "big") + payload
+
+
+def _decode(blob: bytes) -> tuple[int, bytes]:
+    if len(blob) < _COUNT_PREFIX_BYTES:
+        raise ValueError(
+            f"cached blob shorter than count prefix ({len(blob)} bytes); "
+            "the cache file is corrupt — delete it and re-scan"
+        )
+    count = int.from_bytes(blob[:_COUNT_PREFIX_BYTES], "big")
+    return count, blob[_COUNT_PREFIX_BYTES:]
+
+
+def _document_fingerprint(doc: Document | DocumentChunk) -> str | None:
+    """Return a stable content fingerprint for one fetched payload, or
+    None when the connector did not give us enough to cache safely.
+
+    Preference order:
+      1. `Document.content_hash` if the connector populated it (git,
+         object stores, anything with a server-side digest).
+      2. SHA-256 of the body — `text` decoded as UTF-8 or `binary`
+         verbatim. Cheap on the typical multi-MB document.
+      3. None for `DocumentChunk` — chunk-level caching would have to
+         live across all chunks of the document, which the runner does
+         not orchestrate. Streaming connectors fall through to a fresh
+         scan; this is correct, just not maximally efficient.
+    """
+    if isinstance(doc, Document):
+        if doc.content_hash:
+            return doc.content_hash
+        h = sha256()
+        if doc.text is not None:
+            h.update(doc.text.encode("utf-8", errors="replace"))
+        elif doc.binary is not None:
+            h.update(doc.binary)
+        return h.hexdigest()[:32]
+    return None
+
+
+# Cache-key helpers. Newline is illegal in a `source_id` (it is either a
+# URL fragment or a config-supplied label) so the delimiter is
+# unambiguous and the keys read cleanly in `pleno-pii-scanner cache ls`
+# style diagnostic dumps.
+def _sub_cache_key(source_kind: str, source_id: str, sub_id: str) -> str:
+    return f"sub\n{source_kind}\n{source_id}\n{sub_id}"
+
+
+def _doc_cache_key(source_kind: str, source_id: str, ref_path: str) -> str:
+    return f"doc\n{source_kind}\n{source_id}\n{ref_path}"
+
+
+class IncrementalRunner:
+    """Wraps a `Scheduler` with sub-source + document level caching.
+
+    Construction takes a Scheduler, a ScanCache, and the schema_version
+    that ties cached findings to the current detector pipeline. `run()`
+    mirrors `Scheduler.run()`'s signature except the caller passes a
+    `DetectorFn` (returning serialized findings) plus an `OnFindingsFn`
+    (consuming them) instead of the lower-level `scan_fn`.
+    """
+
+    def __init__(
+        self,
+        scheduler: Scheduler,
+        cache: ScanCache,
+        *,
+        schema_version: str,
+    ) -> None:
+        self._scheduler = scheduler
+        self._cache = cache
+        self._schema_version = schema_version
+
+    @property
+    def cache(self) -> ScanCache:
+        return self._cache
+
+    async def run(
+        self,
+        plans: Sequence[SourcePlan],
+        *,
+        scan_id: str,
+        detector: DetectorFn,
+        on_findings: OnFindingsFn,
+    ) -> list[IncrementalResult]:
+        """Drive every plan through the cache + scheduler.
+
+        Plans run concurrently; one plan's cache misses do not delay
+        another's hits. Each plan's `IncrementalResult` is independent
+        so the caller can decide whether one source's failure
+        invalidates the whole run.
+        """
+        coros = [
+            self.run_one(
+                plan,
+                scan_id=scan_id,
+                detector=detector,
+                on_findings=on_findings,
+            )
+            for plan in plans
+        ]
+        return await asyncio.gather(*coros)
+
+    async def run_one(
+        self,
+        plan: SourcePlan,
+        *,
+        scan_id: str,
+        detector: DetectorFn,
+        on_findings: OnFindingsFn,
+    ) -> IncrementalResult:
+        connector = plan.connector
+        kind = connector.kind
+        source_id = connector.id
+        stats = _MutableStats()
+        sub_buffers: dict[str, _SubsourceBuffer] = {}
+
+        skipped = await self._apply_subsource_skip(
+            connector=connector,
+            kind=kind,
+            source_id=source_id,
+            sub_buffers=sub_buffers,
+            stats=stats,
+            on_findings=on_findings,
+        )
+
+        scan_fn = self._make_scan_fn(
+            kind=kind,
+            source_id=source_id,
+            detector=detector,
+            on_findings=on_findings,
+            sub_buffers=sub_buffers,
+            stats=stats,
+        )
+
+        result = await self._scheduler.run_one(
+            plan, scan_id=scan_id, scan_fn=scan_fn
+        )
+
+        # On clean completion, persist per-sub-source rollups so the
+        # next run hits at tier 1. Errored plans skip this — partial
+        # rollups would silently shrink the cached findings of an
+        # unchanged sub-source on the following run.
+        if result.error is None:
+            await self._persist_rollups(
+                kind=kind,
+                source_id=source_id,
+                sub_buffers=sub_buffers,
+                skipped=skipped,
+            )
+
+        return IncrementalResult(
+            source_result=result, cache_stats=stats.freeze()
+        )
+
+    async def _apply_subsource_skip(
+        self,
+        *,
+        connector: object,
+        kind: str,
+        source_id: str,
+        sub_buffers: dict[str, _SubsourceBuffer],
+        stats: _MutableStats,
+        on_findings: OnFindingsFn,
+    ) -> set[str]:
+        """Look up each sub-source in the cache; on hit, replay its
+        findings and tell the connector to skip it. Returns the set of
+        sub_ids that were replayed so the caller does not re-cache them
+        as fresh rollups.
+
+        Cache lookups fan out across all sub-sources concurrently — at
+        org-scan scale (10**3 repos) the sequential variant blocks for
+        seconds on SQLite I/O. `on_findings` callbacks for hits run on
+        the same task that observed the hit so the caller sees results
+        as soon as they are available; ordering across sub-sources is
+        not preserved (callers that need a stable order must sort
+        downstream).
+        """
+        if not isinstance(connector, IncrementalSourceConnector):
+            return set()
+        subsources: Sequence[Subsource] = await connector.list_subsources()
+        stats.subsource_total = len(subsources)
+        skip: set[str] = set()
+        if not subsources:
+            connector.set_subsource_skip(frozenset())
+            return skip
+
+        # One batched SELECT instead of N round-trips. At org-scan
+        # scale (10**3 sub-sources) this is the difference between a
+        # 50 ms pre-pass and a multi-second one — the SQLite WAL lock
+        # serializes per-statement waits even when we asyncio.gather.
+        lookups = [
+            CacheLookup(
+                key=_sub_cache_key(kind, source_id, sub.sub_id),
+                fingerprint=sub.fingerprint,
+                schema_version=self._schema_version,
+            )
+            for sub in subsources
+        ]
+        hits = await self._cache.get_many(lookups)
+
+        # Cache-hit `on_findings` callbacks fan out concurrently. The
+        # caller's findings sink is normally I/O bound (FindingsStore
+        # write, OTLP export); awaiting them in series would needlessly
+        # serialize work the scheduler is happy to parallelize.
+        replay_tasks: list[Awaitable[None]] = []
+        for sub, lk in zip(subsources, lookups, strict=True):
+            blob = hits.get(lk.key)
+            if blob is None:
+                stats.subsource_misses += 1
+                sub_buffers[sub.sub_id] = _SubsourceBuffer(
+                    fingerprint=sub.fingerprint
+                )
+                continue
+            count, payload = _decode(blob)
+            stats.subsource_hits += 1
+            skip.add(sub.sub_id)
+            replay_tasks.append(
+                on_findings(source_id, sub.sub_id, count, payload, True)
+            )
+        if replay_tasks:
+            await asyncio.gather(*replay_tasks)
+        connector.set_subsource_skip(frozenset(skip))
+        return skip
+
+    def _make_scan_fn(
+        self,
+        *,
+        kind: str,
+        source_id: str,
+        detector: DetectorFn,
+        on_findings: OnFindingsFn,
+        sub_buffers: dict[str, _SubsourceBuffer],
+        stats: _MutableStats,
+    ) -> Callable[[DocumentRef, Document | DocumentChunk], Awaitable[int]]:
+        cache = self._cache
+        schema_version = self._schema_version
+
+        async def scan_fn(
+            ref: DocumentRef, doc: Document | DocumentChunk
+        ) -> int:
+            stats.document_total += 1
+            sub_id = ref.metadata.get(SUBSOURCE_METADATA_KEY)
+
+            content_fp = _document_fingerprint(doc)
+            doc_key = _doc_cache_key(kind, source_id, ref.path)
+
+            blob: bytes | None = None
+            if content_fp is not None:
+                blob = await cache.get(
+                    doc_key,
+                    fingerprint=content_fp,
+                    schema_version=schema_version,
+                )
+
+            if blob is not None:
+                count, payload = _decode(blob)
+                stats.document_hits += 1
+                await on_findings(source_id, sub_id, count, payload, True)
+            else:
+                count, payload = await detector(ref, doc)
+                stats.document_misses += 1
+                if content_fp is not None:
+                    await cache.put(
+                        doc_key,
+                        fingerprint=content_fp,
+                        schema_version=schema_version,
+                        value=_encode(count, payload),
+                    )
+                await on_findings(source_id, sub_id, count, payload, False)
+
+            if sub_id is not None and sub_id in sub_buffers:
+                buf = sub_buffers[sub_id]
+                buf.count += count
+                buf.payloads.append(payload)
+            return count
+
+        return scan_fn
+
+    async def _persist_rollups(
+        self,
+        *,
+        kind: str,
+        source_id: str,
+        sub_buffers: dict[str, _SubsourceBuffer],
+        skipped: set[str],
+    ) -> None:
+        """Store one cache entry per sub-source we actually scanned.
+
+        Rollups for skipped sub-sources are already cached from a prior
+        run; rewriting them is wasted I/O. Writes fan out concurrently;
+        the underlying SqliteScanCache serializes through its internal
+        writer lock, so on-disk order matches commit order, but the
+        Python-side waits run in parallel.
+        """
+        pending: list[Awaitable[None]] = []
+        for sub_id, buf in sub_buffers.items():
+            if sub_id in skipped:
+                continue
+            rollup = _encode(buf.count, b"".join(buf.payloads))
+            pending.append(
+                self._cache.put(
+                    _sub_cache_key(kind, source_id, sub_id),
+                    fingerprint=buf.fingerprint,
+                    schema_version=self._schema_version,
+                    value=rollup,
+                )
+            )
+        if pending:
+            await asyncio.gather(*pending)
+
+
+__all__ = [
+    "DetectorFn",
+    "IncrementalResult",
+    "IncrementalRunner",
+    "IncrementalStats",
+    "OnFindingsFn",
+]

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/__init__.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/__init__.py
@@ -14,14 +14,17 @@ can be streamed as `DocumentChunk` slices rather than buffered whole.
 """
 
 from pleno_pii_scanner.sources.base import (
+    SUBSOURCE_METADATA_KEY,
     Capabilities,
     Cursor,
     Document,
     DocumentChunk,
     DocumentRef,
+    IncrementalSourceConnector,
     Principal,
     SourceConnector,
     SourceFilter,
+    Subsource,
 )
 from pleno_pii_scanner.sources.registry import (
     ConnectorError,
@@ -38,6 +41,7 @@ from pleno_pii_scanner.sources.registry import (
 )
 
 __all__ = [
+    "SUBSOURCE_METADATA_KEY",
     "Capabilities",
     "ConnectorError",
     "ConnectorFactory",
@@ -47,9 +51,11 @@ __all__ = [
     "DocumentChunk",
     "DocumentRef",
     "DuplicateConnectorError",
+    "IncrementalSourceConnector",
     "Principal",
     "SourceConnector",
     "SourceFilter",
+    "Subsource",
     "UnknownConnectorError",
     "create",
     "get",

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/base.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/base.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from hashlib import sha256
 from typing import Protocol, runtime_checkable
+
+
+# Reserved DocumentRef.metadata key. Connectors that aggregate sub-units
+# (github org → repos, slack workspace → channels, gdrive → drives,
+# postgres → tables) must populate this on every yielded ref so the
+# IncrementalRunner can attribute per-document findings back to the
+# sub-source they belong to. Connectors with a flat namespace (single
+# repo, one filesystem root) leave it absent.
+SUBSOURCE_METADATA_KEY = "_subsource_id"
 
 
 # Opaque per-connector resume token. Persisted verbatim in CheckpointStore
@@ -157,6 +166,64 @@ class DocumentChunk:
                 f"DocumentChunk.byte_range must be (start>=0, end>=start); "
                 f"got {self.byte_range}"
             )
+
+
+@dataclass(frozen=True, slots=True)
+class Subsource:
+    """An addressable sub-unit of a connector, with a content fingerprint.
+
+    A connector that aggregates many sub-units yields one `Subsource` per
+    unit so the IncrementalRunner can consult the ScanCache and skip
+    sub-units whose `fingerprint` matches a prior successful scan. The
+    fingerprint is opaque to everything outside the connector that
+    produced it — it is a commit SHA for github/git, a delta token for
+    SharePoint, a snapshot id for BigQuery, an `updated_at` cursor for
+    Jira, etc. The contract is only that the same content yields the
+    same fingerprint and different content yields a different one.
+    """
+
+    sub_id: str
+    fingerprint: str
+
+
+@runtime_checkable
+class IncrementalSourceConnector(Protocol):
+    """Optional extension to `SourceConnector` for hierarchical sources.
+
+    Connectors that aggregate many sub-units (org → repos, workspace →
+    channels, account → drives) implement this protocol so the
+    IncrementalRunner can:
+
+      1. Cheaply enumerate sub-units with their snapshot fingerprints.
+      2. Skip any sub-unit whose fingerprint matches the cache, replaying
+         that sub-unit's findings without ever touching its payload.
+
+    Connectors that present a flat namespace (single repo, one filesystem
+    root) do not need to implement this — document-level caching alone
+    handles their incremental story.
+
+    Implementations must populate `DocumentRef.metadata[SUBSOURCE_METADATA_KEY]`
+    on every ref they yield so the runner can attribute per-document
+    findings back to a sub-unit.
+    """
+
+    async def list_subsources(self) -> Sequence[Subsource]:
+        """Cheaply enumerate every sub-unit with its content fingerprint.
+
+        Must complete without downloading payloads (a single API call per
+        sub-unit at most). Called once per scan, before `discover()`.
+        """
+        ...
+
+    def set_subsource_skip(self, skip: frozenset[str]) -> None:
+        """Tell the connector to omit these sub_ids from `discover()`.
+
+        Called by the runner after consulting the cache. The connector
+        must persist the filter for the rest of its lifetime; subsequent
+        `discover()` calls behave as if the skipped sub_ids do not exist.
+        Calling with an empty frozenset clears any prior filter.
+        """
+        ...
 
 
 @runtime_checkable

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/git_source.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/git_source.py
@@ -30,6 +30,7 @@ the pre-multi-source CLI behavior available with zero new dependencies.
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -38,6 +39,7 @@ from typing import Any
 
 from pleno_pii_scanner.git_history import CommitMeta, iter_history
 from pleno_pii_scanner.sources.base import (
+    SUBSOURCE_METADATA_KEY,
     Capabilities,
     Cursor,
     Document,
@@ -46,6 +48,7 @@ from pleno_pii_scanner.sources.base import (
     Principal,
     SourceConnector,
     SourceFilter,
+    Subsource,
 )
 from pleno_pii_scanner.sources.registry import ConnectorSpec
 
@@ -102,15 +105,38 @@ class GitConnector:
         # can find what discover yielded. Bounded by the size of the
         # repo's history; for monorepos the operator caps via max_commits.
         self._slices: dict[str, _CommitFile] = {}
+        # IncrementalSourceConnector state. The "sub-source" for a single
+        # local repo is the repo itself; its fingerprint is HEAD's SHA so
+        # a follow-up scan can short-circuit when no new commits landed.
+        self._skip_subsources: frozenset[str] = frozenset()
 
     def capabilities(self) -> Capabilities:
         return Capabilities(
-            incremental=False,
+            # `incremental` advertises sub-source level skip via
+            # IncrementalSourceConnector; per-commit history is not
+            # itself resumable mid-stream.
+            incremental=True,
             binary=False,
-            content_hash_delta=False,
+            content_hash_delta=True,
             max_concurrent_fetches=4,
             streaming=False,
         )
+
+    async def list_subsources(self) -> tuple[Subsource, ...]:
+        """Treat the whole repo as one sub-source; fingerprint is HEAD SHA.
+
+        For a local git repo, "the same content" means "the same commit
+        graph rooted at HEAD" — which is exactly what `git rev-parse HEAD`
+        captures. When HEAD cannot be resolved (empty repo, broken
+        worktree) we return a sentinel fingerprint so the runner treats
+        it as a guaranteed miss rather than a silent hit.
+        """
+        sha = await asyncio.to_thread(_resolve_head_sha, self._config.repo)
+        fingerprint = sha if sha is not None else f"unknown:{self.id}"
+        return (Subsource(sub_id=self.id, fingerprint=fingerprint),)
+
+    def set_subsource_skip(self, skip: frozenset[str]) -> None:
+        self._skip_subsources = skip
 
     async def discover(
         self,
@@ -119,10 +145,13 @@ class GitConnector:
     ) -> AsyncIterator[DocumentRef]:
         # WHY: iter_history is sync (subprocess pipe). Materialising on a
         # worker thread keeps the event loop free for parallel connectors.
-        # Cursor unused: we report incremental=False because resuming
-        # mid-`git log` requires shelling out with --since=<sha>, which the
-        # enterprise GitHub connector handles with the SaaS API instead.
+        # Cursor unused: resuming mid-`git log` would need --since=<sha>,
+        # which the SaaS GitHub connector handles via API instead.
         del cursor
+        if self.id in self._skip_subsources:
+            # Cache hit at the sub-source level — the IncrementalRunner
+            # already replayed our findings. Yield nothing.
+            return
         slices = await asyncio.to_thread(
             _aggregate, self._config.repo, self._config.max_commits
         )
@@ -186,6 +215,7 @@ class GitConnector:
                 "commit_author": slice_.commit.author,
                 "commit_email": slice_.commit.email,
                 "file": slice_.file,
+                SUBSOURCE_METADATA_KEY: self.id,
             },
         )
 
@@ -245,6 +275,29 @@ def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
     from fnmatch import fnmatch
 
     return any(fnmatch(path, pat) for pat in patterns)
+
+
+def _resolve_head_sha(repo: Path) -> str | None:
+    """Return `git rev-parse HEAD` for `repo`, or None on any failure.
+
+    Mirrors `_default_head_sha` in github_source.py but reads the local
+    repo instead of shelling out to the network. None falls back to a
+    full re-scan rather than risking a stale cache replay.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    sha = proc.stdout.decode("utf-8", errors="replace").strip()
+    if len(sha) not in (40, 64) or not all(c in "0123456789abcdef" for c in sha):
+        return None
+    return sha
 
 
 def _parse_iso(value: str) -> datetime | None:

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/github_source.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/github_source.py
@@ -31,13 +31,8 @@ from pathlib import Path
 from typing import Any
 
 from pleno_pii_scanner.github import list_org_repos
-
-
-# Test seam: factory that turns (slug, config) into a local cloned path.
-# Production default is `_clone_into_tempdir` which shells out to git.
-CloneFn = Callable[[str, "GithubConfig"], Path]
-EnumerateFn = Callable[[str, bool], list[str]]
 from pleno_pii_scanner.sources.base import (
+    SUBSOURCE_METADATA_KEY,
     Capabilities,
     Cursor,
     Document,
@@ -45,9 +40,28 @@ from pleno_pii_scanner.sources.base import (
     DocumentRef,
     SourceConnector,
     SourceFilter,
+    Subsource,
 )
 from pleno_pii_scanner.sources.builtin.dir_source import DirConfig, DirConnector
 from pleno_pii_scanner.sources.registry import ConnectorSpec
+
+
+# Test seams. Production defaults shell out (`git clone`, `gh repo list`,
+# `git ls-remote`); tests inject in-memory doubles to keep the suite
+# deterministic + offline + sub-second.
+CloneFn = Callable[[str, "GithubConfig"], Path]
+EnumerateFn = Callable[[str, bool], list[str]]
+# `HeadShaFn` returns None when the SHA is unavailable (private repo,
+# network failure) so the runner falls back to a full clone instead of
+# risking a stale-cache hit.
+HeadShaFn = Callable[[str], str | None]
+
+
+# Bounds the number of concurrent `git ls-remote` subprocesses during
+# `list_subsources`. 16 is a comfortable balance — high enough that an
+# org with 1000 repos resolves in a few seconds, low enough that we do
+# not exhaust file descriptors or trip GitHub's per-IP abuse heuristics.
+_HEAD_SHA_CONCURRENCY = 16
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,24 +108,65 @@ class GithubConnector:
         *,
         clone_fn: CloneFn | None = None,
         enumerate_fn: EnumerateFn | None = None,
+        head_sha_fn: HeadShaFn | None = None,
     ) -> None:
         self._config = config
         self.id = config.resolved_id()
         self._clone_fn: CloneFn = clone_fn or _clone_into_tempdir
         self._enumerate_fn: EnumerateFn = enumerate_fn or _default_enumerate
+        self._head_sha_fn: HeadShaFn = head_sha_fn or _default_head_sha
         # slug → cloned path; populated lazily during fetch.
         self._clones: dict[str, Path] = {}
         self._tempdirs: list[Path] = []
+        # IncrementalSourceConnector state. Populated by list_subsources()
+        # so a subsequent set_subsource_skip() can land before discover()
+        # runs; cleared on close().
+        self._enumerated_slugs: list[str] | None = None
+        self._skip_subsources: frozenset[str] = frozenset()
         self._lock = asyncio.Lock()
 
     def capabilities(self) -> Capabilities:
         return Capabilities(
-            incremental=False,
+            # `incremental` advertises sub-source level skip via
+            # IncrementalSourceConnector; the per-document iteration is
+            # still a full re-walk inside an unchanged repo.
+            incremental=True,
             binary=False,
-            content_hash_delta=False,
+            content_hash_delta=True,
             max_concurrent_fetches=4,
             streaming=False,
         )
+
+    async def list_subsources(self) -> tuple[Subsource, ...]:
+        """Return one Subsource per repo with its remote HEAD SHA.
+
+        For an org config, enumerates all repos under the org (cached
+        across this connector's lifetime so a follow-up `discover()`
+        does not re-list). For a single-repo config, returns one entry.
+        Slugs whose HEAD SHA cannot be resolved are returned with the
+        sentinel fingerprint `unknown:<slug>` — the runner treats them
+        as cache misses, never as silent hits.
+
+        SHA resolution fans out across `_HEAD_SHA_CONCURRENCY` worker
+        threads — each `git ls-remote` is a 100–500 ms blocking network
+        round-trip, so an org with 1000 repos finishes in seconds, not
+        minutes. The semaphore caps the fan-out so we do not flood the
+        kernel with subprocess forks or trip GitHub's anti-abuse limits
+        on a single client.
+        """
+        slugs = await self._resolve_slugs(use_cache=True)
+        sem = asyncio.Semaphore(_HEAD_SHA_CONCURRENCY)
+
+        async def _resolve(slug: str) -> Subsource:
+            async with sem:
+                sha = await asyncio.to_thread(self._head_sha_fn, slug)
+            fingerprint = sha if sha is not None else f"unknown:{slug}"
+            return Subsource(sub_id=slug, fingerprint=fingerprint)
+
+        return tuple(await asyncio.gather(*(_resolve(s) for s in slugs)))
+
+    def set_subsource_skip(self, skip: frozenset[str]) -> None:
+        self._skip_subsources = skip
 
     async def discover(
         self,
@@ -119,8 +174,12 @@ class GithubConnector:
         cursor: Cursor | None,
     ) -> AsyncIterator[DocumentRef]:
         del cursor
-        slugs = await self._resolve_slugs()
+        slugs = await self._resolve_slugs(use_cache=True)
         for slug in slugs:
+            if slug in self._skip_subsources:
+                # Cache hit — the IncrementalRunner already replayed this
+                # repo's findings; we must not clone or yield refs for it.
+                continue
             repo_path = await self._ensure_clone(slug)
             inner = DirConnector(
                 DirConfig(root=repo_path, id=f"github:{slug}")
@@ -174,16 +233,28 @@ class GithubConnector:
                 await asyncio.to_thread(shutil.rmtree, path, ignore_errors=True)
             self._tempdirs.clear()
             self._clones.clear()
+            self._enumerated_slugs = None
+            self._skip_subsources = frozenset()
 
-    async def _resolve_slugs(self) -> list[str]:
+    async def _resolve_slugs(self, *, use_cache: bool = False) -> list[str]:
+        """Resolve the slug list. Single-repo configs short-circuit; for
+        org configs the enumeration is cached after the first call so
+        list_subsources() and discover() do not double-list. `use_cache`
+        is the only entry point — passing False forces a re-enumeration
+        (currently unused, kept for symmetry with the builtin connector
+        idiom of an explicit refresh path)."""
         if self._config.repo is not None:
             return [self._config.repo]
         assert self._config.org is not None
-        return await asyncio.to_thread(
+        if use_cache and self._enumerated_slugs is not None:
+            return list(self._enumerated_slugs)
+        slugs = await asyncio.to_thread(
             self._enumerate_fn,
             self._config.org,
             self._config.include_archived,
         )
+        self._enumerated_slugs = list(slugs)
+        return list(slugs)
 
     async def _ensure_clone(self, slug: str) -> Path:
         async with self._lock:
@@ -204,7 +275,9 @@ class GithubConnector:
     def _wrap_ref(self, inner: DocumentRef, slug: str) -> DocumentRef:
         # Re-emit with our connector identity + the slug so fetch can
         # find the right clone. parent_chain captures the github://
-        # provenance for findings dashboards.
+        # provenance for findings dashboards. SUBSOURCE_METADATA_KEY
+        # lets the IncrementalRunner attribute findings back to this
+        # repo when it stores the per-sub-source cache entry.
         return DocumentRef(
             source_id=self.id,
             source_kind=self.kind,
@@ -215,7 +288,12 @@ class GithubConnector:
             size=inner.size,
             etag=inner.etag,
             last_modified=inner.last_modified,
-            metadata={**inner.metadata, "slug": slug, "inner_path": inner.path},
+            metadata={
+                **inner.metadata,
+                "slug": slug,
+                "inner_path": inner.path,
+                SUBSOURCE_METADATA_KEY: slug,
+            },
         )
 
     def _unwrap_ref(self, ref: DocumentRef, slug: str) -> DocumentRef:
@@ -234,6 +312,42 @@ class GithubConnector:
 def _default_enumerate(org: str, include_archived: bool) -> list[str]:
     """Positional-arg adapter so EnumerateFn doubles are easy to write."""
     return list_org_repos(org, include_archived=include_archived)
+
+
+def _default_head_sha(slug: str) -> str | None:
+    """Resolve a slug's remote HEAD commit SHA without cloning.
+
+    Uses `git ls-remote --symref <url> HEAD`, parsing the SHA out of the
+    second line ("<sha>\\tHEAD"). One outbound TCP connection per repo;
+    no working tree on disk. Returns None on any failure so the runner
+    can fall back to a full clone instead of risking a stale-cache hit.
+    """
+    url = (
+        slug
+        if "://" in slug or "@" in slug
+        else f"https://github.com/{slug}.git"
+    )
+    try:
+        proc = subprocess.run(
+            ["git", "ls-remote", url, "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    line = proc.stdout.decode("utf-8", errors="replace").strip().splitlines()
+    if not line:
+        return None
+    sha = line[0].split()[0].strip()
+    # WHY: a valid Git SHA-1 is 40 hex chars; SHA-256 repos emit 64.
+    # Anything else (HTML error page from a captive portal, an empty
+    # ref) is a sentinel-worthy failure. Treating it as None forces a
+    # cache miss + fresh clone rather than caching garbage.
+    if len(sha) not in (40, 64) or not all(c in "0123456789abcdef" for c in sha):
+        return None
+    return sha
 
 
 def _clone_into_tempdir(slug: str, config: GithubConfig) -> Path:

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/__init__.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/__init__.py
@@ -1,4 +1,11 @@
-"""Incremental scan state — checkpoints and shard receipts (ADR-0007 §5)."""
+"""Incremental scan state — checkpoints, shard receipts, and the shared
+content-fingerprinted scan cache (ADR-0007 §5).
+
+The CheckpointStore (#6) gives a single scan kill -9 durability via per-
+source resume cursors. The ScanCache is its long-running counterpart:
+results survive across `scan_id`s so a nightly org-scan can amortize the
+95% of work that did not change since yesterday.
+"""
 
 from .checkpoint import (
     Checkpoint,
@@ -8,15 +15,31 @@ from .checkpoint import (
     encode_byte_range,
 )
 from .memory_store import MemoryCheckpointStore
+from .scan_cache import (
+    CacheEntry,
+    CacheLookup,
+    MemoryScanCache,
+    ScanCache,
+    SqliteScanCache,
+    default_cache_path,
+)
+from .schema_version import schema_version
 from .sqlite_store import SqliteCheckpointStore, default_state_path
 
 __all__ = [
+    "CacheEntry",
+    "CacheLookup",
     "Checkpoint",
     "CheckpointStore",
     "MemoryCheckpointStore",
+    "MemoryScanCache",
+    "ScanCache",
     "ShardRecord",
     "SqliteCheckpointStore",
+    "SqliteScanCache",
     "decode_byte_range",
+    "default_cache_path",
     "default_state_path",
     "encode_byte_range",
+    "schema_version",
 ]

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/scan_cache.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/scan_cache.py
@@ -1,0 +1,479 @@
+"""ScanCache — content-fingerprinted result cache for incremental scans.
+
+The CheckpointStore (#6) lets a single scan resume after a kill -9. The
+ScanCache complements it by letting *separate* scan invocations skip work
+that produced the same output last time. The cache survives across
+`scan_id`s on purpose: an org-scan that reruns nightly should not re-walk
+the 95% of repos that did not move since yesterday.
+
+The store is intentionally content-agnostic (`value: bytes`). Callers
+decide the wire format — typically a JSON-serialized findings list, or a
+small marker that says "this sub-source emitted zero findings". Two
+fingerprints gate a hit:
+
+  * `fingerprint` — opaque snapshot key for the scanned content
+    (commit SHA for a repo, ETag for a doc, version vector for a row).
+  * `schema_version` — fingerprint of the detector pipeline so a regex
+    pack update or NER model bump auto-invalidates every cached entry
+    without requiring the operator to wipe state.
+
+Both must match exactly for `get()` to return the stored value.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+import aiosqlite
+
+
+@dataclass(frozen=True, slots=True)
+class CacheEntry:
+    """One cached scan result.
+
+    `value` is opaque bytes — the cache layer never parses it. `stored_at`
+    is for diagnostics and TTL eviction (which the operator runs out of
+    band; the store itself does not garbage-collect on access).
+    """
+
+    key: str
+    fingerprint: str
+    schema_version: str
+    value: bytes
+    stored_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class CacheLookup:
+    """Single batched-lookup request: same `(fingerprint, schema_version)`
+    semantics as `ScanCache.get`, just bundled so a caller can hand a
+    list to `get_many` instead of awaiting `get` once per key.
+    """
+
+    key: str
+    fingerprint: str
+    schema_version: str
+
+
+@runtime_checkable
+class ScanCache(Protocol):
+    """Persistence contract for content-fingerprinted scan results.
+
+    Implementations must be safe to call concurrently from multiple
+    asyncio tasks. Last-writer-wins on the `key` column.
+    """
+
+    async def get(
+        self,
+        key: str,
+        *,
+        fingerprint: str,
+        schema_version: str,
+    ) -> bytes | None:
+        """Return the cached value iff `(key, fingerprint, schema_version)`
+        all match a stored entry. Otherwise `None` — including the case
+        where a row exists for `key` but with a stale `fingerprint` or
+        `schema_version`. The caller never has to defend against stale
+        hits.
+        """
+        ...
+
+    async def get_many(
+        self, lookups: Sequence[CacheLookup]
+    ) -> dict[str, bytes]:
+        """Resolve every lookup against the store in a single round-trip.
+
+        Returns a dict mapping `lookup.key` → `value` for every entry
+        whose stored fingerprint AND schema_version match the request.
+        Misses (absent key, stale fingerprint, stale schema) are simply
+        absent from the result. The on-disk SQLite path collapses to
+        one SELECT regardless of `len(lookups)`, which dominates the
+        sub-source pre-pass at org-scan scale.
+        """
+        ...
+
+    async def put(
+        self,
+        key: str,
+        *,
+        fingerprint: str,
+        schema_version: str,
+        value: bytes,
+    ) -> None:
+        """Upsert a cache entry. Replaces any prior row for `key`."""
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Remove a single cache entry. No-op if absent."""
+        ...
+
+    async def purge_other_schemas(self, schema_version: str) -> int:
+        """Drop every entry whose `schema_version` differs from the given
+        one. Returns the number of rows removed. Called periodically by
+        the runner so the cache file does not grow without bound when the
+        detector pipeline is upgraded.
+        """
+        ...
+
+    def iter_entries(self) -> AsyncIterator[CacheEntry]:
+        """Yield every entry. Used by tests and `pleno-pii-scanner cache
+        ls` style diagnostics. Implementations may snapshot under their
+        internal lock and yield outside it.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release the underlying connection / file handle."""
+        ...
+
+
+def default_cache_path() -> Path:
+    """Resolve the default SQLite path for the shared scan cache.
+
+    Unlike CheckpointStore (`~/.local/state/pleno/<scan_id>/...`), the
+    scan cache is **shared across scan_ids** — the whole point of the
+    cache is to amortize work across separate invocations. So we put it
+    at `~/.local/state/pleno/cache/scan_cache.sqlite` (XDG state, no
+    per-scan subdir).
+    """
+    base_env = os.environ.get("XDG_STATE_HOME")
+    if base_env:
+        base = Path(base_env)
+    else:
+        base = Path.home() / ".local" / "state"
+    return base / "pleno" / "cache" / "scan_cache.sqlite"
+
+
+class MemoryScanCache:
+    """In-process ScanCache. State is dropped on `close()`. Used by tests."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._entries: dict[str, CacheEntry] = {}
+        self._closed = False
+
+    async def __aenter__(self) -> MemoryScanCache:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.close()
+
+    async def get(
+        self,
+        key: str,
+        *,
+        fingerprint: str,
+        schema_version: str,
+    ) -> bytes | None:
+        async with self._lock:
+            self._raise_if_closed()
+            entry = self._entries.get(key)
+        if entry is None:
+            return None
+        if entry.fingerprint != fingerprint:
+            return None
+        if entry.schema_version != schema_version:
+            return None
+        return entry.value
+
+    async def get_many(
+        self, lookups: Sequence[CacheLookup]
+    ) -> dict[str, bytes]:
+        if not lookups:
+            return {}
+        async with self._lock:
+            self._raise_if_closed()
+            snapshot = {
+                lk.key: self._entries.get(lk.key) for lk in lookups
+            }
+        out: dict[str, bytes] = {}
+        for lk in lookups:
+            entry = snapshot.get(lk.key)
+            if entry is None:
+                continue
+            if entry.fingerprint != lk.fingerprint:
+                continue
+            if entry.schema_version != lk.schema_version:
+                continue
+            out[lk.key] = entry.value
+        return out
+
+    async def put(
+        self,
+        key: str,
+        *,
+        fingerprint: str,
+        schema_version: str,
+        value: bytes,
+    ) -> None:
+        async with self._lock:
+            self._raise_if_closed()
+            self._entries[key] = CacheEntry(
+                key=key,
+                fingerprint=fingerprint,
+                schema_version=schema_version,
+                value=value,
+                stored_at=datetime.now(UTC),
+            )
+
+    async def delete(self, key: str) -> None:
+        async with self._lock:
+            self._raise_if_closed()
+            self._entries.pop(key, None)
+
+    async def purge_other_schemas(self, schema_version: str) -> int:
+        async with self._lock:
+            self._raise_if_closed()
+            stale = [
+                k for k, e in self._entries.items()
+                if e.schema_version != schema_version
+            ]
+            for k in stale:
+                del self._entries[k]
+            return len(stale)
+
+    async def iter_entries(self) -> AsyncIterator[CacheEntry]:
+        async with self._lock:
+            self._raise_if_closed()
+            snapshot = list(self._entries.values())
+        for entry in snapshot:
+            yield entry
+
+    async def close(self) -> None:
+        async with self._lock:
+            self._closed = True
+            self._entries.clear()
+
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            raise RuntimeError("ScanCache is closed")
+
+
+_SCHEMA = (
+    """
+    CREATE TABLE IF NOT EXISTS scan_cache (
+        key             TEXT PRIMARY KEY,
+        fingerprint     TEXT NOT NULL,
+        schema_version  TEXT NOT NULL,
+        value           BLOB NOT NULL,
+        stored_at       TEXT NOT NULL
+    );
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS scan_cache_schema_idx
+        ON scan_cache(schema_version);
+    """,
+)
+
+
+class SqliteScanCache:
+    """aiosqlite-backed ScanCache. Use `await SqliteScanCache.open(...)`.
+
+    WAL journal mode + an asyncio.Lock around the single writable
+    connection mirrors `SqliteCheckpointStore` so the two stores share
+    the same crash-durability and concurrency story.
+    """
+
+    def __init__(self, path: Path, conn: aiosqlite.Connection) -> None:
+        self._path = path
+        self._conn = conn
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    @classmethod
+    async def open(cls, *, path: Path | None = None) -> SqliteScanCache:
+        """Open (or create) the shared scan cache database."""
+        target = path if path is not None else default_cache_path()
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        conn = await aiosqlite.connect(target)
+        try:
+            await conn.execute("PRAGMA journal_mode=WAL;")
+            await conn.execute("PRAGMA synchronous=NORMAL;")
+            for stmt in _SCHEMA:
+                await conn.execute(stmt)
+            await conn.commit()
+        except Exception:
+            await conn.close()
+            raise
+        return cls(target, conn)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    async def __aenter__(self) -> SqliteScanCache:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.close()
+
+    async def get(
+        self,
+        key: str,
+        *,
+        fingerprint: str,
+        schema_version: str,
+    ) -> bytes | None:
+        async with self._lock:
+            self._raise_if_closed()
+            cur = await self._conn.execute(
+                "SELECT fingerprint, schema_version, value "
+                "FROM scan_cache WHERE key=?",
+                (key,),
+            )
+            try:
+                row = await cur.fetchone()
+            finally:
+                await cur.close()
+        if row is None:
+            return None
+        stored_fp, stored_sv, value = row
+        if stored_fp != fingerprint or stored_sv != schema_version:
+            return None
+        return bytes(value)
+
+    async def get_many(
+        self, lookups: Sequence[CacheLookup]
+    ) -> dict[str, bytes]:
+        if not lookups:
+            return {}
+        # Single SELECT … WHERE key IN (?, ?, ...) so a sub-source pre-
+        # pass for an org with 10**3 repos pays one round-trip instead
+        # of 10**3. The fingerprint / schema check happens in Python
+        # because SQLite cannot easily compare columns to per-row
+        # constants.
+        keys = [lk.key for lk in lookups]
+        placeholders = ",".join("?" * len(keys))
+        async with self._lock:
+            self._raise_if_closed()
+            cur = await self._conn.execute(
+                f"SELECT key, fingerprint, schema_version, value "
+                f"FROM scan_cache WHERE key IN ({placeholders})",
+                keys,
+            )
+            try:
+                rows = await cur.fetchall()
+            finally:
+                await cur.close()
+        rows_by_key = {
+            row[0]: (row[1], row[2], bytes(row[3])) for row in rows
+        }
+        out: dict[str, bytes] = {}
+        for lk in lookups:
+            row = rows_by_key.get(lk.key)
+            if row is None:
+                continue
+            stored_fp, stored_sv, value = row
+            if stored_fp != lk.fingerprint or stored_sv != lk.schema_version:
+                continue
+            out[lk.key] = value
+        return out
+
+    async def put(
+        self,
+        key: str,
+        *,
+        fingerprint: str,
+        schema_version: str,
+        value: bytes,
+    ) -> None:
+        async with self._lock:
+            self._raise_if_closed()
+            await self._conn.execute(
+                _UPSERT,
+                (
+                    key,
+                    fingerprint,
+                    schema_version,
+                    value,
+                    datetime.now(UTC).isoformat(),
+                ),
+            )
+            await self._conn.commit()
+
+    async def delete(self, key: str) -> None:
+        async with self._lock:
+            self._raise_if_closed()
+            await self._conn.execute(
+                "DELETE FROM scan_cache WHERE key=?", (key,)
+            )
+            await self._conn.commit()
+
+    async def purge_other_schemas(self, schema_version: str) -> int:
+        async with self._lock:
+            self._raise_if_closed()
+            cur = await self._conn.execute(
+                "DELETE FROM scan_cache WHERE schema_version<>?",
+                (schema_version,),
+            )
+            try:
+                removed = cur.rowcount or 0
+            finally:
+                await cur.close()
+            await self._conn.commit()
+        return int(removed)
+
+    async def iter_entries(self) -> AsyncIterator[CacheEntry]:
+        async with self._lock:
+            self._raise_if_closed()
+            cur = await self._conn.execute(
+                "SELECT key, fingerprint, schema_version, value, stored_at "
+                "FROM scan_cache ORDER BY key ASC"
+            )
+            try:
+                rows = await cur.fetchall()
+            finally:
+                await cur.close()
+        for row in rows:
+            yield CacheEntry(
+                key=row[0],
+                fingerprint=row[1],
+                schema_version=row[2],
+                value=bytes(row[3]),
+                stored_at=_parse_iso(row[4]),
+            )
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            await self._conn.close()
+
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            raise RuntimeError("ScanCache is closed")
+
+
+_UPSERT = """
+INSERT INTO scan_cache (key, fingerprint, schema_version, value, stored_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(key) DO UPDATE SET
+    fingerprint    = excluded.fingerprint,
+    schema_version = excluded.schema_version,
+    value          = excluded.value,
+    stored_at      = excluded.stored_at
+"""
+
+
+def _parse_iso(value: Any) -> datetime:
+    dt = datetime.fromisoformat(str(value))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+__all__ = [
+    "CacheEntry",
+    "CacheLookup",
+    "MemoryScanCache",
+    "ScanCache",
+    "SqliteScanCache",
+    "default_cache_path",
+]

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/schema_version.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/schema_version.py
@@ -1,0 +1,68 @@
+"""Schema-version helper — derives a stable cache-busting key from the
+current detector pipeline.
+
+Every cached scan result is tagged with a `schema_version`. When the
+detector pipeline changes (regex pack release, NER model bump, custom
+recognizer added), the schema_version flips and prior cached entries
+fall through as misses without needing the operator to manually wipe
+the cache file.
+
+The value is intentionally derived from package metadata + caller-
+supplied components rather than a hardcoded string. Forgetting to bump
+a hardcoded constant when the pipeline changes silently serves stale
+findings — the highest-cost failure mode for a security tool.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from hashlib import sha256
+from importlib import metadata
+
+
+# `_TRACKED_DISTRIBUTIONS` lists every wheel whose version, when bumped,
+# may change detector output. Add to this list when a new detector
+# component lands; cache entries from older versions then auto-invalidate
+# on the next run. Version-not-found is treated as the literal string
+# `none` so an editable workspace install (no metadata) still yields a
+# stable, reproducible schema_version.
+_TRACKED_DISTRIBUTIONS: tuple[str, ...] = (
+    "pleno-pii-scanner",
+    "pleno-recognizers",
+)
+
+
+def _resolved_versions(distributions: Iterable[str]) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for dist in distributions:
+        try:
+            version = metadata.version(dist)
+        except metadata.PackageNotFoundError:
+            version = "none"
+        out.append((dist, version))
+    return out
+
+
+def schema_version(*extra_components: str) -> str:
+    """Compute the current cache schema version.
+
+    `extra_components` lets callers pin custom recognizer pack revisions,
+    NER model checksums, or per-deployment configuration that affects
+    detector output. Components are combined deterministically (NUL-
+    separated) and SHA-256-hashed so the on-disk cache stores compact
+    fixed-length keys regardless of how many inputs the deployment has.
+    """
+    h = sha256()
+    for dist, version in _resolved_versions(_TRACKED_DISTRIBUTIONS):
+        h.update(dist.encode())
+        h.update(b"=")
+        h.update(version.encode())
+        h.update(b"\0")
+    for component in extra_components:
+        h.update(b"x=")
+        h.update(component.encode())
+        h.update(b"\0")
+    return h.hexdigest()[:32]
+
+
+__all__ = ["schema_version"]

--- a/packages/pii-scanner/tests/scheduler/test_incremental.py
+++ b/packages/pii-scanner/tests/scheduler/test_incremental.py
@@ -1,0 +1,416 @@
+"""IncrementalRunner — sub-source + document level cache short-circuiting.
+
+These tests use lightweight in-memory connectors so they exercise the
+runner's orchestration without needing real git / network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass, field
+
+import pytest
+
+from pleno_pii_scanner.scheduler import (
+    GlobalRateLimiter,
+    IncrementalRunner,
+    Scheduler,
+    SchedulerConfig,
+    SourcePlan,
+)
+from pleno_pii_scanner.sources.base import (
+    SUBSOURCE_METADATA_KEY,
+    Capabilities,
+    Document,
+    DocumentChunk,
+    DocumentRef,
+    SourceFilter,
+    Subsource,
+)
+from pleno_pii_scanner.state import MemoryScanCache
+
+
+# --- Test doubles ----------------------------------------------------------
+
+
+@dataclass
+class _FlatConnector:
+    """Bare-minimum SourceConnector with no sub-source hierarchy."""
+
+    id: str = "flat"
+    kind: str = "flat"
+    refs: tuple[tuple[str, str], ...] = ()  # (path, body)
+
+    async def discover(
+        self, filter: SourceFilter, cursor: str | None
+    ) -> AsyncIterator[DocumentRef]:
+        del cursor
+        for path, _ in self.refs:
+            yield DocumentRef(
+                source_id=self.id,
+                source_kind=self.kind,
+                path=path,
+            )
+
+    async def fetch(
+        self, ref: DocumentRef
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        body = next(b for p, b in self.refs if p == ref.path)
+        yield Document(ref=ref, text=body, content_hash=f"h:{body}")
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities()
+
+    async def close(self) -> None:
+        return None
+
+
+@dataclass
+class _HierarchicalConnector:
+    """SourceConnector that opts into IncrementalSourceConnector.
+
+    `sub_layout` is `{sub_id: (fingerprint, [(path, body), ...])}`. Each
+    sub-source's docs surface the SUBSOURCE_METADATA_KEY tag the runner
+    needs to attribute findings.
+    """
+
+    id: str = "hier"
+    kind: str = "hier"
+    sub_layout: dict[str, tuple[str, list[tuple[str, str]]]] = field(
+        default_factory=dict
+    )
+    skip: frozenset[str] = field(default_factory=frozenset)
+    list_calls: int = 0
+    discover_subs: list[str] = field(default_factory=list)
+
+    async def list_subsources(self) -> Sequence[Subsource]:
+        self.list_calls += 1
+        return tuple(
+            Subsource(sub_id=sid, fingerprint=fp)
+            for sid, (fp, _) in self.sub_layout.items()
+        )
+
+    def set_subsource_skip(self, skip: frozenset[str]) -> None:
+        self.skip = skip
+
+    async def discover(
+        self, filter: SourceFilter, cursor: str | None
+    ) -> AsyncIterator[DocumentRef]:
+        del cursor
+        for sub_id, (_, items) in self.sub_layout.items():
+            if sub_id in self.skip:
+                continue
+            self.discover_subs.append(sub_id)
+            for path, _body in items:
+                yield DocumentRef(
+                    source_id=self.id,
+                    source_kind=self.kind,
+                    path=f"{sub_id}/{path}",
+                    metadata={SUBSOURCE_METADATA_KEY: sub_id},
+                )
+
+    async def fetch(
+        self, ref: DocumentRef
+    ) -> AsyncIterator[Document | DocumentChunk]:
+        sub_id = ref.metadata[SUBSOURCE_METADATA_KEY]
+        path = ref.path[len(sub_id) + 1 :]
+        body = next(b for p, b in self.sub_layout[sub_id][1] if p == path)
+        yield Document(ref=ref, text=body, content_hash=f"h:{body}")
+
+    def capabilities(self) -> Capabilities:
+        return Capabilities(incremental=True, content_hash_delta=True)
+
+    async def close(self) -> None:
+        return None
+
+
+def _runner_pieces() -> tuple[Scheduler, MemoryScanCache]:
+    return (
+        Scheduler(
+            config=SchedulerConfig(per_source_concurrency=2),
+            rate_limiter=GlobalRateLimiter(),
+        ),
+        MemoryScanCache(),
+    )
+
+
+def _detector_returning(per_doc_count: int = 1):
+    """Build a `DetectorFn` that emits a known count + payload per doc."""
+
+    async def detector(
+        ref: DocumentRef, _doc: Document | DocumentChunk
+    ) -> tuple[int, bytes]:
+        return per_doc_count, f"finding:{ref.path}".encode()
+
+    return detector
+
+
+def _collect_findings():
+    """Build a recording `OnFindingsFn`."""
+
+    received: list[tuple[str, str | None, int, bytes, bool]] = []
+
+    async def on_findings(
+        source_id: str,
+        sub_id: str | None,
+        count: int,
+        payload: bytes,
+        replayed: bool,
+    ) -> None:
+        received.append((source_id, sub_id, count, payload, replayed))
+
+    return received, on_findings
+
+
+# --- Document-level cache --------------------------------------------------
+
+
+class TestDocumentLevelCache:
+    @pytest.mark.asyncio
+    async def test_first_run_misses_second_run_hits(self) -> None:
+        sch, cache = _runner_pieces()
+        runner = IncrementalRunner(sch, cache, schema_version="v1")
+        connector = _FlatConnector(refs=(("a.txt", "alpha"), ("b.txt", "bravo")))
+        plan = SourcePlan(connector=connector)
+
+        try:
+            received, on_findings = _collect_findings()
+            results = await runner.run(
+                [plan],
+                scan_id="run-1",
+                detector=_detector_returning(2),
+                on_findings=on_findings,
+            )
+            assert results[0].cache_stats.document_total == 2
+            assert results[0].cache_stats.document_misses == 2
+            assert results[0].cache_stats.document_hits == 0
+            assert all(not replayed for *_, replayed in received)
+
+            # Re-create the connector — same content, fresh discover.
+            connector2 = _FlatConnector(
+                refs=(("a.txt", "alpha"), ("b.txt", "bravo"))
+            )
+            plan2 = SourcePlan(connector=connector2)
+            received2, on_findings2 = _collect_findings()
+            results2 = await runner.run(
+                [plan2],
+                scan_id="run-2",
+                detector=_detector_returning(2),
+                on_findings=on_findings2,
+            )
+            assert results2[0].cache_stats.document_hits == 2
+            assert results2[0].cache_stats.document_misses == 0
+            assert all(replayed for *_, replayed in received2)
+        finally:
+            await sch.close()
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_changed_content_misses(self) -> None:
+        sch, cache = _runner_pieces()
+        runner = IncrementalRunner(sch, cache, schema_version="v1")
+
+        connector1 = _FlatConnector(refs=(("x.txt", "old"),))
+        _, on_findings = _collect_findings()
+        await runner.run(
+            [SourcePlan(connector=connector1)],
+            scan_id="r1",
+            detector=_detector_returning(1),
+            on_findings=on_findings,
+        )
+
+        connector2 = _FlatConnector(refs=(("x.txt", "NEW"),))
+        _, on_findings2 = _collect_findings()
+        results = await runner.run(
+            [SourcePlan(connector=connector2)],
+            scan_id="r2",
+            detector=_detector_returning(1),
+            on_findings=on_findings2,
+        )
+        try:
+            assert results[0].cache_stats.document_misses == 1
+            assert results[0].cache_stats.document_hits == 0
+        finally:
+            await sch.close()
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_schema_version_bump_invalidates(self) -> None:
+        sch, cache = _runner_pieces()
+        runner_v1 = IncrementalRunner(sch, cache, schema_version="v1")
+        connector = _FlatConnector(refs=(("a.txt", "x"),))
+        _, on_findings = _collect_findings()
+        await runner_v1.run(
+            [SourcePlan(connector=connector)],
+            scan_id="r1",
+            detector=_detector_returning(1),
+            on_findings=on_findings,
+        )
+
+        runner_v2 = IncrementalRunner(sch, cache, schema_version="v2")
+        connector2 = _FlatConnector(refs=(("a.txt", "x"),))
+        _, on_findings2 = _collect_findings()
+        results = await runner_v2.run(
+            [SourcePlan(connector=connector2)],
+            scan_id="r2",
+            detector=_detector_returning(1),
+            on_findings=on_findings2,
+        )
+        try:
+            assert results[0].cache_stats.document_misses == 1
+        finally:
+            await sch.close()
+            await cache.close()
+
+
+# --- Sub-source level cache ------------------------------------------------
+
+
+class TestSubsourceCache:
+    @pytest.mark.asyncio
+    async def test_unchanged_subsource_skipped_on_second_run(self) -> None:
+        sch, cache = _runner_pieces()
+        runner = IncrementalRunner(sch, cache, schema_version="v1")
+
+        layout = {
+            "repo-a": ("sha-aaa", [("f1.py", "alpha")]),
+            "repo-b": ("sha-bbb", [("f2.py", "bravo")]),
+        }
+        c1 = _HierarchicalConnector(sub_layout=layout)
+        _, on_findings1 = _collect_findings()
+        r1 = await runner.run(
+            [SourcePlan(connector=c1)],
+            scan_id="run-1",
+            detector=_detector_returning(3),
+            on_findings=on_findings1,
+        )
+        assert r1[0].cache_stats.subsource_hits == 0
+        assert r1[0].cache_stats.subsource_misses == 2
+        assert sorted(c1.discover_subs) == ["repo-a", "repo-b"]
+
+        # Same fingerprints → both skipped on second run.
+        c2 = _HierarchicalConnector(sub_layout=layout)
+        received2, on_findings2 = _collect_findings()
+        r2 = await runner.run(
+            [SourcePlan(connector=c2)],
+            scan_id="run-2",
+            detector=_detector_returning(3),
+            on_findings=on_findings2,
+        )
+        try:
+            assert r2[0].cache_stats.subsource_hits == 2
+            assert r2[0].cache_stats.subsource_misses == 0
+            # Connector.discover never visited any sub-source.
+            assert c2.discover_subs == []
+            # All emitted findings came from the cache (replayed=True).
+            assert received2 and all(replayed for *_, replayed in received2)
+            # Per-sub-source counts match the rollup we stored on run 1.
+            counts_by_sub = {sub: count for _, sub, count, _, _ in received2}
+            assert counts_by_sub == {"repo-a": 3, "repo-b": 3}
+        finally:
+            await sch.close()
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_partial_change_only_rescans_changed_subsource(self) -> None:
+        sch, cache = _runner_pieces()
+        runner = IncrementalRunner(sch, cache, schema_version="v1")
+
+        c1 = _HierarchicalConnector(
+            sub_layout={
+                "repo-a": ("sha-1", [("a.py", "x")]),
+                "repo-b": ("sha-2", [("b.py", "y")]),
+            }
+        )
+        _, on_findings1 = _collect_findings()
+        await runner.run(
+            [SourcePlan(connector=c1)],
+            scan_id="r1",
+            detector=_detector_returning(1),
+            on_findings=on_findings1,
+        )
+
+        # repo-b's fingerprint flips — repo-a should still hit.
+        c2 = _HierarchicalConnector(
+            sub_layout={
+                "repo-a": ("sha-1", [("a.py", "x")]),
+                "repo-b": ("sha-2-new", [("b.py", "y2")]),
+            }
+        )
+        _, on_findings2 = _collect_findings()
+        r2 = await runner.run(
+            [SourcePlan(connector=c2)],
+            scan_id="r2",
+            detector=_detector_returning(1),
+            on_findings=on_findings2,
+        )
+        try:
+            assert r2[0].cache_stats.subsource_hits == 1
+            assert r2[0].cache_stats.subsource_misses == 1
+            # discover only walked the changed sub-source.
+            assert c2.discover_subs == ["repo-b"]
+        finally:
+            await sch.close()
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_errored_plan_does_not_cache_rollup(self) -> None:
+        sch, cache = _runner_pieces()
+        runner = IncrementalRunner(sch, cache, schema_version="v1")
+
+        layout = {"repo": ("sha-x", [("f.py", "v1")])}
+        c1 = _HierarchicalConnector(sub_layout=layout)
+
+        async def failing_detector(
+            _ref: DocumentRef, _doc: Document | DocumentChunk
+        ) -> tuple[int, bytes]:
+            raise RuntimeError("detector blew up")
+
+        _, on_findings = _collect_findings()
+        r1 = await runner.run(
+            [SourcePlan(connector=c1)],
+            scan_id="r1",
+            detector=failing_detector,
+            on_findings=on_findings,
+        )
+        # The scheduler captures the detector error onto SourceResult.error.
+        assert r1[0].source_result.error is not None
+
+        # A clean rerun must MISS, not silently hit a half-formed entry.
+        c2 = _HierarchicalConnector(sub_layout=layout)
+        _, on_findings2 = _collect_findings()
+        r2 = await runner.run(
+            [SourcePlan(connector=c2)],
+            scan_id="r2",
+            detector=_detector_returning(1),
+            on_findings=on_findings2,
+        )
+        try:
+            assert r2[0].cache_stats.subsource_misses == 1
+            assert r2[0].cache_stats.subsource_hits == 0
+        finally:
+            await sch.close()
+            await cache.close()
+
+
+# --- Schedule-stat propagation ---------------------------------------------
+
+
+class TestSchedulerCounts:
+    @pytest.mark.asyncio
+    async def test_findings_count_reflects_detector_return(self) -> None:
+        sch, cache = _runner_pieces()
+        runner = IncrementalRunner(sch, cache, schema_version="v1")
+        connector = _FlatConnector(refs=(("a", "1"), ("b", "2")))
+        _, on_findings = _collect_findings()
+        try:
+            r = await runner.run(
+                [SourcePlan(connector=connector)],
+                scan_id="run",
+                detector=_detector_returning(5),
+                on_findings=on_findings,
+            )
+            assert r[0].source_result.findings_emitted == 10
+        finally:
+            await sch.close()
+            await cache.close()

--- a/packages/pii-scanner/tests/sources/builtin/test_git_source.py
+++ b/packages/pii-scanner/tests/sources/builtin/test_git_source.py
@@ -10,9 +10,11 @@ from pathlib import Path
 import pytest
 
 from pleno_pii_scanner.sources import (
+    SUBSOURCE_METADATA_KEY,
     Capabilities,
     Document,
     DocumentRef,
+    IncrementalSourceConnector,
     SourceConnector,
     SourceFilter,
     create,
@@ -71,12 +73,14 @@ class TestProtocol:
         c = GitConnector(GitConfig(repo=repo))
         assert isinstance(c, SourceConnector)
 
-    def test_capabilities_are_conservative(self, repo: Path) -> None:
+    def test_capabilities_advertise_subsource_skip(self, repo: Path) -> None:
         c = GitConnector(GitConfig(repo=repo))
         assert c.capabilities() == Capabilities(
-            incremental=False,
+            # IncrementalSourceConnector treats the whole repo as one
+            # sub-source whose fingerprint is HEAD's SHA.
+            incremental=True,
             binary=False,
-            content_hash_delta=False,
+            content_hash_delta=True,
             max_concurrent_fetches=4,
             streaming=False,
         )
@@ -271,3 +275,50 @@ class TestParseHelpers:
         assert lines[0] == "first"
         assert lines[1] == ""
         assert lines[4] == "fifth"
+
+
+class TestIncrementalSubsources:
+    def test_runtime_isinstance(self, repo: Path) -> None:
+        c = GitConnector(GitConfig(repo=repo))
+        assert isinstance(c, IncrementalSourceConnector)
+
+    async def test_list_subsources_uses_head_sha(self, repo: Path) -> None:
+        c = GitConnector(GitConfig(repo=repo))
+        subs = await c.list_subsources()
+        # One sub-source = the whole repo. Fingerprint is HEAD's SHA.
+        assert len(subs) == 1
+        assert subs[0].sub_id == c.id
+        assert len(subs[0].fingerprint) in (40, 64)
+        assert all(ch in "0123456789abcdef" for ch in subs[0].fingerprint)
+
+    async def test_list_subsources_unknown_sha_for_broken_repo(
+        self, tmp_path: Path
+    ) -> None:
+        broken = tmp_path / "not-a-repo"
+        broken.mkdir()
+        c = GitConnector(GitConfig(repo=broken))
+        subs = await c.list_subsources()
+        assert subs[0].fingerprint.startswith("unknown:")
+
+    async def test_set_subsource_skip_yields_zero_refs(
+        self, repo: Path
+    ) -> None:
+        c = GitConnector(GitConfig(repo=repo))
+        c.set_subsource_skip(frozenset({c.id}))
+        try:
+            refs = await _drain(c.discover(SourceFilter(), None))
+            assert refs == []
+        finally:
+            await c.close()
+
+    async def test_subsource_metadata_attached_to_refs(
+        self, repo: Path
+    ) -> None:
+        c = GitConnector(GitConfig(repo=repo))
+        try:
+            refs = await _drain(c.discover(SourceFilter(), None))
+            assert refs
+            for r in refs:
+                assert r.metadata[SUBSOURCE_METADATA_KEY] == c.id
+        finally:
+            await c.close()

--- a/packages/pii-scanner/tests/sources/builtin/test_github_source.py
+++ b/packages/pii-scanner/tests/sources/builtin/test_github_source.py
@@ -14,9 +14,11 @@ from pathlib import Path
 import pytest
 
 from pleno_pii_scanner.sources import (
+    SUBSOURCE_METADATA_KEY,
     Capabilities,
     Document,
     DocumentRef,
+    IncrementalSourceConnector,
     SourceConnector,
     SourceFilter,
     create,
@@ -105,9 +107,13 @@ class TestProtocol:
     def test_capabilities(self) -> None:
         c = GithubConnector(GithubConfig(repo="a/b"))
         assert c.capabilities() == Capabilities(
-            incremental=False,
+            # `incremental=True` advertises the IncrementalSourceConnector
+            # protocol — sub-source level skip via list_subsources +
+            # set_subsource_skip. Per-document iteration is still a full
+            # walk inside an unchanged repo.
+            incremental=True,
             binary=False,
-            content_hash_delta=False,
+            content_hash_delta=True,
             max_concurrent_fetches=4,
             streaming=False,
         )
@@ -404,3 +410,112 @@ class TestProductionHelpers:
         result = mod._default_enumerate("acme", True)
         assert result == ["a/x"]
         assert called["args"] == ("acme", True)
+
+
+# --- IncrementalSourceConnector ---------------------------------------
+
+
+class TestIncrementalSubsources:
+    def test_runtime_isinstance(self) -> None:
+        c = GithubConnector(GithubConfig(repo="a/b"))
+        assert isinstance(c, IncrementalSourceConnector)
+
+    async def test_list_subsources_for_single_repo(self) -> None:
+        # One slug → one Subsource, fingerprint = the stub HEAD SHA.
+        c = GithubConnector(
+            GithubConfig(repo="acme/widgets"),
+            head_sha_fn=lambda slug: "deadbeefcafebabe1234567890abcdef12345678",
+        )
+        subs = await c.list_subsources()
+        assert len(subs) == 1
+        assert subs[0].sub_id == "acme/widgets"
+        assert subs[0].fingerprint == (
+            "deadbeefcafebabe1234567890abcdef12345678"
+        )
+
+    async def test_list_subsources_for_org(self) -> None:
+        c = GithubConnector(
+            GithubConfig(org="acme"),
+            enumerate_fn=lambda org, archived: ["acme/one", "acme/two"],
+            head_sha_fn=lambda slug: f"sha-{slug.split('/')[-1]}-pad-pad-pad-pad-pad-pad-pad",
+        )
+        subs = await c.list_subsources()
+        slug_set = {s.sub_id for s in subs}
+        assert slug_set == {"acme/one", "acme/two"}
+
+    async def test_unknown_sha_yields_sentinel_fingerprint(self) -> None:
+        c = GithubConnector(
+            GithubConfig(repo="acme/widgets"),
+            head_sha_fn=lambda slug: None,
+        )
+        subs = await c.list_subsources()
+        # Sentinel makes the runner treat this as a guaranteed miss.
+        assert subs[0].fingerprint == "unknown:acme/widgets"
+
+    async def test_set_subsource_skip_omits_those_slugs_from_discover(
+        self, fake_repo: Path, tmp_path: Path
+    ) -> None:
+        # Stage the fake repo content under tmp_path so _stub_clone copies it.
+        for f in fake_repo.iterdir():
+            if f.is_file():
+                (tmp_path / f.name).write_text(f.read_text())
+        c = GithubConnector(
+            GithubConfig(org="acme"),
+            clone_fn=_stub_clone(tmp_path),
+            enumerate_fn=lambda org, archived: ["acme/one", "acme/two"],
+            head_sha_fn=lambda slug: "0" * 40,
+        )
+        c.set_subsource_skip(frozenset({"acme/one"}))
+        try:
+            refs = await _drain_refs(c.discover(SourceFilter(), None))
+            slugs = {r.metadata["slug"] for r in refs}
+            # acme/one was told to skip; only acme/two surfaces.
+            assert slugs == {"acme/two"}
+            for r in refs:
+                # Subsource attribution is wired through metadata.
+                assert r.metadata[SUBSOURCE_METADATA_KEY] == "acme/two"
+        finally:
+            await c.close()
+
+    def test_default_head_sha_parses_ls_remote_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pleno_pii_scanner.sources.builtin import github_source as mod
+
+        sample = (
+            b"abcdef0123456789abcdef0123456789abcdef01\tHEAD\n"
+        )
+        monkeypatch.setattr(
+            mod.subprocess,
+            "run",
+            lambda cmd, **kw: type("R", (), {"stdout": sample})(),
+        )
+        assert mod._default_head_sha("acme/widgets") == (
+            "abcdef0123456789abcdef0123456789abcdef01"
+        )
+
+    def test_default_head_sha_returns_none_on_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pleno_pii_scanner.sources.builtin import github_source as mod
+
+        def boom(cmd, **kw):
+            raise mod.subprocess.SubprocessError("network down")
+
+        monkeypatch.setattr(mod.subprocess, "run", boom)
+        assert mod._default_head_sha("acme/widgets") is None
+
+    def test_default_head_sha_rejects_garbage(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pleno_pii_scanner.sources.builtin import github_source as mod
+
+        # HTML error page from a captive portal: not a SHA.
+        monkeypatch.setattr(
+            mod.subprocess,
+            "run",
+            lambda cmd, **kw: type(
+                "R", (), {"stdout": b"<html>nope</html>\n"}
+            )(),
+        )
+        assert mod._default_head_sha("acme/widgets") is None

--- a/packages/pii-scanner/tests/state/test_scan_cache.py
+++ b/packages/pii-scanner/tests/state/test_scan_cache.py
@@ -1,0 +1,260 @@
+"""ScanCache tests — Memory + SQLite parity, fingerprint/schema gating, XDG path.
+
+Mirrors `test_memory_store.py` / `test_sqlite_store.py` so the same
+correctness bar applies to both implementations of the new cache.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pleno_pii_scanner.state import (
+    CacheLookup,
+    MemoryScanCache,
+    ScanCache,
+    SqliteScanCache,
+    default_cache_path,
+)
+
+
+@pytest.fixture
+async def memory() -> ScanCache:
+    return MemoryScanCache()
+
+
+@pytest.fixture
+async def sqlite(tmp_path: Path) -> ScanCache:
+    return await SqliteScanCache.open(path=tmp_path / "cache.sqlite")
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+async def cache(request: pytest.FixtureRequest, tmp_path: Path) -> ScanCache:
+    if request.param == "memory":
+        return MemoryScanCache()
+    return await SqliteScanCache.open(path=tmp_path / "cache.sqlite")
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_put_then_get_returns_value(self, cache: ScanCache) -> None:
+        try:
+            await cache.put(
+                "k", fingerprint="fp", schema_version="sv", value=b"payload"
+            )
+            assert (
+                await cache.get("k", fingerprint="fp", schema_version="sv")
+            ) == b"payload"
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_get_missing_key_returns_none(self, cache: ScanCache) -> None:
+        try:
+            assert (
+                await cache.get("k", fingerprint="fp", schema_version="sv")
+            ) is None
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_put_replaces_existing_entry(self, cache: ScanCache) -> None:
+        try:
+            await cache.put("k", fingerprint="fp", schema_version="sv", value=b"a")
+            await cache.put("k", fingerprint="fp", schema_version="sv", value=b"b")
+            assert (
+                await cache.get("k", fingerprint="fp", schema_version="sv")
+            ) == b"b"
+        finally:
+            await cache.close()
+
+
+class TestFingerprintGating:
+    @pytest.mark.asyncio
+    async def test_stale_fingerprint_returns_none(
+        self, cache: ScanCache
+    ) -> None:
+        try:
+            await cache.put("k", fingerprint="old", schema_version="sv", value=b"v")
+            assert (
+                await cache.get("k", fingerprint="new", schema_version="sv")
+            ) is None
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_stale_schema_returns_none(self, cache: ScanCache) -> None:
+        try:
+            await cache.put(
+                "k", fingerprint="fp", schema_version="v1", value=b"v"
+            )
+            assert (
+                await cache.get("k", fingerprint="fp", schema_version="v2")
+            ) is None
+        finally:
+            await cache.close()
+
+
+class TestGetMany:
+    @pytest.mark.asyncio
+    async def test_returns_only_matching_entries(self, cache: ScanCache) -> None:
+        try:
+            await cache.put("a", fingerprint="f1", schema_version="s", value=b"A")
+            await cache.put("b", fingerprint="f2", schema_version="s", value=b"B")
+            await cache.put("c", fingerprint="f3", schema_version="s", value=b"C")
+            result = await cache.get_many(
+                [
+                    CacheLookup(key="a", fingerprint="f1", schema_version="s"),
+                    CacheLookup(key="b", fingerprint="STALE", schema_version="s"),
+                    CacheLookup(key="c", fingerprint="f3", schema_version="OLD"),
+                    CacheLookup(key="missing", fingerprint="x", schema_version="s"),
+                ]
+            )
+            assert result == {"a": b"A"}
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_lookups_returns_empty(self, cache: ScanCache) -> None:
+        try:
+            assert await cache.get_many([]) == {}
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_large_batch(self, cache: ScanCache) -> None:
+        try:
+            for i in range(50):
+                await cache.put(
+                    f"k{i}", fingerprint="f", schema_version="s", value=str(i).encode()
+                )
+            result = await cache.get_many(
+                [
+                    CacheLookup(key=f"k{i}", fingerprint="f", schema_version="s")
+                    for i in range(50)
+                ]
+            )
+            assert len(result) == 50
+            assert result["k0"] == b"0"
+            assert result["k49"] == b"49"
+        finally:
+            await cache.close()
+
+
+class TestPurgeOtherSchemas:
+    @pytest.mark.asyncio
+    async def test_keeps_current_drops_other(self, cache: ScanCache) -> None:
+        try:
+            await cache.put("a", fingerprint="x", schema_version="cur", value=b"1")
+            await cache.put("b", fingerprint="y", schema_version="old", value=b"2")
+            removed = await cache.purge_other_schemas("cur")
+            assert removed == 1
+            assert (
+                await cache.get("a", fingerprint="x", schema_version="cur")
+            ) == b"1"
+            assert (
+                await cache.get("b", fingerprint="y", schema_version="old")
+            ) is None
+        finally:
+            await cache.close()
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_removes_entry(self, cache: ScanCache) -> None:
+        try:
+            await cache.put("k", fingerprint="f", schema_version="s", value=b"v")
+            await cache.delete("k")
+            assert (
+                await cache.get("k", fingerprint="f", schema_version="s")
+            ) is None
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_is_noop(self, cache: ScanCache) -> None:
+        try:
+            await cache.delete("nope")
+        finally:
+            await cache.close()
+
+
+class TestIterEntries:
+    @pytest.mark.asyncio
+    async def test_iter_yields_all_stored(self, cache: ScanCache) -> None:
+        try:
+            await cache.put("a", fingerprint="x", schema_version="s", value=b"1")
+            await cache.put("b", fingerprint="y", schema_version="s", value=b"2")
+            keys = sorted([e.key async for e in cache.iter_entries()])
+            assert keys == ["a", "b"]
+        finally:
+            await cache.close()
+
+
+class TestClosedSemantics:
+    @pytest.mark.asyncio
+    async def test_use_after_close_raises(self, cache: ScanCache) -> None:
+        await cache.close()
+        with pytest.raises(RuntimeError):
+            await cache.put(
+                "k", fingerprint="f", schema_version="s", value=b"v"
+            )
+
+    @pytest.mark.asyncio
+    async def test_double_close_is_noop(self, cache: ScanCache) -> None:
+        await cache.close()
+        await cache.close()
+
+
+class TestDefaultCachePath:
+    def test_uses_xdg_state_home_when_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        assert default_cache_path() == (
+            tmp_path / "pleno" / "cache" / "scan_cache.sqlite"
+        )
+
+    def test_falls_back_to_local_state(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert default_cache_path() == (
+            tmp_path / ".local" / "state" / "pleno" / "cache" / "scan_cache.sqlite"
+        )
+
+    def test_empty_xdg_state_home_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("XDG_STATE_HOME", "")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert default_cache_path() == (
+            tmp_path / ".local" / "state" / "pleno" / "cache" / "scan_cache.sqlite"
+        )
+
+
+class TestSqlitePersistence:
+    @pytest.mark.asyncio
+    async def test_survives_close_and_reopen(self, tmp_path: Path) -> None:
+        path = tmp_path / "c.sqlite"
+        first = await SqliteScanCache.open(path=path)
+        await first.put("k", fingerprint="f", schema_version="s", value=b"v")
+        await first.close()
+        second = await SqliteScanCache.open(path=path)
+        try:
+            assert (
+                await second.get("k", fingerprint="f", schema_version="s")
+            ) == b"v"
+        finally:
+            await second.close()
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c.sqlite"
+        cache = await SqliteScanCache.open(path=nested)
+        try:
+            assert nested.exists()
+        finally:
+            await cache.close()

--- a/packages/pii-scanner/tests/state/test_schema_version.py
+++ b/packages/pii-scanner/tests/state/test_schema_version.py
@@ -1,0 +1,26 @@
+"""schema_version helper — determinism and component sensitivity."""
+
+from __future__ import annotations
+
+from pleno_pii_scanner.state import schema_version
+
+
+class TestSchemaVersion:
+    def test_deterministic_across_calls(self) -> None:
+        assert schema_version() == schema_version()
+
+    def test_extra_components_change_the_hash(self) -> None:
+        base = schema_version()
+        with_extra = schema_version("custom-recognizer-v1")
+        assert base != with_extra
+
+    def test_component_order_matters(self) -> None:
+        # WHY: the runner must invalidate when *any* component flips, so
+        # `(a, b)` and `(b, a)` are intentionally distinct schemas. A
+        # stable ordering keeps the invariant clear.
+        assert schema_version("a", "b") != schema_version("b", "a")
+
+    def test_returns_short_hex(self) -> None:
+        sv = schema_version()
+        assert len(sv) == 32
+        assert all(c in "0123456789abcdef" for c in sv)

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ resolution-markers = [
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer-span = "P1D"
 
 [manifest]
 members = [
@@ -840,7 +840,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -1275,6 +1275,7 @@ sdist = { url = "https://pypi.flatt.tech/files/packages/3c/3f/dbf99fb14bfeb88c28
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://pypi.flatt.tech/files/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://pypi.flatt.tech/files/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
     { url = "https://pypi.flatt.tech/files/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
     { url = "https://pypi.flatt.tech/files/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://pypi.flatt.tech/files/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
@@ -1282,6 +1283,7 @@ wheels = [
     { url = "https://pypi.flatt.tech/files/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
     { url = "https://pypi.flatt.tech/files/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://pypi.flatt.tech/files/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://pypi.flatt.tech/files/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
     { url = "https://pypi.flatt.tech/files/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
     { url = "https://pypi.flatt.tech/files/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://pypi.flatt.tech/files/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
@@ -1289,6 +1291,7 @@ wheels = [
     { url = "https://pypi.flatt.tech/files/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
     { url = "https://pypi.flatt.tech/files/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://pypi.flatt.tech/files/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://pypi.flatt.tech/files/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
     { url = "https://pypi.flatt.tech/files/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
     { url = "https://pypi.flatt.tech/files/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://pypi.flatt.tech/files/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
@@ -1296,6 +1299,7 @@ wheels = [
     { url = "https://pypi.flatt.tech/files/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
     { url = "https://pypi.flatt.tech/files/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://pypi.flatt.tech/files/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://pypi.flatt.tech/files/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
     { url = "https://pypi.flatt.tech/files/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
     { url = "https://pypi.flatt.tech/files/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://pypi.flatt.tech/files/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
@@ -2592,7 +2596,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2603,7 +2607,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2630,9 +2634,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2643,7 +2647,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://pypi.flatt.tech/files/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3329,7 +3333,7 @@ provides-extras = ["training", "hf", "bench"]
 
 [[package]]
 name = "pleno-pii-scanner"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "packages/pii-scanner" }
 dependencies = [
     { name = "aiosmtplib" },
@@ -5180,8 +5184,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.flatt.tech/simple/" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://pypi.flatt.tech/files/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Why

Long-running multi-source scans (nightly org-scan over hundreds of repos, daily Confluence sweeps, hourly DB exports) currently re-walk content that has not changed since the prior run. For an org with 1000 repos where 95% are unchanged day-to-day, that's a daily waste of network, disk, and detector cycles — and the bigger the scan, the bigger the win from caching.

## What

Two-tier content-fingerprinted result cache that survives across \`scan_id\`s:

### Tier 1: Sub-source level
Connectors opt in to the new \`IncrementalSourceConnector\` protocol — they enumerate sub-units cheaply (one network call per repo / channel / drive) tagged with a content fingerprint. Sub-units whose fingerprint matches the cache are skipped entirely; prior findings replay via \`on_findings\` without any download or detector work.

* **github**: \`git ls-remote ... HEAD\` → SHA fingerprint. An unchanged repo never gets cloned.
* **git**: \`git rev-parse HEAD\` for the local repo.
* **Any future connector** (slack channels, gdrive folders, postgres tables, ...) picks this up by implementing the same protocol.

### Tier 2: Document level
Any connector — even those without a hierarchy — gets per-document caching keyed on \`Document.content_hash\` (or SHA-256 of the body when absent).

### Schema versioning
Cached entries are tagged with a \`schema_version\` derived from \`pleno-pii-scanner\` + \`pleno-recognizers\` package versions plus optional caller components. A recognizer update flips the schema and every cached entry auto-invalidates on the next run — no manual wipe, no stale findings risk.

## Parallelism

* \`IncrementalRunner._apply_subsource_skip\` issues a single batched \`ScanCache.get_many\` per plan instead of N round-trips. At 1000 sub-sources this is ~50 ms vs multi-second.
* \`GithubConnector.list_subsources\` fans out HEAD-SHA resolution across 16 worker threads via \`asyncio.gather\`.
* \`_persist_rollups\` parallelises cache.put.
* \`on_findings\` cache-hit replays fan out concurrently.

## CLI

\`\`\`
pleno-pii-scanner scan run <kind> --cache       # default; reuses prior findings
pleno-pii-scanner scan run <kind> --no-cache    # bypass cache entirely
pleno-pii-scanner scan run <kind> --cache-path /custom/path.sqlite
\`\`\`

Output reports cache hit/miss telemetry: \`cache=sub(173/200)/doc(8400/8500)\`.

## Test coverage

* \`MemoryScanCache\` + \`SqliteScanCache\` parity (parametrized).
* Schema-version determinism + invalidation.
* IncrementalRunner: doc-level hit/miss, partial-change subsource skip, schema bump invalidation, errored plan does not poison cache.
* GithubConnector + GitConnector \`IncrementalSourceConnector\` conformance.

Bumps \`pleno-pii-scanner\` to 0.3.0 (new public surface).