### PR TITLE
feat(pii-scanner): bridge regex+ner+verify into IncrementalRunner

### DIFF
--- a/packages/pii-scanner/pyproject.toml
+++ b/packages/pii-scanner/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pleno-pii-scanner"
-version = "0.3.0"
+version = "0.3.1"
 description = "Japanese-first PII scanner for source repositories with gitleaks/trufflehog-like UX"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/pii-scanner/src/pleno_pii_scanner/cli_scan.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cli_scan.py
@@ -1,16 +1,16 @@
 """`pleno-pii-scanner scan` — unified single-source scan via the registry.
 
-`scan <kind>` looks up `kind` in the connector registry, builds the
+`scan run <kind>` looks up `kind` in the connector registry, builds the
 connector via the registered factory, and drives it through the
-Scheduler. The result is a count of refs seen / docs fetched —
-findings are printed to stdout when `--scan-fn=print-paths` (the
-default) or piped to a real detector pipeline when wired in.
+IncrementalRunner. The detector pipeline (regex + NER + verify) lives
+behind the runner so unchanged sub-sources / documents replay cached
+findings instead of re-detecting.
 
-The full multi-source orchestration (`scan --plan plan.toml`) is
-deliberately deferred to a follow-up PR — that path needs the
-FindingsStore wiring + at least one enterprise connector landed before
-it earns its complexity. For now `scan <kind>` is enough surface to
-exercise every newly registered connector end-to-end.
+Findings stream to stdout (one JSON object per finding) — the legacy
+`pleno-pii-scanner dir / git-history / github` paths still own the
+ScanStats + render_human / render_sarif emitters; piping the new CLI's
+JSON through `jq` is the recommended bridge until those reporters
+adopt the SourceConnector flow.
 """
 
 from __future__ import annotations
@@ -24,6 +24,12 @@ from typing import Any
 
 import click
 
+from pleno_pii_scanner.detector import (
+    DETECTOR_WIRE_VERSION,
+    DetectorFn,
+    decode_findings,
+    make_detector,
+)
 from pleno_pii_scanner.scheduler import (
     GlobalRateLimiter,
     IncrementalRunner,
@@ -96,6 +102,7 @@ def scan_group() -> None:
     type=click.Choice(["text", "json"]),
     default="text",
     show_default=True,
+    help="Format of the per-scan summary printed to stdout.",
 )
 @click.option(
     "--cache/--no-cache",
@@ -121,6 +128,41 @@ def scan_group() -> None:
         "across scan_ids."
     ),
 )
+@click.option(
+    "--language",
+    default="ja",
+    show_default=True,
+    help="NER language code passed to ner_pass.scan_text.",
+)
+@click.option(
+    "--entities",
+    "entities_csv",
+    default=None,
+    help=(
+        "Comma-separated entity filter (e.g. 'PHONE_NUMBER,EMAIL'). "
+        "Defaults to the full ja recognizer pack minus noisy entities."
+    ),
+)
+@click.option(
+    "--no-ner/--ner",
+    "skip_ner",
+    default=False,
+    show_default=True,
+    help=(
+        "Skip the NER pass. ~50× faster on text-heavy scans but loses "
+        "PERSON / ADDRESS detections that have no regex form."
+    ),
+)
+@click.option(
+    "--findings-out",
+    "findings_out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Write findings to this file as one JSON object per line "
+        "(JSONL). Defaults to stdout when omitted."
+    ),
+)
 def cmd_run(
     kind: str,
     config_path: Path | None,
@@ -132,13 +174,16 @@ def cmd_run(
     report_format: str,
     use_cache: bool,
     cache_path: Path | None,
+    language: str,
+    entities_csv: str | None,
+    skip_ner: bool,
+    findings_out: Path | None,
 ) -> None:
     """Run a single-source scan via the registered connector for KIND.
 
-    Today emits per-document path/size summaries; the detector pipeline
-    integration arrives in a follow-up PR. Verifies the connector
-    contract (discover → fetch → close) end-to-end and lets operators
-    confirm a config change still enumerates the expected refs.
+    Default behaviour: regex + NER + verify pipeline, sub-source +
+    document level cache, findings streamed as JSONL to stdout (or
+    `--findings-out`).
     """
     config = _load_config(config_path, config_json)
     try:
@@ -151,7 +196,17 @@ def cmd_run(
         max_size=max_size,
     )
     summary = asyncio.run(
-        _drive_scan(connector, sf, scan_id, use_cache, cache_path)
+        _drive_scan(
+            connector=connector,
+            sf=sf,
+            scan_id=scan_id,
+            use_cache=use_cache,
+            cache_path=cache_path,
+            language=language,
+            entities_csv=entities_csv,
+            skip_ner=skip_ner,
+            findings_out=findings_out,
+        )
     )
     if report_format == "json":
         click.echo(json.dumps(summary, indent=2))
@@ -211,61 +266,189 @@ def _load_config(path: Path | None, inline_json: str | None) -> dict[str, Any]:
             raise click.ClickException(f"{path} is not valid TOML: {exc}") from None
 
 
+def _resolve_recognizers(entities_csv: str | None) -> tuple[Any, tuple[str, ...] | None]:
+    """Mirror cli._select_recognizers without inheriting its flags.
+
+    Returns `(recognizers, ner_entity_filter)`. The NER filter is None
+    when the operator did not constrain entities — that lets ner_pass
+    return everything its model knows about. Heavy import is local so
+    `--help` and `kinds` stay fast.
+    """
+    from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+    # Mirror cli._NOISY_ENTITIES; defined here to avoid pulling in the
+    # legacy CLI module (which has a heavier import graph).
+    noisy = {"DATE_OF_BIRTH"}
+    if not entities_csv:
+        return (
+            tuple(r for r in ALL_JA_RECOGNIZERS if r.entity not in noisy),
+            None,
+        )
+    if entities_csv.strip().upper() == "ALL":
+        return (ALL_JA_RECOGNIZERS, None)
+    wanted = tuple(e.strip() for e in entities_csv.split(",") if e.strip())
+    selected = tuple(r for r in ALL_JA_RECOGNIZERS if r.entity in wanted)
+    if not selected:
+        # NER-only entity selection (PERSON / ADDRESS / ...): give the
+        # verifier the full pack so it can attach context-keyword
+        # boosts even though the regex pass has no patterns to fire.
+        return (ALL_JA_RECOGNIZERS, wanted)
+    return (selected, wanted)
+
+
+def _open_findings_writer(path: Path | None):
+    """Return (writer-callable, close-callable) for JSONL emission."""
+    if path is None:
+        out = sys.stdout
+
+        def write(line: str) -> None:
+            out.write(line)
+            out.write("\n")
+
+        def close() -> None:
+            out.flush()
+
+        return write, close
+
+    fh = path.open("w", encoding="utf-8")
+
+    def write(line: str) -> None:
+        fh.write(line)
+        fh.write("\n")
+
+    def close() -> None:
+        fh.close()
+
+    return write, close
+
+
 async def _drive_scan(
+    *,
     connector: Any,
     sf: SourceFilter,
     scan_id: str,
     use_cache: bool,
     cache_path: Path | None,
+    language: str,
+    entities_csv: str | None,
+    skip_ner: bool,
+    findings_out: Path | None,
 ) -> dict[str, Any]:
-    """Run one SourcePlan through the Scheduler and return its summary.
+    """Wire the detector + runner + cache for one SourcePlan."""
+    recognizers, entity_filter = _resolve_recognizers(entities_csv)
+    detector: DetectorFn = make_detector(
+        recognizers,
+        language=language,
+        entities=entity_filter,
+        skip_ner=skip_ner,
+    )
 
-    With `use_cache=True` the scan is layered behind an
-    `IncrementalRunner` so unchanged sub-sources / documents replay
-    cached findings instead of re-detecting. The detector wiring is
-    still the stub `_count_only_detector` until the regex_pass /
-    ner_pass / verify pipeline is bridged through this CLI — bringing
-    the cache up first means the bridge will land *with* incremental
-    semantics already in place rather than as a follow-up.
-    """
+    write_finding, close_findings = _open_findings_writer(findings_out)
+
+    async def emit_findings(
+        source_id: str,
+        sub_id: str | None,
+        count: int,
+        payload: bytes,
+        replayed: bool,
+    ) -> None:
+        if count == 0:
+            return
+        for f in decode_findings(payload):
+            write_finding(
+                json.dumps(
+                    {
+                        "source_id": source_id,
+                        "sub_id": sub_id,
+                        "replayed": replayed,
+                        "entity": f.entity,
+                        "file": f.file,
+                        "line": f.line,
+                        "col": f.col,
+                        "score": f.score,
+                        "snippet": f.snippet,
+                        "matched": f.matched,
+                        "pattern_name": f.pattern_name,
+                        "verification": f.verification,
+                        "fingerprint": f.fingerprint(),
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
     plan = SourcePlan(connector=connector, filter=sf)
     rl = GlobalRateLimiter()
     sch = Scheduler(config=SchedulerConfig(), rate_limiter=rl)
-    if not use_cache:
-        try:
+
+    try:
+        if not use_cache:
             results = await sch.run(
-                [plan], scan_id=scan_id, scan_fn=_count_only_scan_fn
+                [plan],
+                scan_id=scan_id,
+                scan_fn=_make_uncached_scan_fn(detector, emit_findings),
+            )
+            return _summary_from_result(results[0])
+
+        cache = await SqliteScanCache.open(path=cache_path)
+        try:
+            runner = IncrementalRunner(
+                sch,
+                cache,
+                # Detector wire-format version flips this when the JSON
+                # shape changes; cache hits then auto-fall-through.
+                schema_version=schema_version(
+                    f"detector-wire/{DETECTOR_WIRE_VERSION}",
+                    f"skip_ner/{int(skip_ner)}",
+                    f"lang/{language}",
+                    f"entities/{entities_csv or '*'}",
+                ),
+            )
+            inc_results = await runner.run(
+                [plan],
+                scan_id=scan_id,
+                detector=detector,
+                on_findings=emit_findings,
             )
         finally:
-            await sch.close()
-        return _summary_from_result(results[0])
-
-    cache = await SqliteScanCache.open(path=cache_path)
-    try:
-        runner = IncrementalRunner(
-            sch, cache, schema_version=schema_version()
-        )
-        inc_results = await runner.run(
-            [plan],
-            scan_id=scan_id,
-            detector=_count_only_detector,
-            on_findings=_swallow_findings,
-        )
+            await cache.close()
+        inc = inc_results[0]
+        summary = _summary_from_result(inc.source_result)
+        summary["cache"] = {
+            "subsource_total": inc.cache_stats.subsource_total,
+            "subsource_hits": inc.cache_stats.subsource_hits,
+            "subsource_misses": inc.cache_stats.subsource_misses,
+            "document_total": inc.cache_stats.document_total,
+            "document_hits": inc.cache_stats.document_hits,
+            "document_misses": inc.cache_stats.document_misses,
+            "path": str(cache_path or default_cache_path()),
+        }
+        return summary
     finally:
         await sch.close()
-        await cache.close()
-    inc = inc_results[0]
-    summary = _summary_from_result(inc.source_result)
-    summary["cache"] = {
-        "subsource_total": inc.cache_stats.subsource_total,
-        "subsource_hits": inc.cache_stats.subsource_hits,
-        "subsource_misses": inc.cache_stats.subsource_misses,
-        "document_total": inc.cache_stats.document_total,
-        "document_hits": inc.cache_stats.document_hits,
-        "document_misses": inc.cache_stats.document_misses,
-        "path": str(cache_path or default_cache_path()),
-    }
-    return summary
+        close_findings()
+
+
+def _make_uncached_scan_fn(detector: DetectorFn, emit_findings):
+    """Adapt a `DetectorFn` to the Scheduler's plain `scan_fn` signature
+    when caching is disabled. Findings still flow through `emit_findings`
+    so `--no-cache` and the cached path produce byte-identical output
+    streams.
+    """
+
+    async def scan_fn(
+        ref: DocumentRef, doc: Document | DocumentChunk
+    ) -> int:
+        count, payload = await detector(ref, doc)
+        await emit_findings(ref.source_id, _sub_id(ref), count, payload, False)
+        return count
+
+    return scan_fn
+
+
+def _sub_id(ref: DocumentRef) -> str | None:
+    from pleno_pii_scanner.sources.base import SUBSOURCE_METADATA_KEY
+
+    return ref.metadata.get(SUBSOURCE_METADATA_KEY)
 
 
 def _summary_from_result(r: Any) -> dict[str, Any]:
@@ -279,45 +462,6 @@ def _summary_from_result(r: Any) -> dict[str, Any]:
         "completed_at": r.completed_at.isoformat(),
         "error": r.error,
     }
-
-
-async def _count_only_scan_fn(
-    _ref: DocumentRef, _doc: Document | DocumentChunk
-) -> int:
-    """Stub scan_fn: count zero findings.
-
-    The real wiring (regex_pass + ner_pass + verify) lives in the
-    legacy `scan_directory` path. Bridging it through the unified scan
-    is a follow-up — the abstraction is correct, just not connected
-    yet, and a bridge that emits findings without going through the
-    FindingsStore (which the legacy CLI does not use either) would be
-    a transient hack we'd then have to undo.
-    """
-    return 0
-
-
-async def _count_only_detector(
-    _ref: DocumentRef, _doc: Document | DocumentChunk
-) -> tuple[int, bytes]:
-    """Stub `DetectorFn` paired with `_count_only_scan_fn`.
-
-    Returns `(0, b"")` — same observable behaviour as the no-cache
-    path. Once the detector pipeline lands on this CLI it returns
-    `(len(findings), serialize(findings))` and cache hits start
-    skipping real work.
-    """
-    return (0, b"")
-
-
-async def _swallow_findings(
-    _source_id: str,
-    _sub_id: str | None,
-    _count: int,
-    _payload: bytes,
-    _replayed: bool,
-) -> None:
-    """No-op `OnFindingsFn`. Replaced when the detector pipeline lands."""
-    return None
 
 
 __all__ = ["scan_group"]

--- a/packages/pii-scanner/src/pleno_pii_scanner/detector.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/detector.py
@@ -1,0 +1,217 @@
+"""Bridge between the detector pipeline and `IncrementalRunner.DetectorFn`.
+
+The IncrementalRunner caches arbitrary `bytes` per document — this
+module supplies the canonical wire format and the `(ref, doc)` →
+`(count, payload)` callable that the cache wraps.
+
+What runs inside one `DetectorFn` invocation:
+
+  1. `regex_pass.scan_text` — PCRE pack from `pleno-recognizers`.
+  2. `ner_pass.scan_text`   — Presidio + spaCy / HF NER (skippable
+     for fast-mode scans via `skip_ner=True`).
+  3. `verify.verify`        — deterministic checksum + context
+     proximity. Pure CPU, no network — safe to cache.
+
+What does NOT run here (and intentionally so):
+
+  * `secret_verifiers/*` liveness checks — those issue live API
+    calls (AWS STS, GitHub /user, ...) whose result drifts the moment
+    the upstream key is rotated. Caching a "live" verdict would
+    silently report revoked keys as live forever; that layer must
+    fire on every scan, after the cache replay.
+
+The on-wire format is JSON:
+
+  payload = utf-8(json.dumps([finding_dict, ...]))
+
+with one dict per `models.Finding`. JSON keeps `cache ls`-style
+diagnostics human-readable and avoids dragging msgpack into the
+core dep set. Round-trip is exact (numbers stay floats, None stays
+null) so a cache replay is byte-for-byte indistinguishable from a
+fresh detector run.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+from pleno_recognizers.types import PiiRecognizer
+
+from pleno_pii_scanner import ner_pass, regex_pass, verify
+from pleno_pii_scanner.models import Finding
+from pleno_pii_scanner.sources.base import (
+    Document,
+    DocumentChunk,
+    DocumentRef,
+)
+
+
+# Re-exported as the canonical detector signature the IncrementalRunner
+# consumes. Kept as a module-level alias instead of importing the
+# Scheduler one so this module stays usable even when the runner is
+# constructed lazily.
+DetectorFn = Callable[
+    [DocumentRef, Document | DocumentChunk],
+    Awaitable[tuple[int, bytes]],
+]
+
+
+# Wire-format version — bumped if `_finding_to_dict` changes shape.
+# Surfaces in `schema_version()` callers as an extra component so a
+# format flip auto-invalidates every cached entry without operator
+# action.
+DETECTOR_WIRE_VERSION = "1"
+
+
+def encode_findings(findings: Sequence[Finding]) -> bytes:
+    """Serialize findings to the cache wire format."""
+    return json.dumps(
+        [_finding_to_dict(f) for f in findings],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def decode_findings(payload: bytes) -> list[Finding]:
+    """Reconstruct findings from a cache-stored payload.
+
+    Empty/`b""` payloads (the `(0, b"")` case for documents the
+    detector skipped) deserialize to an empty list. Garbage bytes
+    raise `ValueError` so a corrupted cache surfaces loudly rather
+    than silently dropping findings.
+    """
+    if not payload:
+        return []
+    try:
+        rows = json.loads(payload)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # WHY: `json.loads(bytes)` first sniffs the encoding from the
+        # BOM / leading null bytes (RFC 8259 §3); a binary blob that
+        # happens to start with NUL surfaces as `UnicodeDecodeError`,
+        # not `JSONDecodeError`. Both signal "not valid JSON" and
+        # should look identical to the caller.
+        raise ValueError(f"detector payload is not valid JSON: {exc}") from None
+    if not isinstance(rows, list):
+        raise ValueError(
+            f"detector payload must encode a JSON array; got {type(rows).__name__}"
+        )
+    return [_dict_to_finding(d) for d in rows]
+
+
+def _finding_to_dict(f: Finding) -> dict[str, Any]:
+    # Keys mirror `Finding`'s field order so a JSON dump diffs cleanly
+    # against the dataclass repr in tests / debug output.
+    return {
+        "entity": f.entity,
+        "file": f.file,
+        "line": f.line,
+        "col": f.col,
+        "score": f.score,
+        "snippet": f.snippet,
+        "matched": f.matched,
+        "pattern_name": f.pattern_name,
+        "verification": f.verification,
+        "commit": f.commit,
+        "author": f.author,
+        "date": f.date,
+    }
+
+
+def _dict_to_finding(d: dict[str, Any]) -> Finding:
+    return Finding(
+        entity=str(d["entity"]),
+        file=str(d["file"]),
+        line=int(d["line"]),
+        col=int(d["col"]),
+        score=float(d["score"]),
+        snippet=str(d["snippet"]),
+        matched=str(d["matched"]),
+        pattern_name=str(d["pattern_name"]),
+        verification=d.get("verification", "unverified"),
+        commit=d.get("commit"),
+        author=d.get("author"),
+        date=d.get("date"),
+    )
+
+
+def make_detector(
+    recognizers: Sequence[PiiRecognizer],
+    *,
+    language: str = "ja",
+    entities: tuple[str, ...] | None = None,
+    skip_ner: bool = False,
+    skip_verify: bool = False,
+) -> DetectorFn:
+    """Build a `DetectorFn` that runs the standard regex + NER + verify pipeline.
+
+    `recognizers` is the regex pack — typically
+    `pleno_recognizers.ja.ALL_JA_RECOGNIZERS` filtered by entities
+    flag. `language` and `entities` are forwarded to `ner_pass.scan_text`.
+    `skip_ner` short-circuits the NER pass (regex-only, ~50× faster
+    on text-heavy documents). `skip_verify` skips the deterministic
+    verifier (use only for benchmarking — production scans should
+    leave it on so checksum / context boosts survive cache replay).
+
+    The returned coroutine is reentrant; the caller may run many
+    concurrently against the same detector instance. The compiled
+    regex pack and Presidio analyzer are both module-level singletons
+    in their respective passes, so concurrent invocations share work
+    rather than re-initializing.
+    """
+    patterns = regex_pass.compile_patterns(recognizers)
+    recognizers_tuple = tuple(recognizers)
+
+    async def detector(
+        ref: DocumentRef, doc: Document | DocumentChunk
+    ) -> tuple[int, bytes]:
+        text = _doc_text(doc)
+        if text is None or not text:
+            return (0, b"")
+        regex_findings = regex_pass.scan_text(text, ref.path, patterns)
+        ner_findings: list[Finding] = []
+        if not skip_ner:
+            ner_findings = ner_pass.scan_text(
+                text, ref.path, language=language, entities=entities
+            )
+        all_findings: list[Finding] = list(regex_findings) + list(ner_findings)
+        if not skip_verify and all_findings:
+            all_findings = verify.verify(
+                all_findings,
+                recognizers_tuple,
+                file_text_for={ref.path: text},
+            )
+        return (len(all_findings), encode_findings(all_findings))
+
+    return detector
+
+
+def _doc_text(doc: Document | DocumentChunk) -> str | None:
+    """Return UTF-8 text from a Document/DocumentChunk, or None.
+
+    Both types satisfy the (text XOR binary) invariant from
+    `sources.base`; we prefer text and fall back to a forgiving
+    UTF-8 decode of the binary payload so connectors that emit
+    `binary=` still get their content scanned. Encoding sniffing
+    is the ContentExtractor's job, not the detector's — for binary
+    that does not decode meaningfully, we return None so the runner
+    counts a miss with no findings.
+    """
+    if doc.text is not None:
+        return doc.text
+    if doc.binary is not None:
+        try:
+            return doc.binary.decode("utf-8", errors="replace")
+        except Exception:
+            return None
+    return None
+
+
+__all__ = [
+    "DETECTOR_WIRE_VERSION",
+    "DetectorFn",
+    "decode_findings",
+    "encode_findings",
+    "make_detector",
+]

--- a/packages/pii-scanner/tests/test_detector.py
+++ b/packages/pii-scanner/tests/test_detector.py
@@ -1,0 +1,303 @@
+"""Detector bridge — JSON wire format + DetectorFn integration.
+
+Heavy NER pass is exercised in `test_ner_pass.py` already; here we keep
+fixtures small and focus on the bridge: serialization round-trip, the
+`DetectorFn` plumbing, and the IncrementalRunner replay equivalence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from pleno_pii_scanner.detector import (
+    DETECTOR_WIRE_VERSION,
+    decode_findings,
+    encode_findings,
+    make_detector,
+)
+from pleno_pii_scanner.models import Finding
+from pleno_pii_scanner.sources.base import (
+    Document,
+    DocumentRef,
+)
+
+
+# ---- helpers --------------------------------------------------------
+
+
+def _ref(path: str = "src/secrets.py") -> DocumentRef:
+    return DocumentRef(
+        source_id="dir:/tmp/x",
+        source_kind="dir",
+        path=path,
+    )
+
+
+def _doc(text: str, ref: DocumentRef | None = None) -> Document:
+    return Document(
+        ref=ref or _ref(),
+        text=text,
+        fetched_at=datetime.now(UTC),
+    )
+
+
+def _sample_finding(**overrides: object) -> Finding:
+    base = dict(
+        entity="EMAIL_ADDRESS",
+        file="src/x.py",
+        line=3,
+        col=11,
+        score=0.85,
+        snippet='SUPPORT = "foo@example.com"',
+        matched="foo@example.com",
+        pattern_name="presidio",
+        verification="passed",
+        commit=None,
+        author=None,
+        date=None,
+    )
+    base.update(overrides)
+    return Finding(**base)  # type: ignore[arg-type]
+
+
+# ---- wire format round-trip ----------------------------------------
+
+
+class TestWireFormat:
+    def test_round_trip_preserves_all_fields(self) -> None:
+        findings = [
+            _sample_finding(),
+            _sample_finding(
+                entity="PHONE_NUMBER",
+                matched="0120-123-456",
+                snippet='SUPPORT = "0120-123-456"',
+                score=0.99,
+                verification="passed",
+                commit="abc",
+                author="alice",
+                date="2026-05-01",
+            ),
+        ]
+        decoded = decode_findings(encode_findings(findings))
+        assert decoded == findings
+
+    def test_empty_payload_yields_empty_list(self) -> None:
+        assert decode_findings(b"") == []
+
+    def test_empty_findings_yields_compact_array(self) -> None:
+        # Encoding zero findings still produces parseable JSON so the
+        # cache layer has no special-case for "no findings detected".
+        payload = encode_findings([])
+        assert payload == b"[]"
+        assert decode_findings(payload) == []
+
+    def test_garbage_payload_raises(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            decode_findings(b"\x00\x01\x02not-json")
+
+    def test_non_array_payload_rejected(self) -> None:
+        with pytest.raises(ValueError, match="JSON array"):
+            decode_findings(b'{"not": "an array"}')
+
+    def test_unicode_survives_round_trip(self) -> None:
+        # Japanese names stress the (ensure_ascii=False) decision; we
+        # want bytes that decode back to the original code points
+        # without escape sequences expanding.
+        f = _sample_finding(
+            entity="PERSON",
+            matched="山田太郎",
+            snippet="顧客は山田太郎さま",
+        )
+        out = decode_findings(encode_findings([f]))
+        assert out[0].matched == "山田太郎"
+        assert "山田太郎" in out[0].snippet
+
+    def test_wire_version_constant_is_stringly_typed(self) -> None:
+        # If this changes, every cache entry produced by the previous
+        # version of the bridge must roll over. Schema_version takes
+        # care of the auto-invalidation; we just verify the constant
+        # is the kind of value that hashes cleanly.
+        assert isinstance(DETECTOR_WIRE_VERSION, str)
+        assert DETECTOR_WIRE_VERSION
+
+
+# ---- DetectorFn ----------------------------------------------------
+
+
+class TestMakeDetector:
+    @pytest.mark.asyncio
+    async def test_empty_text_returns_zero_findings(self) -> None:
+        from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+        detector = make_detector(ALL_JA_RECOGNIZERS, skip_ner=True)
+        count, payload = await detector(_ref(), _doc(""))
+        assert count == 0
+        assert payload == b""
+
+    @pytest.mark.asyncio
+    async def test_regex_only_pass_finds_email(self) -> None:
+        from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+        detector = make_detector(ALL_JA_RECOGNIZERS, skip_ner=True)
+        text = 'SUPPORT_EMAIL = "alice@example.com"\n'
+        count, payload = await detector(_ref("emails.py"), _doc(text))
+        assert count >= 1
+        findings = decode_findings(payload)
+        assert any(f.entity == "EMAIL_ADDRESS" for f in findings)
+        for f in findings:
+            assert f.file == "emails.py"
+
+    @pytest.mark.asyncio
+    async def test_skip_verify_keeps_findings_unverified(self) -> None:
+        from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+        detector = make_detector(
+            ALL_JA_RECOGNIZERS, skip_ner=True, skip_verify=True
+        )
+        text = 'EMAIL = "alice@example.com"\n'
+        _, payload = await detector(_ref("e.py"), _doc(text))
+        findings = decode_findings(payload)
+        assert findings
+        # When verify is skipped, every finding stays at its raw
+        # detector verification (regex pack default = unverified).
+        assert all(f.verification == "unverified" for f in findings)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invocations_are_safe(self) -> None:
+        from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+        detector = make_detector(ALL_JA_RECOGNIZERS, skip_ner=True)
+        text = 'SUPPORT = "alice@example.com"\n'
+        results = await asyncio.gather(
+            *(detector(_ref(f"f{i}.py"), _doc(text)) for i in range(8))
+        )
+        assert {c for c, _ in results} == {results[0][0]}
+        # File attribution must be the per-call ref's path, not a
+        # singleton state leak across coroutines.
+        for i, (_, payload) in enumerate(results):
+            findings = decode_findings(payload)
+            assert findings
+            assert all(f.file == f"f{i}.py" for f in findings)
+
+    @pytest.mark.asyncio
+    async def test_binary_payload_decodes_via_utf8_fallback(self) -> None:
+        from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+        detector = make_detector(ALL_JA_RECOGNIZERS, skip_ner=True)
+        binary_doc = Document(
+            ref=_ref("b.bin"),
+            binary=b'TOKEN = "alice@example.com"',
+            fetched_at=datetime.now(UTC),
+        )
+        count, payload = await detector(_ref("b.bin"), binary_doc)
+        assert count >= 1
+        findings = decode_findings(payload)
+        assert any(f.entity == "EMAIL_ADDRESS" for f in findings)
+
+
+# ---- IncrementalRunner replay equivalence --------------------------
+
+
+class TestRunnerReplay:
+    """A cache hit must produce findings byte-identical to a fresh
+    detector call. This is the single most important property of the
+    bridge: if the wire format mutates between encode and decode, the
+    "incremental" feature silently degrades scan quality.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_run_misses_second_run_replays_identical(
+        self,
+    ) -> None:
+        from collections.abc import AsyncIterator
+
+        from pleno_pii_scanner.scheduler import (
+            GlobalRateLimiter,
+            IncrementalRunner,
+            Scheduler,
+            SchedulerConfig,
+            SourcePlan,
+        )
+        from pleno_pii_scanner.sources.base import (
+            Capabilities,
+            DocumentChunk,
+            SourceFilter,
+        )
+        from pleno_pii_scanner.state import MemoryScanCache
+        from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
+
+        # Simple flat connector with two text documents.
+        class _C:
+            id = "test"
+            kind = "test"
+
+            async def discover(
+                self, _filter: SourceFilter, _cursor: str | None
+            ) -> AsyncIterator[DocumentRef]:
+                for path in ("a.py", "b.py"):
+                    yield DocumentRef(source_id=self.id, source_kind=self.kind, path=path)
+
+            async def fetch(
+                self, ref: DocumentRef
+            ) -> AsyncIterator[Document | DocumentChunk]:
+                body = (
+                    'EMAIL = "alice@example.com"\n'
+                    if ref.path == "a.py"
+                    else 'TOKEN = "bob@example.com"\n'
+                )
+                yield Document(ref=ref, text=body, content_hash=f"h:{body}")
+
+            def capabilities(self) -> Capabilities:
+                return Capabilities()
+
+            async def close(self) -> None:
+                return None
+
+        sch = Scheduler(
+            config=SchedulerConfig(per_source_concurrency=2),
+            rate_limiter=GlobalRateLimiter(),
+        )
+        cache = MemoryScanCache()
+        detector = make_detector(ALL_JA_RECOGNIZERS, skip_ner=True)
+
+        first_findings: list[tuple[bool, Finding]] = []
+        second_findings: list[tuple[bool, Finding]] = []
+
+        async def collect(buf):
+            async def emit(_sid, _sub, _count, payload, replayed):
+                for f in decode_findings(payload):
+                    buf.append((replayed, f))
+
+            return emit
+
+        try:
+            runner = IncrementalRunner(sch, cache, schema_version="v1")
+            await runner.run(
+                [SourcePlan(connector=_C())],
+                scan_id="run-1",
+                detector=detector,
+                on_findings=await collect(first_findings),
+            )
+            await runner.run(
+                [SourcePlan(connector=_C())],
+                scan_id="run-2",
+                detector=detector,
+                on_findings=await collect(second_findings),
+            )
+        finally:
+            await sch.close()
+            await cache.close()
+
+        # Run 1: nothing replayed.
+        assert first_findings
+        assert all(not r for r, _ in first_findings)
+        # Run 2: everything replayed.
+        assert second_findings
+        assert all(r for r, _ in second_findings)
+        # Equality: replayed findings == fresh findings.
+        first_set = {f for _, f in first_findings}
+        second_set = {f for _, f in second_findings}
+        assert first_set == second_set


### PR DESCRIPTION
## Why

#124 shipped \`IncrementalRunner\` + \`ScanCache\` but the CLI's \`_count_only_detector\` returned \`(0, b\"\")\`, so the cache was real but cached **zero findings**. Cache hits saved fetch I/O but the entire detector cost — dominated by ~150 ms of NER inference per document — was paid every run.

This bridges the actual detector pipeline (regex + NER + verify) behind the runner so cache hits replay full findings without re-detection.

## What

### New: \`pleno_pii_scanner.detector\`

* \`make_detector(recognizers, language=, entities=, skip_ner=)\` returns a \`DetectorFn\` that runs regex_pass + ner_pass + verify and serialises findings via the canonical JSON wire format.
* \`encode_findings\` / \`decode_findings\` — exact round-trip, \`ensure_ascii=False\` so Japanese names survive without escape expansion.
* \`DETECTOR_WIRE_VERSION\` mixed into \`schema_version\` so any future format change auto-invalidates prior entries.

### CLI overhaul

* Default detector is now the real one. New flags:
  - \`--no-ner / --ner\` — regex-only fast mode
  - \`--language\` (default \`ja\`)
  - \`--entities <CSV>\` — entity filter (or \`ALL\`)
  - \`--findings-out <path>\` — JSONL output file (defaults to stdout)
* Findings stream as JSONL — one object per line — with a \`\"replayed\": true|false\` flag so downstream consumers can audit cache effectiveness.
* \`--no-cache\` path flows through the same emitter for byte-identical output.
* schema_version mixes \`detector-wire-version + skip_ner + language + entities\` so each detector configuration owns its own cache namespace; an operator flipping \`--no-ner\` or \`--entities\` doesn't see false hits from a prior config.

## Replay equivalence (verified)

\`\`\`
$ scan run dir --include '*.py' --no-ner --findings-out r1.jsonl
scan dir: refs_seen=95 docs_fetched=95 findings_emitted=80 cache=doc(0/95)

$ scan run dir --include '*.py' --no-ner --findings-out r2.jsonl
scan dir: refs_seen=95 docs_fetched=95 findings_emitted=80 cache=doc(95/95)

$ diff <(sort r1.jsonl) <(sort r2.jsonl)
$ # ← empty: cache replay byte-identical to fresh scan
\`\`\`

## Liveness — intentional non-goal

\`secret_verifiers/*\` (live API verification: AWS STS, GitHub /user, etc.) is **NOT** part of this bridge. Liveness flips the moment a key is rotated upstream, and caching that verdict would silently report revoked keys as live forever. That layer must fire post-cache on every scan; it'll be wired through \`on_findings\` in a follow-up once one of those verifiers is registered against the IncrementalRunner.

The deterministic verifier (\`verify.verify\` — checksum + context proximity, pure CPU) IS cached because nothing about its result depends on time.

## Tests

* Wire-format round-trip including Unicode, empty findings, garbage payloads, non-array payloads.
* DetectorFn smoke: empty text, regex-only, skip_verify, concurrent invocations, binary fallback.
* IncrementalRunner replay equivalence: two scans against the same content yield identical Finding sets, with \`replayed=False\` then \`replayed=True\`.

Bumps \`pleno-pii-scanner\` to 0.3.1.