### PR TITLE
chore: fix repo-wide ruff lint + format drift to unblock CI

### DIFF
--- a/packages/pii-scanner-aws/src/pleno_pii_scanner_aws/auth.py
+++ b/packages/pii-scanner-aws/src/pleno_pii_scanner_aws/auth.py
@@ -270,9 +270,7 @@ class HopRunner:
 class _RealHopRunner(HopRunner):
     """Production HopRunner: uses STS via aioboto3."""
 
-    async def start(
-        self, session: aioboto3.Session, region: str
-    ) -> AwsCredentials:
+    async def start(self, session: aioboto3.Session, region: str) -> AwsCredentials:
         # Materialize the base session into AwsCredentials so the chain
         # walker can treat the seed and hop results uniformly. For the
         # default chain (no explicit keys) aioboto3 may resolve creds
@@ -345,9 +343,7 @@ class StubHopRunner(HopRunner):
     hops: list[AwsCredentials] = field(default_factory=list)
     calls: list[tuple[AssumeRoleHop, str]] = field(default_factory=list)
 
-    async def start(
-        self, session: aioboto3.Session, region: str
-    ) -> AwsCredentials:
+    async def start(self, session: aioboto3.Session, region: str) -> AwsCredentials:
         del session, region
         return self.seed
 

--- a/packages/pii-scanner-aws/src/pleno_pii_scanner_aws/s3.py
+++ b/packages/pii-scanner-aws/src/pleno_pii_scanner_aws/s3.py
@@ -31,7 +31,7 @@ import io
 import json
 import logging
 from collections.abc import AsyncIterator, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -277,7 +277,9 @@ class S3Connector:
                 async for ref in self._discover_bucket(
                     plan,
                     floor,
-                    decoded if idx == decoded.bucket_index else _Cursor(bucket_index=idx),
+                    decoded
+                    if idx == decoded.bucket_index
+                    else _Cursor(bucket_index=idx),
                 ):
                     yield ref
 
@@ -300,7 +302,9 @@ class S3Connector:
 
         creds = await self._sessions.credentials_for(plan.account)
         session = self._sessions.base_session()
-        async with self._client_factory(session, creds, plan.account, plan.bucket) as s3:
+        async with self._client_factory(
+            session, creds, plan.account, plan.bucket
+        ) as s3:
             if plan.sample:
                 async for ref in self._discover_sampled(s3, plan, floor, cursor):
                     yield ref
@@ -337,7 +341,11 @@ class S3Connector:
                 ref = _ref_from_listing_entry(self.id, plan, entry, version_id=None)
                 if ref is None:
                     continue
-                if floor is not None and ref.last_modified is not None and ref.last_modified <= floor:
+                if (
+                    floor is not None
+                    and ref.last_modified is not None
+                    and ref.last_modified <= floor
+                ):
                     continue
                 yield _attach_cursor(
                     ref,
@@ -382,7 +390,11 @@ class S3Connector:
                 )
                 if ref is None:
                     continue
-                if floor is not None and ref.last_modified is not None and ref.last_modified <= floor:
+                if (
+                    floor is not None
+                    and ref.last_modified is not None
+                    and ref.last_modified <= floor
+                ):
                     continue
                 yield _attach_cursor(
                     ref,
@@ -434,7 +446,11 @@ class S3Connector:
                 ref = _ref_from_listing_entry(self.id, plan, entry, version_id=None)
                 if ref is None:
                     continue
-                if floor is not None and ref.last_modified is not None and ref.last_modified <= floor:
+                if (
+                    floor is not None
+                    and ref.last_modified is not None
+                    and ref.last_modified <= floor
+                ):
                     continue
                 sampler.offer(ref)
             if not resp.get("IsTruncated"):
@@ -459,7 +475,9 @@ class S3Connector:
         creds = await self._sessions.credentials_for(plan.account)
         session = self._sessions.base_session()
         manifest_bucket, manifest_key = _parse_s3_uri(manifest_uri)
-        async with self._client_factory(session, creds, plan.account, plan.bucket) as s3:
+        async with self._client_factory(
+            session, creds, plan.account, plan.bucket
+        ) as s3:
             manifest = await _read_manifest(s3, manifest_bucket, manifest_key)
             for shard in manifest.get("files", ()):
                 shard_key = shard["key"]
@@ -476,9 +494,7 @@ class S3Connector:
                         continue
                     yield ref
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         """Retrieve `ref`'s payload as a Document or DocumentChunk stream.
 
         The (account, bucket) pair is rebuilt from `ref.metadata`; we put
@@ -501,7 +517,9 @@ class S3Connector:
         size = ref.size or 0
         async with self._client_factory(session, creds, account, bucket) as s3:
             if size and size <= self._config.max_doc_bytes:
-                async for piece in self._fetch_whole(s3, bucket_name, key, version_id, ref):
+                async for piece in self._fetch_whole(
+                    s3, bucket_name, key, version_id, ref
+                ):
                     yield piece
             else:
                 async for piece in self._fetch_chunked(
@@ -628,8 +646,7 @@ class ClientFactory:  # pragma: no cover - structural typing alias
         creds: Any,
         account: AccountSpec,
         bucket: BucketSpec,
-    ) -> Any:
-        ...
+    ) -> Any: ...
 
 
 def _default_client_factory(
@@ -849,7 +866,9 @@ def _iter_inventory_rows(
     text too so test fixtures can avoid the gzip dance. The column names
     come from `manifest["fileSchema"]` (a comma-separated string).
     """
-    schema = [c.strip() for c in str(manifest.get("fileSchema", "")).split(",") if c.strip()]
+    schema = [
+        c.strip() for c in str(manifest.get("fileSchema", "")).split(",") if c.strip()
+    ]
     text: str
     if raw[:2] == b"\x1f\x8b":  # gzip magic
         import gzip
@@ -903,13 +922,9 @@ def _maybe_raise_rate_limited(exc: BaseException) -> None:
     error = response.get("Error", {})
     code = error.get("Code") if isinstance(error, Mapping) else None
     metadata = response.get("ResponseMetadata", {})
-    status = (
-        metadata.get("HTTPStatusCode") if isinstance(metadata, Mapping) else None
-    )
+    status = metadata.get("HTTPStatusCode") if isinstance(metadata, Mapping) else None
     if code in _THROTTLE_CODES or status in _THROTTLE_STATUS:
-        raise RateLimited(
-            f"S3 throttled (code={code} status={status})"
-        ) from exc
+        raise RateLimited(f"S3 throttled (code={code} status={status})") from exc
 
 
 # --- factory + spec --------------------------------------------------------

--- a/packages/pii-scanner-aws/tests/_fakes.py
+++ b/packages/pii-scanner-aws/tests/_fakes.py
@@ -74,7 +74,10 @@ class FakeS3Client:
         if len(self.calls) > self._throttle_after:
             raise _ClientError(
                 {
-                    "Error": {"Code": "SlowDown", "Message": "Reduce your request rate"},
+                    "Error": {
+                        "Code": "SlowDown",
+                        "Message": "Reduce your request rate",
+                    },
                     "ResponseMetadata": {"HTTPStatusCode": 503},
                 }
             )
@@ -100,7 +103,9 @@ class FakeS3Client:
             start = int(ContinuationToken)
         page = items[start : start + self._page_size]
         next_token = (
-            str(start + self._page_size) if start + self._page_size < len(items) else None
+            str(start + self._page_size)
+            if start + self._page_size < len(items)
+            else None
         )
         return {
             "Contents": [
@@ -140,7 +145,9 @@ class FakeS3Client:
             start = int(KeyMarker)
         page = items[start : start + self._page_size]
         next_marker = (
-            str(start + self._page_size) if start + self._page_size < len(items) else None
+            str(start + self._page_size)
+            if start + self._page_size < len(items)
+            else None
         )
         return {
             "Versions": [
@@ -168,7 +175,10 @@ class FakeS3Client:
         **_: Any,
     ) -> dict[str, Any]:
         self.calls.append(
-            ("get_object", {"Bucket": Bucket, "Key": Key, "Range": Range, "VersionId": VersionId})
+            (
+                "get_object",
+                {"Bucket": Bucket, "Key": Key, "Range": Range, "VersionId": VersionId},
+            )
         )
         self._maybe_throttle()
         for o in self._objects.get(Bucket, []):

--- a/packages/pii-scanner-aws/tests/test_auth.py
+++ b/packages/pii-scanner-aws/tests/test_auth.py
@@ -240,7 +240,9 @@ class TestAwsSessionFactory:
         from botocore.exceptions import ProfileNotFound
 
         f = AwsSessionFactory(
-            base=AwsBaseIdentity(profile_name="__nonexistent_profile__", region="us-west-2")
+            base=AwsBaseIdentity(
+                profile_name="__nonexistent_profile__", region="us-west-2"
+            )
         )
         try:
             session = f.base_session()
@@ -344,7 +346,10 @@ class TestRealHopRunnerAssume:
 
         runner = auth_mod._RealHopRunner()
         prev = AwsCredentials(
-            access_key_id="P", secret_access_key="P", session_token="t", region="us-east-1"
+            access_key_id="P",
+            secret_access_key="P",
+            session_token="t",
+            region="us-east-1",
         )
         hop = AssumeRoleHop(
             provider="aws",

--- a/packages/pii-scanner-aws/tests/test_s3.py
+++ b/packages/pii-scanner-aws/tests/test_s3.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import gzip
-import io
 import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -82,9 +81,7 @@ class TestS3Config:
 
     def test_requires_buckets(self) -> None:
         with pytest.raises(ValueError, match="buckets"):
-            S3Config(
-                accounts=(AccountSpec(account_id="1"),), buckets=()
-            )
+            S3Config(accounts=(AccountSpec(account_id="1"),), buckets=())
 
     def test_invalid_max_doc_bytes(self) -> None:
         with pytest.raises(ValueError):
@@ -105,7 +102,11 @@ class TestS3Config:
 
 class TestCursor:
     def test_round_trip(self) -> None:
-        c = _Cursor(bucket_index=2, continuation_token="t", last_modified_floor="2024-01-01T00:00:00+00:00")
+        c = _Cursor(
+            bucket_index=2,
+            continuation_token="t",
+            last_modified_floor="2024-01-01T00:00:00+00:00",
+        )
         again = _Cursor.loads(c.dumps())
         assert again == c
 
@@ -123,7 +124,9 @@ class TestProtocolCompliance:
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
-        c = S3Connector(_config([BucketSpec(name="b")], concurrency=8), _factory_creds())
+        c = S3Connector(
+            _config([BucketSpec(name="b")], concurrency=8), _factory_creds()
+        )
         caps = c.capabilities()
         assert caps == Capabilities(
             incremental=True,
@@ -151,9 +154,7 @@ def _client_with(objects: dict[str, list[FakeObject]], **kw: Any) -> FakeS3Clien
     return FakeS3Client(objects, **kw)
 
 
-def _connector(
-    config: S3Config, client: FakeS3Client | None = None
-) -> S3Connector:
+def _connector(config: S3Config, client: FakeS3Client | None = None) -> S3Connector:
     factory = make_client_factory(lambda a, b: client or _client_with({}))
     return S3Connector(config, _factory_creds(), client_factory=factory)
 
@@ -168,7 +169,10 @@ async def _drain_refs(c: S3Connector, cursor: str | None = None) -> list[Documen
 
 class TestDiscoverObjects:
     async def test_lists_and_paginates(self) -> None:
-        objs = [FakeObject(key=f"a/{i}.txt", body=b"x", last_modified=_now()) for i in range(5)]
+        objs = [
+            FakeObject(key=f"a/{i}.txt", body=b"x", last_modified=_now())
+            for i in range(5)
+        ]
         client = _client_with({"b": objs}, page_size=2)
         c = _connector(_config([BucketSpec(name="b")]), client)
         refs = await _drain_refs(c)
@@ -176,7 +180,9 @@ class TestDiscoverObjects:
         assert {r.path for r in refs} == {f"s3://b/a/{i}.txt" for i in range(5)}
 
     async def test_metadata_carries_account_and_key(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"hello", last_modified=_now())]})
+        client = _client_with(
+            {"b": [FakeObject(key="x", body=b"hello", last_modified=_now())]}
+        )
         c = _connector(_config([BucketSpec(name="b")]), client)
         ref = (await _drain_refs(c))[0]
         assert ref.metadata["aws_account_id"] == "111111111111"
@@ -189,10 +195,30 @@ class TestDiscoverObjects:
         client = _client_with(
             {
                 "b": [
-                    FakeObject(key="a", body=b"x", storage_class="STANDARD", last_modified=_now()),
-                    FakeObject(key="b", body=b"y", storage_class="GLACIER", last_modified=_now()),
-                    FakeObject(key="c", body=b"z", storage_class="DEEP_ARCHIVE", last_modified=_now()),
-                    FakeObject(key="d", body=b"w", storage_class="GLACIER_IR", last_modified=_now()),
+                    FakeObject(
+                        key="a",
+                        body=b"x",
+                        storage_class="STANDARD",
+                        last_modified=_now(),
+                    ),
+                    FakeObject(
+                        key="b",
+                        body=b"y",
+                        storage_class="GLACIER",
+                        last_modified=_now(),
+                    ),
+                    FakeObject(
+                        key="c",
+                        body=b"z",
+                        storage_class="DEEP_ARCHIVE",
+                        last_modified=_now(),
+                    ),
+                    FakeObject(
+                        key="d",
+                        body=b"w",
+                        storage_class="GLACIER_IR",
+                        last_modified=_now(),
+                    ),
                 ]
             },
             page_size=10,
@@ -216,7 +242,9 @@ class TestDiscoverObjects:
         c = _connector(_config([BucketSpec(name="b")]), client)
         refs = [
             r
-            async for r in c.discover(SourceFilter(since=_now() - timedelta(days=1)), None)
+            async for r in c.discover(
+                SourceFilter(since=_now() - timedelta(days=1)), None
+            )
         ]
         assert {r.metadata["aws_key"] for r in refs} == {"new"}
 
@@ -246,11 +274,16 @@ class TestDiscoverObjects:
             await _drain_refs(c)
 
     async def test_non_throttle_error_propagates(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"x", last_modified=_now())]})
+        client = _client_with(
+            {"b": [FakeObject(key="x", body=b"x", last_modified=_now())]}
+        )
 
         async def boom(*a, **k):  # noqa: ARG001
             raise _ClientError(
-                {"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPStatusCode": 403}}
+                {
+                    "Error": {"Code": "AccessDenied"},
+                    "ResponseMetadata": {"HTTPStatusCode": 403},
+                }
             )
 
         client.list_objects_v2 = boom  # type: ignore[assignment]
@@ -264,15 +297,17 @@ class TestDiscoverVersions:
         client = _client_with(
             {
                 "b": [
-                    FakeObject(key="x", body=b"v1", version_id="v1", last_modified=_now()),
-                    FakeObject(key="x", body=b"v2", version_id="v2", last_modified=_now()),
+                    FakeObject(
+                        key="x", body=b"v1", version_id="v1", last_modified=_now()
+                    ),
+                    FakeObject(
+                        key="x", body=b"v2", version_id="v2", last_modified=_now()
+                    ),
                 ]
             },
             page_size=10,
         )
-        c = _connector(
-            _config([BucketSpec(name="b")], include_versions=True), client
-        )
+        c = _connector(_config([BucketSpec(name="b")], include_versions=True), client)
         refs = await _drain_refs(c)
         assert {r.metadata["aws_version_id"] for r in refs} == {"v1", "v2"}
 
@@ -280,26 +315,28 @@ class TestDiscoverVersions:
         client = _client_with(
             {
                 "b": [
-                    FakeObject(key=f"k{i}", body=b"x", version_id="v", last_modified=_now())
+                    FakeObject(
+                        key=f"k{i}", body=b"x", version_id="v", last_modified=_now()
+                    )
                     for i in range(5)
                 ]
             },
             page_size=2,
         )
-        c = _connector(
-            _config([BucketSpec(name="b")], include_versions=True), client
-        )
+        c = _connector(_config([BucketSpec(name="b")], include_versions=True), client)
         refs = await _drain_refs(c)
         assert len(refs) == 5
 
     async def test_versions_throttle_translated(self) -> None:
         client = _client_with(
-            {"b": [FakeObject(key="x", body=b"x", version_id="v", last_modified=_now())]},
+            {
+                "b": [
+                    FakeObject(key="x", body=b"x", version_id="v", last_modified=_now())
+                ]
+            },
             throttle_after_calls=0,
         )
-        c = _connector(
-            _config([BucketSpec(name="b")], include_versions=True), client
-        )
+        c = _connector(_config([BucketSpec(name="b")], include_versions=True), client)
         with pytest.raises(RateLimited):
             await _drain_refs(c)
 
@@ -322,7 +359,12 @@ class TestDiscoverVersions:
 class TestSamplingPath:
     async def test_reservoir_caps_results(self) -> None:
         client = _client_with(
-            {"b": [FakeObject(key=f"k{i}", body=b"x", last_modified=_now()) for i in range(100)]},
+            {
+                "b": [
+                    FakeObject(key=f"k{i}", body=b"x", last_modified=_now())
+                    for i in range(100)
+                ]
+            },
             page_size=10,
         )
         cfg = _config(
@@ -336,7 +378,12 @@ class TestSamplingPath:
 
     async def test_force_full_scan_disables_sampling(self) -> None:
         client = _client_with(
-            {"b": [FakeObject(key=f"k{i}", body=b"x", last_modified=_now()) for i in range(50)]},
+            {
+                "b": [
+                    FakeObject(key=f"k{i}", body=b"x", last_modified=_now())
+                    for i in range(50)
+                ]
+            },
             page_size=20,
         )
         cfg = _config(
@@ -448,7 +495,10 @@ class TestInventoryPath:
         )
         c = _connector(_config([bucket]), client)
         refs = [
-            r async for r in c.discover(SourceFilter(since=_now() - timedelta(days=1)), None)
+            r
+            async for r in c.discover(
+                SourceFilter(since=_now() - timedelta(days=1)), None
+            )
         ]
         assert refs == []
 
@@ -542,7 +592,10 @@ class TestFetchSmall:
 
         async def boom(*a, **k):  # noqa: ARG001
             raise _ClientError(
-                {"Error": {"Code": "ThrottlingException"}, "ResponseMetadata": {"HTTPStatusCode": 429}}
+                {
+                    "Error": {"Code": "ThrottlingException"},
+                    "ResponseMetadata": {"HTTPStatusCode": 429},
+                }
             )
 
         client.get_object = boom  # type: ignore[assignment]
@@ -551,12 +604,16 @@ class TestFetchSmall:
 
     async def test_fetch_versioned(self) -> None:
         client = _client_with(
-            {"b": [FakeObject(key="x", body=b"v1-body", version_id="v1", last_modified=_now())]},
+            {
+                "b": [
+                    FakeObject(
+                        key="x", body=b"v1-body", version_id="v1", last_modified=_now()
+                    )
+                ]
+            },
             page_size=10,
         )
-        c = _connector(
-            _config([BucketSpec(name="b")], include_versions=True), client
-        )
+        c = _connector(_config([BucketSpec(name="b")], include_versions=True), client)
         ref = (await _drain_refs(c))[0]
         out = [d async for d in c.fetch(ref)]
         assert isinstance(out[0], Document)
@@ -569,7 +626,9 @@ class TestFetchSmall:
             [d async for d in c.fetch(bare)]
 
     async def test_fetch_unknown_account_raises(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"y", last_modified=_now())]})
+        client = _client_with(
+            {"b": [FakeObject(key="x", body=b"y", last_modified=_now())]}
+        )
         c = _connector(_config([BucketSpec(name="b")]), client)
         ref = DocumentRef(
             source_id="x",
@@ -582,13 +641,19 @@ class TestFetchSmall:
             [d async for d in c.fetch(ref)]
 
     async def test_fetch_unknown_bucket_raises(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"y", last_modified=_now())]})
+        client = _client_with(
+            {"b": [FakeObject(key="x", body=b"y", last_modified=_now())]}
+        )
         c = _connector(_config([BucketSpec(name="b")]), client)
         ref = DocumentRef(
             source_id="x",
             source_kind=KIND,
             path="s3://b/x",
-            metadata={"aws_account_id": "111111111111", "aws_bucket": "ghost", "aws_key": "x"},
+            metadata={
+                "aws_account_id": "111111111111",
+                "aws_bucket": "ghost",
+                "aws_key": "x",
+            },
             size=1,
         )
         with pytest.raises(KeyError, match="bucket"):
@@ -628,7 +693,10 @@ class TestFetchChunked:
 
         async def boom(*a, **k):  # noqa: ARG001
             raise _ClientError(
-                {"Error": {"Code": "SlowDown"}, "ResponseMetadata": {"HTTPStatusCode": 503}}
+                {
+                    "Error": {"Code": "SlowDown"},
+                    "ResponseMetadata": {"HTTPStatusCode": 503},
+                }
             )
 
         client.get_object = boom  # type: ignore[assignment]
@@ -680,7 +748,10 @@ class TestFetchChunked:
 
         async def boom(*a, **k):  # noqa: ARG001
             raise _ClientError(
-                {"Error": {"Code": "SlowDown"}, "ResponseMetadata": {"HTTPStatusCode": 503}}
+                {
+                    "Error": {"Code": "SlowDown"},
+                    "ResponseMetadata": {"HTTPStatusCode": 503},
+                }
             )
 
         client.get_object = boom  # type: ignore[assignment]
@@ -837,7 +908,9 @@ class TestEdgeCoverage:
         client = _client_with(
             {
                 "b": [
-                    FakeObject(key=f"k{i}", body=b"x", version_id="v", last_modified=_now())
+                    FakeObject(
+                        key=f"k{i}", body=b"x", version_id="v", last_modified=_now()
+                    )
                     for i in range(4)
                 ]
             },
@@ -847,7 +920,11 @@ class TestEdgeCoverage:
         refs = await _drain_refs(c)
         assert len(refs) == 4
         # second call had KeyMarker set
-        kms = [params["KeyMarker"] for name, params in client.calls if name == "list_object_versions"]
+        kms = [
+            params["KeyMarker"]
+            for name, params in client.calls
+            if name == "list_object_versions"
+        ]
         assert kms[0] is None
         assert kms[1] is not None
 
@@ -921,10 +998,21 @@ class TestEdgeCoverage:
         assert refs[0].last_modified.year == 2025
 
     async def test_versions_non_throttle_error_propagates(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"x", version_id="v", last_modified=_now())]})
+        client = _client_with(
+            {
+                "b": [
+                    FakeObject(key="x", body=b"x", version_id="v", last_modified=_now())
+                ]
+            }
+        )
 
         async def boom(**_):
-            raise _ClientError({"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPStatusCode": 403}})
+            raise _ClientError(
+                {
+                    "Error": {"Code": "AccessDenied"},
+                    "ResponseMetadata": {"HTTPStatusCode": 403},
+                }
+            )
 
         client.list_object_versions = boom  # type: ignore[assignment]
         c = _connector(_config([BucketSpec(name="b")], include_versions=True), client)
@@ -932,10 +1020,17 @@ class TestEdgeCoverage:
             await _drain_refs(c)
 
     async def test_sampled_non_throttle_error_propagates(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"x", last_modified=_now())]})
+        client = _client_with(
+            {"b": [FakeObject(key="x", body=b"x", last_modified=_now())]}
+        )
 
         async def boom(**_):
-            raise _ClientError({"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPStatusCode": 403}})
+            raise _ClientError(
+                {
+                    "Error": {"Code": "AccessDenied"},
+                    "ResponseMetadata": {"HTTPStatusCode": 403},
+                }
+            )
 
         client.list_objects_v2 = boom  # type: ignore[assignment]
         cfg = _config(
@@ -948,12 +1043,19 @@ class TestEdgeCoverage:
             await _drain_refs(c)
 
     async def test_fetch_whole_non_throttle_error_propagates(self) -> None:
-        client = _client_with({"b": [FakeObject(key="x", body=b"x", last_modified=_now())]})
+        client = _client_with(
+            {"b": [FakeObject(key="x", body=b"x", last_modified=_now())]}
+        )
         c = _connector(_config([BucketSpec(name="b")]), client)
         ref = (await _drain_refs(c))[0]
 
         async def boom(**_):
-            raise _ClientError({"Error": {"Code": "NoSuchKey"}, "ResponseMetadata": {"HTTPStatusCode": 404}})
+            raise _ClientError(
+                {
+                    "Error": {"Code": "NoSuchKey"},
+                    "ResponseMetadata": {"HTTPStatusCode": 404},
+                }
+            )
 
         client.get_object = boom  # type: ignore[assignment]
         with pytest.raises(_ClientError):
@@ -992,7 +1094,13 @@ class TestEdgeCoverage:
         # arm of `_fetch_chunked`.
         body = b"H" * 2_000
         client = _client_with(
-            {"b": [FakeObject(key="x", body=body, version_id="v1", last_modified=_now())]},
+            {
+                "b": [
+                    FakeObject(
+                        key="x", body=body, version_id="v1", last_modified=_now()
+                    )
+                ]
+            },
             page_size=10,
         )
         cfg = _config([BucketSpec(name="b")], chunk_bytes=1_000, max_doc_bytes=500)
@@ -1029,7 +1137,10 @@ class TestEdgeCoverage:
             call_count["n"] += 1
             if call_count["n"] >= 2:
                 raise _ClientError(
-                    {"Error": {"Code": "NoSuchKey"}, "ResponseMetadata": {"HTTPStatusCode": 404}}
+                    {
+                        "Error": {"Code": "NoSuchKey"},
+                        "ResponseMetadata": {"HTTPStatusCode": 404},
+                    }
                 )
             return await original(**kwargs)
 
@@ -1086,7 +1197,10 @@ class TestEdgeCoverage:
 
         async def boom(**_):
             raise _ClientError(
-                {"Error": {"Code": "AccessDenied"}, "ResponseMetadata": {"HTTPStatusCode": 403}}
+                {
+                    "Error": {"Code": "AccessDenied"},
+                    "ResponseMetadata": {"HTTPStatusCode": 403},
+                }
             )
 
         client.get_object = boom  # type: ignore[assignment]
@@ -1140,7 +1254,9 @@ class TestDefaultClientFactory:
     def test_returns_async_context_manager(self) -> None:
         from pleno_pii_scanner_aws.s3 import _default_client_factory
 
-        creds = AwsCredentials(access_key_id="A", secret_access_key="B", region="us-east-1")
+        creds = AwsCredentials(
+            access_key_id="A", secret_access_key="B", region="us-east-1"
+        )
         cm = _default_client_factory(
             session=None,
             creds=creds,

--- a/packages/pii-scanner-aws/tests/test_sampling.py
+++ b/packages/pii-scanner-aws/tests/test_sampling.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 
 import pytest
 

--- a/packages/pii-scanner-azure-blob/src/pleno_pii_scanner_azure_blob/_auth.py
+++ b/packages/pii-scanner-azure-blob/src/pleno_pii_scanner_azure_blob/_auth.py
@@ -49,9 +49,7 @@ import httpx
 # Microsoft Entra v2.0 token endpoint template. Tenant-scoped because
 # the multi-tenant `/common/` endpoint cannot issue tokens for the
 # Azure Storage resource without an admin-consented common app.
-_AAD_TOKEN_URL_TEMPLATE = (
-    "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
-)
+_AAD_TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
 # Azure Storage OAuth resource scope. The `/.default` suffix is the
 # v2.0 endpoint convention requesting the union of consented scopes
 # for the resource. Hard-coded because this is a public Azure constant
@@ -62,15 +60,11 @@ AZURE_STORAGE_DEFAULT_SCOPE = f"{AZURE_STORAGE_RESOURCE}.default"
 # the documented minimum and stable across all Azure SKUs that expose
 # IMDS (VMs, AKS, App Service, Functions). Pinned so a future IMDS
 # version bump does not silently change the response shape.
-_IMDS_TOKEN_URL = (
-    "http://169.254.169.254/metadata/identity/oauth2/token"
-)
+_IMDS_TOKEN_URL = "http://169.254.169.254/metadata/identity/oauth2/token"
 _IMDS_API_VERSION = "2018-02-01"
 # JWT-bearer client-assertion grant. RFC 7521 / 7523. AAD documents
 # this string verbatim; any deviation 400s with an unhelpful message.
-_CLIENT_ASSERTION_TYPE = (
-    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-)
+_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 # Refresh tokens this many seconds before the upstream `expires_at` so
 # in-flight paginates do not 401 mid-walk. 30 s mirrors the GCS / AWS
 # connector's safety margin.
@@ -221,9 +215,7 @@ class TokenCache:
 
     async def get(self, client: httpx.AsyncClient) -> AccessToken:
         async with self._lock:
-            if self._cached is not None and not self._cached.is_expired(
-                self.now()
-            ):
+            if self._cached is not None and not self._cached.is_expired(self.now()):
                 return self._cached
             self._cached = await self.source.acquire(client)
             return self._cached
@@ -263,9 +255,7 @@ class SharedKeyCredential:
         try:
             base64.b64decode(self.account_key_b64, validate=True)
         except (ValueError, base64.binascii.Error) as exc:
-            raise ValueError(
-                f"account_key_b64 is not valid base64: {exc}"
-            ) from None
+            raise ValueError(f"account_key_b64 is not valid base64: {exc}") from None
         if not self.account_name:
             raise ValueError("account_name must be non-empty")
 
@@ -329,29 +319,37 @@ def sign_shared_key(
     if_unmodified_since = h.get("if-unmodified-since", "")
     range_header = h.get("range", "")
     canonicalized_headers = _canonicalize_headers(h)
-    canonicalized_resource = _canonicalize_resource(
-        credential.account_name, url
-    )
+    canonicalized_resource = _canonicalize_resource(credential.account_name, url)
     string_to_sign = (
-        verb + "\n"
-        + content_encoding + "\n"
-        + content_language + "\n"
-        + content_length_str + "\n"
-        + content_md5 + "\n"
-        + content_type + "\n"
-        + date + "\n"
-        + if_modified_since + "\n"
-        + if_match + "\n"
-        + if_none_match + "\n"
-        + if_unmodified_since + "\n"
-        + range_header + "\n"
+        verb
+        + "\n"
+        + content_encoding
+        + "\n"
+        + content_language
+        + "\n"
+        + content_length_str
+        + "\n"
+        + content_md5
+        + "\n"
+        + content_type
+        + "\n"
+        + date
+        + "\n"
+        + if_modified_since
+        + "\n"
+        + if_match
+        + "\n"
+        + if_none_match
+        + "\n"
+        + if_unmodified_since
+        + "\n"
+        + range_header
+        + "\n"
         + canonicalized_headers
         + canonicalized_resource
     )
     key = base64.b64decode(credential.account_key_b64)
-    sig = hmac.new(
-        key, string_to_sign.encode("utf-8"), hashlib.sha256
-    ).digest()
+    sig = hmac.new(key, string_to_sign.encode("utf-8"), hashlib.sha256).digest()
     sig_b64 = base64.b64encode(sig).decode("ascii")
     return f"SharedKey {credential.account_name}:{sig_b64}"
 
@@ -425,9 +423,7 @@ def _canonicalize_resource(account_name: str, url: httpx.URL) -> str:
 # --- helpers --------------------------------------------------------
 
 
-def _parse_aad_token_response(
-    resp: httpx.Response, now: datetime
-) -> AccessToken:
+def _parse_aad_token_response(resp: httpx.Response, now: datetime) -> AccessToken:
     """Convert an Entra v2.0 token response into our AccessToken.
 
     Entra returns `access_token` + `expires_in` (seconds). We compute
@@ -446,16 +442,12 @@ def _parse_aad_token_response(
     body = resp.json()
     token = body.get("access_token")
     if not token:
-        raise ValueError(
-            "Entra token response missing access_token"
-        )
+        raise ValueError("Entra token response missing access_token")
     ttl = int(body.get("expires_in", 3600))
     return AccessToken(value=token, expires_at=now + timedelta(seconds=ttl))
 
 
-def _parse_imds_token_response(
-    resp: httpx.Response, now: datetime
-) -> AccessToken:
+def _parse_imds_token_response(resp: httpx.Response, now: datetime) -> AccessToken:
     """Convert an IMDS token response into our AccessToken.
 
     IMDS returns `access_token` + `expires_in` (seconds, sometimes a

--- a/packages/pii-scanner-azure-blob/src/pleno_pii_scanner_azure_blob/connector.py
+++ b/packages/pii-scanner-azure-blob/src/pleno_pii_scanner_azure_blob/connector.py
@@ -161,8 +161,7 @@ class AzureBlobAuthConfig:
             )
         if modes > 1:
             raise ValueError(
-                "AzureBlobAuthConfig must select EXACTLY one auth "
-                "mode; got multiple"
+                "AzureBlobAuthConfig must select EXACTLY one auth mode; got multiple"
             )
 
 
@@ -190,7 +189,9 @@ class AzureAccount:
         return f"https://{self.storage_account}.{self.endpoint_suffix}"
 
     def resolved_label(self) -> str:
-        return self.label or f"azure_blob:{self.storage_account}"  # pragma: no cover - operator-facing helper, not on the scan hot path
+        return (
+            self.label or f"azure_blob:{self.storage_account}"
+        )  # pragma: no cover - operator-facing helper, not on the scan hot path
 
 
 @dataclass(frozen=True, slots=True)
@@ -277,8 +278,7 @@ class AzureBlobConfig:
             for name in self.discovery.accounts:
                 if name not in account_names:
                     raise ValueError(
-                        f"discovery account={name!r} is not in "
-                        f"AzureBlobConfig.accounts"
+                        f"discovery account={name!r} is not in AzureBlobConfig.accounts"
                     )
 
 
@@ -429,9 +429,7 @@ class AzureBlobConnector:
                     source_id=self.id,
                     source_kind=self.kind,
                     path=f"azure-blob://{account.storage_account}/{container}/",
-                    native_url=(
-                        f"{account.base_url()}/{container}"
-                    ),
+                    native_url=(f"{account.base_url()}/{container}"),
                     content_type="text/plain",
                     metadata={
                         "azure_storage_account": account.storage_account,
@@ -484,13 +482,9 @@ class AzureBlobConnector:
             if marker:
                 params["marker"] = marker
             url = f"{account.base_url()}/"
-            resp = await self._authed_request(
-                "GET", url, account, params=params
-            )
+            resp = await self._authed_request("GET", url, account, params=params)
             if resp.status_code == 403:
-                raise _AccessDenied(
-                    status=403, account=account.storage_account
-                )
+                raise _AccessDenied(status=403, account=account.storage_account)
             resp.raise_for_status()
             root = _parse_xml(resp.content)
             containers_node = root.find("Containers")
@@ -538,9 +532,7 @@ class AzureBlobConnector:
                 params["include"] = ",".join(include_clauses)
             if marker:
                 params["marker"] = marker
-            resp = await self._authed_request(
-                "GET", url, account, params=params
-            )
+            resp = await self._authed_request("GET", url, account, params=params)
             if resp.status_code == 403:
                 raise _AccessDenied(status=403)
             resp.raise_for_status()
@@ -588,8 +580,7 @@ class AzureBlobConnector:
         name = name_node.text
         deleted_node = entry.find("Deleted")
         is_deleted = (
-            deleted_node is not None
-            and (deleted_node.text or "").lower() == "true"
+            deleted_node is not None and (deleted_node.text or "").lower() == "true"
         )
         if is_deleted and not self._config.include_versions:
             return None
@@ -622,12 +613,12 @@ class AzureBlobConnector:
                 kms_key = kms_key_node.text
             # Encryption-scope (CMK alternative) — also opaque.
             scope_node = props.find("EncryptionScope")
-            if scope_node is not None and scope_node.text:  # pragma: no cover - rare CMK alternative, exercised in integration
+            if (
+                scope_node is not None and scope_node.text
+            ):  # pragma: no cover - rare CMK alternative, exercised in integration
                 kms_key = kms_key or scope_node.text
         version_id_node = entry.find("VersionId")
-        version_id = (
-            version_id_node.text if version_id_node is not None else None
-        )
+        version_id = version_id_node.text if version_id_node is not None else None
         metadata: dict[str, str] = {
             "azure_storage_account": account.storage_account,
             "azure_container": container,
@@ -644,9 +635,7 @@ class AzureBlobConnector:
             source_id=self.id,
             source_kind=self.kind,
             path=f"azure-blob://{account.storage_account}/{container}/{name}",
-            native_url=(
-                f"{account.base_url()}/{container}/{quote(name, safe='/')}"
-            ),
+            native_url=(f"{account.base_url()}/{container}/{quote(name, safe='/')}"),
             content_type=content_type,
             size=size,
             etag=etag,
@@ -654,9 +643,7 @@ class AzureBlobConnector:
             metadata=metadata,
         )
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         """Stream the blob body via `GET <account>/<container>/<blob>`.
 
         Bounded by `_fetch_semaphore` so the per-connector concurrency
@@ -672,13 +659,8 @@ class AzureBlobConnector:
             )
         account = self._accounts_by_name.get(account_name)
         if account is None:
-            raise KeyError(
-                f"account={account_name!r} not in AzureBlobConfig.accounts"
-            )
-        url = (
-            f"{account.base_url()}/{container}/"
-            f"{quote(blob, safe='/')}"
-        )
+            raise KeyError(f"account={account_name!r} not in AzureBlobConfig.accounts")
+        url = f"{account.base_url()}/{container}/{quote(blob, safe='/')}"
         params: dict[str, str] = {}
         version_id = ref.metadata.get("azure_version_id")
         if version_id:
@@ -815,11 +797,7 @@ def _parse_xml(raw: bytes) -> ET.Element:
 
 def _key_from_path(path: str) -> str:
     """Strip `azure-blob://account/container/` from a full path."""
-    rest = (
-        path[len("azure-blob://") :]
-        if path.startswith("azure-blob://")
-        else path
-    )
+    rest = path[len("azure-blob://") :] if path.startswith("azure-blob://") else path
     parts = rest.split("/", 2)
     return parts[2] if len(parts) == 3 else ""
 
@@ -848,7 +826,9 @@ def _parse_rfc1123(value: str) -> datetime | None:
         dt = parsedate_to_datetime(value)
     except (TypeError, ValueError):
         return None
-    if dt is None:  # pragma: no cover - parsedate_to_datetime returns None on edge inputs
+    if (
+        dt is None
+    ):  # pragma: no cover - parsedate_to_datetime returns None on edge inputs
         return None
     if dt.tzinfo is None:  # pragma: no cover - RFC1123 always carries GMT
         dt = dt.replace(tzinfo=UTC)
@@ -880,9 +860,7 @@ def _build_token_source(auth: AzureBlobAuthConfig) -> TokenSource | None:
             scope=auth.scope,
         )
     if auth.managed_identity:
-        return ManagedIdentityTokenSource(
-            client_id=auth.managed_identity_client_id
-        )
+        return ManagedIdentityTokenSource(client_id=auth.managed_identity_client_id)
     # Shared Key only: no bearer source needed.
     return None
 
@@ -894,9 +872,7 @@ def _build_shared_keys(
     if not auth.account_keys:
         return {}
     return {
-        name: SharedKeyCredential(
-            account_name=name, account_key_b64=key
-        )
+        name: SharedKeyCredential(account_name=name, account_key_b64=key)
         for name, key in auth.account_keys.items()
     }
 
@@ -932,9 +908,7 @@ def _factory(config: Mapping[str, Any]) -> AzureBlobConnector:
     if not isinstance(auth_raw, Mapping):
         raise ValueError("azure_blob config: 'auth' must be a mapping")
     if not isinstance(discovery_raw, Mapping):
-        raise ValueError(
-            "azure_blob config: 'discovery' must be a mapping"
-        )
+        raise ValueError("azure_blob config: 'discovery' must be a mapping")
     if not isinstance(accounts_raw, (list, tuple)):
         raise ValueError(
             "azure_blob config: 'accounts' must be a list of account specs"
@@ -944,9 +918,7 @@ def _factory(config: Mapping[str, Any]) -> AzureBlobConnector:
         client_id=auth_raw.get("client_id"),
         oidc_token_path=auth_raw.get("oidc_token_path"),
         managed_identity=bool(auth_raw.get("managed_identity", False)),
-        managed_identity_client_id=auth_raw.get(
-            "managed_identity_client_id"
-        ),
+        managed_identity_client_id=auth_raw.get("managed_identity_client_id"),
         account_keys=dict(auth_raw.get("account_keys", {}) or {}),
         scope=str(auth_raw.get("scope", AZURE_STORAGE_DEFAULT_SCOPE)),
     )
@@ -954,9 +926,7 @@ def _factory(config: Mapping[str, Any]) -> AzureBlobConnector:
         AzureAccount(
             storage_account=str(a["storage_account"]),
             subscription_id=str(a.get("subscription_id", "")),
-            endpoint_suffix=str(
-                a.get("endpoint_suffix", DEFAULT_ENDPOINT_SUFFIX)
-            ),
+            endpoint_suffix=str(a.get("endpoint_suffix", DEFAULT_ENDPOINT_SUFFIX)),
             label=str(a.get("label", "")),
         )
         for a in accounts_raw
@@ -967,9 +937,7 @@ def _factory(config: Mapping[str, Any]) -> AzureBlobConnector:
             ContainerSpec(account=str(c["account"]), name=str(c["name"]))
             for c in containers_raw
         ),
-        accounts=tuple(
-            str(name) for name in (discovery_raw.get("accounts") or ())
-        ),
+        accounts=tuple(str(name) for name in (discovery_raw.get("accounts") or ())),
     )
     cfg = AzureBlobConfig(
         auth=auth,

--- a/packages/pii-scanner-azure-blob/tests/test_auth.py
+++ b/packages/pii-scanner-azure-blob/tests/test_auth.py
@@ -68,9 +68,7 @@ class TestWorkloadIdentity:
                 },
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 tenant_id="tenant-abc",
                 client_id="client-xyz",
@@ -99,13 +97,9 @@ class TestWorkloadIdentity:
         def handler(request: httpx.Request) -> httpx.Response:
             params = dict(httpx.QueryParams(request.content.decode()).items())
             seen_assertions.append(params["client_assertion"])
-            return httpx.Response(
-                200, json={"access_token": "x", "expires_in": 60}
-            )
+            return httpx.Response(200, json={"access_token": "x", "expires_in": 60})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 tenant_id="t",
                 client_id="c",
@@ -124,13 +118,9 @@ class TestWorkloadIdentity:
         def handler(request: httpx.Request) -> httpx.Response:
             params = dict(httpx.QueryParams(request.content.decode()).items())
             assert params["client_assertion"] == "from-seam"
-            return httpx.Response(
-                200, json={"access_token": "tok", "expires_in": 60}
-            )
+            return httpx.Response(200, json={"access_token": "tok", "expires_in": 60})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 tenant_id="t",
                 client_id="c",
@@ -140,16 +130,15 @@ class TestWorkloadIdentity:
             tok = await src.acquire(client)
         assert tok.value == "tok"
 
-    async def test_entra_error_does_not_leak_assertion(
-        self, tmp_path
-    ) -> None:
+    async def test_entra_error_does_not_leak_assertion(self, tmp_path) -> None:
         token_file = tmp_path / "oidc.jwt"
         token_file.write_text("LEAKING-JWT")
 
         async with httpx.AsyncClient(
             transport=httpx.MockTransport(
                 lambda _r: httpx.Response(
-                    400, json={"error": "invalid_client", "client_assertion": "LEAKING-JWT"}
+                    400,
+                    json={"error": "invalid_client", "client_assertion": "LEAKING-JWT"},
                 )
             )
         ) as client:
@@ -161,9 +150,7 @@ class TestWorkloadIdentity:
         assert "LEAKING-JWT" not in str(info.value)
         assert "status=400" in str(info.value)
 
-    async def test_entra_missing_access_token_rejected(
-        self, tmp_path
-    ) -> None:
+    async def test_entra_missing_access_token_rejected(self, tmp_path) -> None:
         token_file = tmp_path / "oidc.jwt"
         token_file.write_text("ok")
         async with httpx.AsyncClient(
@@ -188,10 +175,7 @@ class TestManagedIdentity:
             assert request.url.path == "/metadata/identity/oauth2/token"
             assert request.headers.get("Metadata") == "true"
             assert request.url.params.get("api-version") == "2018-02-01"
-            assert (
-                request.url.params.get("resource")
-                == "https://storage.azure.com/"
-            )
+            assert request.url.params.get("resource") == "https://storage.azure.com/"
             assert request.url.params.get("client_id") is None
             return httpx.Response(
                 200,
@@ -202,9 +186,7 @@ class TestManagedIdentity:
                 },
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = ManagedIdentityTokenSource()
             token = await src.acquire(client)
         assert token.value == "imds-bearer"
@@ -212,21 +194,15 @@ class TestManagedIdentity:
     async def test_user_assigned_client_id_added(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
             assert request.url.params.get("client_id") == "uami-1234"
-            return httpx.Response(
-                200, json={"access_token": "x", "expires_in": 60}
-            )
+            return httpx.Response(200, json={"access_token": "x", "expires_in": 60})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = ManagedIdentityTokenSource(client_id="uami-1234")
             await src.acquire(client)
 
     async def test_imds_non_200_raises(self) -> None:
         async with httpx.AsyncClient(
-            transport=httpx.MockTransport(
-                lambda _r: httpx.Response(500, text="oops")
-            )
+            transport=httpx.MockTransport(lambda _r: httpx.Response(500, text="oops"))
         ) as client:
             src = ManagedIdentityTokenSource()
             with pytest.raises(httpx.HTTPStatusError) as info:
@@ -256,9 +232,7 @@ class TestManagedIdentity:
                 },
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = ManagedIdentityTokenSource()
             tok = await src.acquire(client)
         # ~1 h ahead, allow 5 s skew.
@@ -345,9 +319,7 @@ class TestSharedKeyCredential:
 
     def test_invalid_base64_rejected(self) -> None:
         with pytest.raises(ValueError, match="not valid base64"):
-            SharedKeyCredential(
-                account_name="acct", account_key_b64="not-base64!!!"
-            )
+            SharedKeyCredential(account_name="acct", account_key_b64="not-base64!!!")
 
     def test_empty_account_name_rejected(self) -> None:
         key = base64.b64encode(b"x" * 32).decode("ascii")
@@ -386,36 +358,32 @@ class TestSharedKeySignature:
         credential = SharedKeyCredential(
             account_name="myaccount", account_key_b64=key_b64
         )
-        url = httpx.URL(
-            "http://myaccount.blob.core.windows.net/?comp=list"
-        )
+        url = httpx.URL("http://myaccount.blob.core.windows.net/?comp=list")
         headers = {
             "x-ms-date": "Fri, 26 Jun 2015 23:39:12 GMT",
             "x-ms-version": "2015-02-21",
         }
         # Hand-construct StringToSign per the spec.
         expected_sts = (
-            "GET\n"      # VERB
-            "\n"         # Content-Encoding
-            "\n"         # Content-Language
-            "\n"         # Content-Length (0 → empty)
-            "\n"         # Content-MD5
-            "\n"         # Content-Type
-            "\n"         # Date (empty because x-ms-date is set)
-            "\n"         # If-Modified-Since
-            "\n"         # If-Match
-            "\n"         # If-None-Match
-            "\n"         # If-Unmodified-Since
-            "\n"         # Range
+            "GET\n"  # VERB
+            "\n"  # Content-Encoding
+            "\n"  # Content-Language
+            "\n"  # Content-Length (0 → empty)
+            "\n"  # Content-MD5
+            "\n"  # Content-Type
+            "\n"  # Date (empty because x-ms-date is set)
+            "\n"  # If-Modified-Since
+            "\n"  # If-Match
+            "\n"  # If-None-Match
+            "\n"  # If-Unmodified-Since
+            "\n"  # Range
             "x-ms-date:Fri, 26 Jun 2015 23:39:12 GMT\n"
             "x-ms-version:2015-02-21\n"
             "/myaccount/\n"
             "comp:list"
         )
         expected_sig = base64.b64encode(
-            hmac.new(
-                key_raw, expected_sts.encode("utf-8"), hashlib.sha256
-            ).digest()
+            hmac.new(key_raw, expected_sts.encode("utf-8"), hashlib.sha256).digest()
         ).decode("ascii")
         expected_header = f"SharedKey myaccount:{expected_sig}"
         actual = sign_shared_key(
@@ -431,9 +399,7 @@ class TestSharedKeySignature:
         # GET /container/blob — the path must appear in the canonical
         # resource exactly once, prefixed by the account name.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
         url = httpx.URL("https://acct.blob.core.windows.net/c/blob.txt")
         sig = sign_shared_key(
             method="GET",
@@ -453,9 +419,7 @@ class TestSharedKeySignature:
             "/acct/c/blob.txt"
         )
         expected_b64 = base64.b64encode(
-            hmac.new(
-                b"k" * 32, sts.encode("utf-8"), hashlib.sha256
-            ).digest()
+            hmac.new(b"k" * 32, sts.encode("utf-8"), hashlib.sha256).digest()
         ).decode("ascii")
         assert sig == f"SharedKey acct:{expected_b64}"
 
@@ -463,9 +427,7 @@ class TestSharedKeySignature:
         # `comp=list&prefix=foo&restype=container` — names lowercased,
         # sorted, and joined with `\n`.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
         url = httpx.URL(
             "https://acct.blob.core.windows.net/c?restype=container&comp=list&prefix=foo"
         )
@@ -490,21 +452,15 @@ class TestSharedKeySignature:
             "restype:container"
         )
         expected_b64 = base64.b64encode(
-            hmac.new(
-                b"k" * 32, sts.encode("utf-8"), hashlib.sha256
-            ).digest()
+            hmac.new(b"k" * 32, sts.encode("utf-8"), hashlib.sha256).digest()
         ).decode("ascii")
         assert sig == f"SharedKey acct:{expected_b64}"
 
     def test_repeated_query_param_values_comma_joined_sorted(self) -> None:
         # Spec example: `comp=metadata&comp=list` → `comp:list,metadata`.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
-        url = httpx.URL(
-            "https://acct.blob.core.windows.net/c?comp=metadata&comp=list"
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
+        url = httpx.URL("https://acct.blob.core.windows.net/c?comp=metadata&comp=list")
         sig = sign_shared_key(
             method="GET",
             url=url,
@@ -523,9 +479,7 @@ class TestSharedKeySignature:
             "comp:list,metadata"
         )
         expected_b64 = base64.b64encode(
-            hmac.new(
-                b"k" * 32, sts.encode("utf-8"), hashlib.sha256
-            ).digest()
+            hmac.new(b"k" * 32, sts.encode("utf-8"), hashlib.sha256).digest()
         ).decode("ascii")
         assert sig == f"SharedKey acct:{expected_b64}"
 
@@ -533,9 +487,7 @@ class TestSharedKeySignature:
         # When the caller passes only headers (no explicit content_length),
         # the signer must read `content-length` from the headers map.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
         url = httpx.URL("https://acct.blob.core.windows.net/c/blob")
         sig_explicit = sign_shared_key(
             method="PUT",
@@ -565,9 +517,7 @@ class TestSharedKeySignature:
         # as 0 rather than raising — the signer must not crash on input
         # it cannot parse.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
         url = httpx.URL("https://acct.blob.core.windows.net/c")
         sig_bad = sign_shared_key(
             method="GET",
@@ -595,9 +545,7 @@ class TestSharedKeySignature:
         # When `x-ms-date` is absent, the legacy `Date` header is what
         # the StringToSign references in slot 7.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
         url = httpx.URL("https://acct.blob.core.windows.net/c")
         sig = sign_shared_key(
             method="GET",
@@ -617,9 +565,7 @@ class TestSharedKeySignature:
             "/acct/c"
         )
         expected_b64 = base64.b64encode(
-            hmac.new(
-                b"k" * 32, sts.encode("utf-8"), hashlib.sha256
-            ).digest()
+            hmac.new(b"k" * 32, sts.encode("utf-8"), hashlib.sha256).digest()
         ).decode("ascii")
         assert sig == f"SharedKey acct:{expected_b64}"
 
@@ -628,9 +574,7 @@ class TestSharedKeySignature:
         # constructed URL could lack it. The canonical resource must
         # still produce `/<account>/<path>`.
         key_b64 = base64.b64encode(b"k" * 32).decode("ascii")
-        credential = SharedKeyCredential(
-            account_name="acct", account_key_b64=key_b64
-        )
+        credential = SharedKeyCredential(account_name="acct", account_key_b64=key_b64)
 
         class _FakeURL:
             path = "container/blob"
@@ -653,8 +597,6 @@ class TestSharedKeySignature:
             "/acct/container/blob"
         )
         expected_b64 = base64.b64encode(
-            hmac.new(
-                b"k" * 32, sts.encode("utf-8"), hashlib.sha256
-            ).digest()
+            hmac.new(b"k" * 32, sts.encode("utf-8"), hashlib.sha256).digest()
         ).decode("ascii")
         assert sig == f"SharedKey acct:{expected_b64}"

--- a/packages/pii-scanner-azure-blob/tests/test_connector.py
+++ b/packages/pii-scanner-azure-blob/tests/test_connector.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
 import httpx
@@ -62,9 +61,7 @@ def _canned_cache() -> TokenCache:
 
 
 def _account(name: str = "acct1", subscription: str = "sub-1") -> AzureAccount:
-    return AzureAccount(
-        storage_account=name, subscription_id=subscription
-    )
+    return AzureAccount(storage_account=name, subscription_id=subscription)
 
 
 def _explicit_config(
@@ -84,9 +81,7 @@ def _explicit_config(
     return AzureBlobConfig(
         auth=AzureBlobAuthConfig(managed_identity=True),
         discovery=AzureBlobDiscovery(
-            containers=tuple(
-                ContainerSpec(account=a, name=c) for a, c in containers
-            )
+            containers=tuple(ContainerSpec(account=a, name=c) for a, c in containers)
         ),
         accounts=accounts,
         id=id,
@@ -131,19 +126,13 @@ def _list_xml(
         ):
             parts.append("<Properties>")
             if b.get("last_modified"):
-                parts.append(
-                    f"<Last-Modified>{b['last_modified']}</Last-Modified>"
-                )
+                parts.append(f"<Last-Modified>{b['last_modified']}</Last-Modified>")
             if b.get("etag"):
                 parts.append(f'<Etag>"{b["etag"]}"</Etag>')
             if b.get("size") is not None:
-                parts.append(
-                    f"<Content-Length>{b['size']}</Content-Length>"
-                )
+                parts.append(f"<Content-Length>{b['size']}</Content-Length>")
             if b.get("content_type"):
-                parts.append(
-                    f"<Content-Type>{b['content_type']}</Content-Type>"
-                )
+                parts.append(f"<Content-Type>{b['content_type']}</Content-Type>")
             if b.get("cmk_sha256"):
                 parts.append(
                     f"<CustomerProvidedKeySha256>{b['cmk_sha256']}"
@@ -160,9 +149,7 @@ def _list_xml(
     return "".join(parts).encode("utf-8")
 
 
-def _container_list_xml(
-    *names: str, next_marker: str | None = None
-) -> bytes:
+def _container_list_xml(*names: str, next_marker: str | None = None) -> bytes:
     parts = [
         '<?xml version="1.0" encoding="utf-8"?>',
         "<EnumerationResults>",
@@ -270,9 +257,7 @@ class TestConfigValidation:
 
 class TestProtocol:
     async def test_runtime_isinstance(self) -> None:
-        c = AzureBlobConnector(
-            _explicit_config(("acct1", "c1")), _canned_cache()
-        )
+        c = AzureBlobConnector(_explicit_config(("acct1", "c1")), _canned_cache())
         try:
             assert isinstance(c, SourceConnector)
         finally:
@@ -349,13 +334,9 @@ class TestDiscoverExplicit:
             assert request.url.params.get("comp") == "list"
             marker = request.url.params.get("marker")
             seen_markers.append(marker)
-            return httpx.Response(
-                200, content=page2 if marker == "page2" else page1
-            )
+            return httpx.Response(200, content=page2 if marker == "page2" else page1)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -384,9 +365,7 @@ class TestDiscoverExplicit:
             seen_prefix["v"] = request.url.params.get("prefix")
             return httpx.Response(200, content=_list_xml())
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1"), prefix="logs/"),
                 _canned_cache(),
@@ -400,17 +379,27 @@ class TestDiscoverExplicit:
 
     async def test_glob_filters_client_side(self) -> None:
         body = _list_xml(
-            {"name": "a.log", "size": "1", "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT"},
-            {"name": "b.txt", "size": "1", "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT"},
-            {"name": "c.log", "size": "1", "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT"},
+            {
+                "name": "a.log",
+                "size": "1",
+                "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT",
+            },
+            {
+                "name": "b.txt",
+                "size": "1",
+                "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT",
+            },
+            {
+                "name": "c.log",
+                "size": "1",
+                "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT",
+            },
         )
 
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1"), glob="*.log"),
                 _canned_cache(),
@@ -427,16 +416,22 @@ class TestDiscoverExplicit:
 
     async def test_filter_include_used_when_no_explicit_glob(self) -> None:
         body = _list_xml(
-            {"name": "x.json", "size": "1", "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT"},
-            {"name": "y.csv", "size": "1", "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT"},
+            {
+                "name": "x.json",
+                "size": "1",
+                "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT",
+            },
+            {
+                "name": "y.csv",
+                "size": "1",
+                "last_modified": "Wed, 01 Jan 2026 00:00:00 GMT",
+            },
         )
 
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -444,10 +439,7 @@ class TestDiscoverExplicit:
             )
             try:
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("*.csv",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("*.csv",)), None)
                 ]
             finally:
                 await c.close()
@@ -455,16 +447,22 @@ class TestDiscoverExplicit:
 
     async def test_since_filter_drops_old_items(self) -> None:
         body = _list_xml(
-            {"name": "old", "size": "1", "last_modified": "Sun, 01 Jan 2023 00:00:00 GMT"},
-            {"name": "new", "size": "1", "last_modified": "Tue, 01 Jun 2027 00:00:00 GMT"},
+            {
+                "name": "old",
+                "size": "1",
+                "last_modified": "Sun, 01 Jan 2023 00:00:00 GMT",
+            },
+            {
+                "name": "new",
+                "size": "1",
+                "last_modified": "Tue, 01 Jun 2027 00:00:00 GMT",
+            },
         )
 
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -505,9 +503,7 @@ class TestVersioning:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -535,9 +531,7 @@ class TestVersioning:
             seen_include["v"] = request.url.params.get("include")
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1"), include_versions=True),
                 _canned_cache(),
@@ -578,9 +572,7 @@ class TestAccessDenied:
                 )
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "denied"), ("acct1", "ok")),
                 _canned_cache(),
@@ -606,15 +598,19 @@ class TestPerAccountDiscovery:
         def handler(request: httpx.Request) -> httpx.Response:
             url = str(request.url)
             seen_paths.append(url)
-            if "acct1." in url and request.url.params.get("comp") == "list" and request.url.params.get("restype") is None:
+            if (
+                "acct1." in url
+                and request.url.params.get("comp") == "list"
+                and request.url.params.get("restype") is None
+            ):
                 # Container enumeration for acct1.
-                return httpx.Response(
-                    200, content=_container_list_xml("c1", "c2")
-                )
-            if "acct2." in url and request.url.params.get("comp") == "list" and request.url.params.get("restype") is None:
-                return httpx.Response(
-                    200, content=_container_list_xml("c3")
-                )
+                return httpx.Response(200, content=_container_list_xml("c1", "c2"))
+            if (
+                "acct2." in url
+                and request.url.params.get("comp") == "list"
+                and request.url.params.get("restype") is None
+            ):
+                return httpx.Response(200, content=_container_list_xml("c3"))
             # Blob listing inside any container.
             return httpx.Response(
                 200,
@@ -632,9 +628,7 @@ class TestPerAccountDiscovery:
             discovery=AzureBlobDiscovery(accounts=("acct1", "acct2")),
             accounts=(_account("acct1"), _account("acct2", "sub-2")),
         )
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(cfg, _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -669,9 +663,7 @@ class TestPerAccountDiscovery:
             discovery=AzureBlobDiscovery(accounts=("acct1",)),
             accounts=(_account("acct1"),),
         )
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(cfg, _canned_cache(), client=client)
             try:
                 _ = [r async for r in c.discover(SourceFilter(), None)]
@@ -701,9 +693,7 @@ class TestPerAccountDiscovery:
             discovery=AzureBlobDiscovery(accounts=("acct1",)),
             accounts=(_account("acct1"),),
         )
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(cfg, _canned_cache(), client=client)
             try:
                 names = await c._list_containers(c._accounts_by_name["acct1"])
@@ -725,9 +715,7 @@ class TestPerAccountDiscovery:
             discovery=AzureBlobDiscovery(accounts=("acct1",)),
             accounts=(_account("acct1"),),
         )
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(cfg, _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -760,9 +748,7 @@ class TestFetch:
                 return httpx.Response(200, content=payload)
             return httpx.Response(200, content=list_body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -787,9 +773,7 @@ class TestFetch:
             seen_version["v"] = request.url.params.get("versionid")
             return httpx.Response(200, content=b"x")
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -814,9 +798,7 @@ class TestFetch:
         assert seen_version["v"] == "v-9"
 
     async def test_fetch_rejects_ref_without_metadata(self) -> None:
-        c = AzureBlobConnector(
-            _explicit_config(("acct1", "c1")), _canned_cache()
-        )
+        c = AzureBlobConnector(_explicit_config(("acct1", "c1")), _canned_cache())
         try:
             ref = DocumentRef(
                 source_id=c.id, source_kind=c.kind, path="azure-blob://acct1/c1/x"
@@ -828,9 +810,7 @@ class TestFetch:
             await c.close()
 
     async def test_fetch_rejects_ref_with_unknown_account(self) -> None:
-        c = AzureBlobConnector(
-            _explicit_config(("acct1", "c1")), _canned_cache()
-        )
+        c = AzureBlobConnector(_explicit_config(("acct1", "c1")), _canned_cache())
         try:
             ref = DocumentRef(
                 source_id=c.id,
@@ -927,9 +907,7 @@ class TestAuthRetry:
             assert request.headers["Authorization"] == "Bearer tok-2"
             return httpx.Response(200, content=_list_xml())
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")), cache, client=client
             )
@@ -962,16 +940,10 @@ class TestSharedKeyAuth:
             accounts=(_account("acct1"),),
         )
         shared_keys = {
-            "acct1": SharedKeyCredential(
-                account_name="acct1", account_key_b64=key_b64
-            )
+            "acct1": SharedKeyCredential(account_name="acct1", account_key_b64=key_b64)
         }
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = AzureBlobConnector(
-                cfg, None, shared_keys=shared_keys, client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = AzureBlobConnector(cfg, None, shared_keys=shared_keys, client=client)
             try:
                 _ = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -1003,9 +975,7 @@ class TestCursor:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -1031,9 +1001,7 @@ class TestCursor:
                     return httpx.Response(200, content=_list_xml())
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "first"), ("acct1", "second")),
                 _canned_cache(),
@@ -1047,9 +1015,7 @@ class TestCursor:
         assert seen_containers == ["second"]
 
     async def test_cursor_unparseable_raises(self) -> None:
-        c = AzureBlobConnector(
-            _explicit_config(("acct1", "c1")), _canned_cache()
-        )
+        c = AzureBlobConnector(_explicit_config(("acct1", "c1")), _canned_cache())
         try:
             with pytest.raises(ValueError, match="unparseable cursor"):
                 async for _ in c.discover(SourceFilter(), "not-json"):
@@ -1065,9 +1031,7 @@ class TestFactory:
     def test_spec_metadata(self) -> None:
         assert SPEC.kind == "azure_blob"
         assert SPEC.version == "0.1.0"
-        assert any(
-            "blobs/read" in s for s in SPEC.required_scopes
-        )
+        assert any("blobs/read" in s for s in SPEC.required_scopes)
 
     def test_factory_minimal_managed_identity(self) -> None:
         register(SPEC)
@@ -1095,12 +1059,8 @@ class TestFactory:
                     "client_id": "c",
                     "oidc_token_path": str(token_file),
                 },
-                "discovery": {
-                    "containers": [{"account": "acct1", "name": "c1"}]
-                },
-                "accounts": [
-                    {"storage_account": "acct1", "subscription_id": "sub-1"}
-                ],
+                "discovery": {"containers": [{"account": "acct1", "name": "c1"}]},
+                "accounts": [{"storage_account": "acct1", "subscription_id": "sub-1"}],
                 "prefix": "logs/",
                 "glob": "*.json",
                 "include_versions": True,
@@ -1119,9 +1079,7 @@ class TestFactory:
             "azure_blob",
             {
                 "auth": {"account_keys": {"acct1": key_b64}},
-                "discovery": {
-                    "containers": [{"account": "acct1", "name": "c1"}]
-                },
+                "discovery": {"containers": [{"account": "acct1", "name": "c1"}]},
                 "accounts": [{"storage_account": "acct1"}],
             },
         )
@@ -1217,9 +1175,7 @@ class TestFactory:
 
 class TestLifecycle:
     async def test_close_owned_client(self) -> None:
-        c = AzureBlobConnector(
-            _explicit_config(("acct1", "c1")), _canned_cache()
-        )
+        c = AzureBlobConnector(_explicit_config(("acct1", "c1")), _canned_cache())
         assert c._owns_client
         await c.close()
 
@@ -1235,9 +1191,7 @@ class TestLifecycle:
         await client.aclose()
 
     async def test_close_idempotent(self) -> None:
-        c = AzureBlobConnector(
-            _explicit_config(("acct1", "c1")), _canned_cache()
-        )
+        c = AzureBlobConnector(_explicit_config(("acct1", "c1")), _canned_cache())
         await c.close()
         await c.close()
 
@@ -1261,9 +1215,7 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -1287,9 +1239,7 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -1313,9 +1263,7 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -1339,9 +1287,7 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),
@@ -1359,9 +1305,7 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=b"<not-xml")
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = AzureBlobConnector(
                 _explicit_config(("acct1", "c1")),
                 _canned_cache(),

--- a/packages/pii-scanner-azure-devops/src/pleno_pii_scanner_azure_devops/api.py
+++ b/packages/pii-scanner-azure-devops/src/pleno_pii_scanner_azure_devops/api.py
@@ -110,9 +110,7 @@ class AzureDevOpsApi:
             # Build the SSLContext ourselves so a missing bundle file
             # surfaces immediately as FileNotFoundError instead of as a
             # cryptic httpx ConnectError on first request.
-            ctx = ssl.create_default_context(
-                cafile=str(self._ca_bundle_path)
-            )
+            ctx = ssl.create_default_context(cafile=str(self._ca_bundle_path))
             kwargs["verify"] = ctx
         self._client = httpx.AsyncClient(**kwargs)
         return self._client
@@ -199,9 +197,7 @@ def _raise_for_rate_limit(response: httpx.Response) -> None:
     """
     if response.status_code == 429:
         retry_after = response.headers.get("Retry-After")
-        raise RateLimited(
-            f"azure-devops 429; retry_after={retry_after!r}"
-        )
+        raise RateLimited(f"azure-devops 429; retry_after={retry_after!r}")
 
 
 __all__ = [

--- a/packages/pii-scanner-azure-devops/src/pleno_pii_scanner_azure_devops/auth.py
+++ b/packages/pii-scanner-azure-devops/src/pleno_pii_scanner_azure_devops/auth.py
@@ -49,9 +49,7 @@ AZURE_DEVOPS_DEFAULT_SCOPE = f"{AZURE_DEVOPS_RESOURCE_ID}/.default"
 # Microsoft Entra v2.0 token endpoint template. Tenant-scoped because
 # the multi-tenant `/common/` endpoint cannot issue tokens for the
 # Azure DevOps resource without an admin-consented common app.
-_AAD_TOKEN_URL_TEMPLATE = (
-    "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
-)
+_AAD_TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
 
 # Re-mint the federated bearer 5 minutes before expiry so an in-flight
 # request never carries a token that expires mid-flight. AAD issues
@@ -60,9 +58,7 @@ _TOKEN_SKEW_SECONDS = 5 * 60
 
 # JWT-bearer client-assertion grant. RFC 7521 / 7523. AAD documents
 # this string verbatim; any deviation 400s with an unhelpful message.
-_CLIENT_ASSERTION_TYPE = (
-    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-)
+_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 
 AuthMode = Literal["pat", "oauth", "federated"]
@@ -172,9 +168,7 @@ class AzureDevOpsAuth:
         """
         if self.mode == "pat":
             assert self._pat is not None
-            encoded = base64.b64encode(f":{self._pat}".encode("ascii")).decode(
-                "ascii"
-            )
+            encoded = base64.b64encode(f":{self._pat}".encode("ascii")).decode("ascii")
             return f"Basic {encoded}"
         if self.mode == "oauth":
             assert self._bearer is not None
@@ -254,9 +248,7 @@ class AzureDevOpsAuth:
         payload = response.json()
         token = payload.get("access_token")
         if not isinstance(token, str) or not token:
-            raise FederatedTokenError(
-                "AAD response missing 'access_token'"
-            )
+            raise FederatedTokenError("AAD response missing 'access_token'")
         # `expires_in` is seconds-from-now per RFC 6749 §5.1. AAD always
         # emits it; default to 1h if it is somehow missing so the cache
         # is never poisoned with a never-expiring token.

--- a/packages/pii-scanner-azure-devops/src/pleno_pii_scanner_azure_devops/connector.py
+++ b/packages/pii-scanner-azure-devops/src/pleno_pii_scanner_azure_devops/connector.py
@@ -26,7 +26,7 @@ import shutil
 import subprocess
 import tempfile
 from collections.abc import AsyncIterator, Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -123,8 +123,7 @@ class AzureDevOpsConfig:
             # not possible (collection path varies per install).
             if not self.base_url:
                 raise ValueError(
-                    "flavor='server' requires explicit `base_url` "
-                    "(collection URL)"
+                    "flavor='server' requires explicit `base_url` (collection URL)"
                 )
 
     def resolved_base_url(self) -> str:
@@ -206,9 +205,7 @@ class AzureDevOpsConnector:
                 continue
             slug = f"{project}/{repo_name}"
             repo_path = await self._ensure_clone(slug, clone_url)
-            inner = DirConnector(
-                DirConfig(root=repo_path, id=f"azure-devops:{slug}")
-            )
+            inner = DirConnector(DirConfig(root=repo_path, id=f"azure-devops:{slug}"))
             try:
                 async for inner_ref in inner.discover(filter, None):
                     yield self._wrap_ref(inner_ref, project, repo_name)
@@ -226,9 +223,7 @@ class AzureDevOpsConnector:
             # connector. Same idiom as GitHub builtin: yield nothing.
             return
         repo_path = self._clones[slug]
-        inner = DirConnector(
-            DirConfig(root=repo_path, id=f"azure-devops:{slug}")
-        )
+        inner = DirConnector(DirConfig(root=repo_path, id=f"azure-devops:{slug}"))
         try:
             inner_ref = self._unwrap_ref(ref, slug, inner_path)
             async for doc in inner.fetch(inner_ref):
@@ -255,9 +250,7 @@ class AzureDevOpsConnector:
         """
         async with self._lock:
             for path in self._tempdirs:
-                await asyncio.to_thread(
-                    shutil.rmtree, path, ignore_errors=True
-                )
+                await asyncio.to_thread(shutil.rmtree, path, ignore_errors=True)
             self._tempdirs.clear()
             self._clones.clear()
         await self._api.aclose()
@@ -301,9 +294,7 @@ class AzureDevOpsConnector:
         params: dict[str, Any] = {}
         if start_cursor:
             params["continuationToken"] = start_cursor
-        async for response in self._api.get_paginated(
-            "/_apis/projects", params=params
-        ):
+        async for response in self._api.get_paginated("/_apis/projects", params=params):
             payload = response.json()
             next_cursor = response.headers.get("x-ms-continuationtoken") or None
             for project in payload.get("value", []):
@@ -322,9 +313,7 @@ class AzureDevOpsConnector:
         self, project: str
     ) -> AsyncIterator[tuple[str, str, str, bool]]:
         """Yield repos for one project as ``(project, repo, clone_url, disabled)``."""
-        response = await self._api.get(
-            f"/{project}/_apis/git/repositories"
-        )
+        response = await self._api.get(f"/{project}/_apis/git/repositories")
         if response.status_code == 404:
             # Project was deleted between projects-list and repos-list
             # (race) or the credential cannot see it. Either way, skip
@@ -373,17 +362,13 @@ class AzureDevOpsConnector:
                 # Lost the race; the loser cleans up its own tempdir
                 # and uses the cached one. Avoids two clones of the
                 # same repo when discover is invoked concurrently.
-                await asyncio.to_thread(
-                    shutil.rmtree, path, ignore_errors=True
-                )
+                await asyncio.to_thread(shutil.rmtree, path, ignore_errors=True)
                 return existing
             self._clones[slug] = path
             self._tempdirs.append(path)
         return path
 
-    def _wrap_ref(
-        self, inner: DocumentRef, project: str, repo: str
-    ) -> DocumentRef:
+    def _wrap_ref(self, inner: DocumentRef, project: str, repo: str) -> DocumentRef:
         slug = f"{project}/{repo}"
         return DocumentRef(
             source_id=self.id,
@@ -407,9 +392,7 @@ class AzureDevOpsConnector:
             },
         )
 
-    def _unwrap_ref(
-        self, ref: DocumentRef, slug: str, inner_path: str
-    ) -> DocumentRef:
+    def _unwrap_ref(self, ref: DocumentRef, slug: str, inner_path: str) -> DocumentRef:
         return DocumentRef(
             source_id=f"azure-devops:{slug}",
             source_kind="dir",
@@ -486,9 +469,7 @@ def _build_auth(payload: Mapping[str, Any]) -> AzureDevOpsAuth:
     if mode == "oauth":
         access_token = payload.get("access_token")
         if not isinstance(access_token, str):
-            raise ValueError(
-                "credential mode='oauth' requires `access_token` string"
-            )
+            raise ValueError("credential mode='oauth' requires `access_token` string")
         return AzureDevOpsAuth.oauth(access_token)
     if mode == "federated":
         oidc_token_path = payload.get("oidc_token_path")
@@ -539,14 +520,10 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
                 else None
             ),
             base_url=(
-                str(config["base_url"])
-                if config.get("base_url") is not None
-                else None
+                str(config["base_url"]) if config.get("base_url") is not None else None
             ),
             project=(
-                str(config["project"])
-                if config.get("project") is not None
-                else None
+                str(config["project"]) if config.get("project") is not None else None
             ),
             include_disabled=bool(config.get("include_disabled", False)),
             include_private=bool(config.get("include_private", True)),

--- a/packages/pii-scanner-azure-devops/tests/test_api.py
+++ b/packages/pii-scanner-azure-devops/tests/test_api.py
@@ -310,9 +310,7 @@ class TestCABundle:
         from datetime import UTC, datetime, timedelta
 
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        subject = x509.Name(
-            [x509.NameAttribute(x509.NameOID.COMMON_NAME, "test-ca")]
-        )
+        subject = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, "test-ca")])
         cert = (
             x509.CertificateBuilder()
             .subject_name(subject)

--- a/packages/pii-scanner-azure-devops/tests/test_auth.py
+++ b/packages/pii-scanner-azure-devops/tests/test_auth.py
@@ -121,13 +121,9 @@ def _build_federated_auth(
 
 
 class TestFederatedMode:
-    async def test_token_exchange_posts_oidc_assertion(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_token_exchange_posts_oidc_assertion(self, tmp_path: Path) -> None:
         captured: dict = {}
-        client, auth = _build_federated_auth(
-            tmp_path, _federated_handler_ok(captured)
-        )
+        client, auth = _build_federated_auth(tmp_path, _federated_handler_ok(captured))
         try:
             header = await auth.authorization_header()
             assert header == "Bearer aad-bearer-1"
@@ -266,9 +262,7 @@ class TestFederatedMode:
             await auth.aclose()
             await client.aclose()
 
-    async def test_aad_missing_expires_in_uses_1h_default(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_aad_missing_expires_in_uses_1h_default(self, tmp_path: Path) -> None:
         # No `expires_in` -> must NOT cache forever; the connector
         # treats absence as a 1h TTL (documented default).
         clock = {"t": 0.0}

--- a/packages/pii-scanner-azure-devops/tests/test_connector.py
+++ b/packages/pii-scanner-azure-devops/tests/test_connector.py
@@ -55,9 +55,7 @@ def _stub_clone(path_factory):
         assert auth_header.startswith(("Bearer ", "Basic "))
         # Identify the repo by the trailing path segment of the URL.
         slug = clone_url.rstrip("/").rsplit("/", 1)[-1]
-        return (
-            path_factory(slug) if callable(path_factory) else path_factory
-        )
+        return path_factory(slug) if callable(path_factory) else path_factory
 
     return fn
 
@@ -65,9 +63,7 @@ def _stub_clone(path_factory):
 def _projects_response(
     names: list[str], *, continuation: str | None = None
 ) -> httpx.Response:
-    headers = (
-        {CONTINUATION_TOKEN_HEADER: continuation} if continuation else {}
-    )
+    headers = {CONTINUATION_TOKEN_HEADER: continuation} if continuation else {}
     return httpx.Response(
         200,
         json={"value": [{"name": n, "visibility": "private"} for n in names]},
@@ -121,15 +117,11 @@ class TestConfig:
         assert cfg.resolved_id() == "azure-devops:contoso"
 
     def test_resolved_id_server(self) -> None:
-        cfg = AzureDevOpsConfig(
-            flavor="server", base_url="https://tfs/Coll"
-        )
+        cfg = AzureDevOpsConfig(flavor="server", base_url="https://tfs/Coll")
         assert "azure-devops-server:" in cfg.resolved_id()
 
     def test_resolved_id_explicit(self) -> None:
-        cfg = AzureDevOpsConfig(
-            flavor="services", organization="x", id="custom"
-        )
+        cfg = AzureDevOpsConfig(flavor="services", organization="x", id="custom")
         assert cfg.resolved_id() == "custom"
 
 
@@ -137,9 +129,7 @@ class TestConfig:
 
 
 class TestServicesDiscoverFetch:
-    async def test_single_project_lists_repos_and_clones(
-        self, make_repo
-    ) -> None:
+    async def test_single_project_lists_repos_and_clones(self, make_repo) -> None:
         # One project shortcut: skip the projects-list call entirely.
         # Repo response contains one enabled repo + one disabled repo;
         # default config skips the disabled one.
@@ -175,9 +165,7 @@ class TestServicesDiscoverFetch:
             clone_fn=_stub_clone(lambda _slug: repo),
         )
         try:
-            refs = [
-                r async for r in connector.discover(SourceFilter(), None)
-            ]
+            refs = [r async for r in connector.discover(SourceFilter(), None)]
             assert len(refs) == 1
             ref = refs[0]
             assert ref.path == "Banking/core/app.py"
@@ -188,9 +176,7 @@ class TestServicesDiscoverFetch:
         finally:
             await connector.close()
 
-    async def test_include_disabled_yields_disabled_repos(
-        self, make_repo
-    ) -> None:
+    async def test_include_disabled_yields_disabled_repos(self, make_repo) -> None:
         def handler(_: httpx.Request) -> httpx.Response:
             return _repos_response(
                 [
@@ -298,9 +284,7 @@ class TestServicesDiscoverFetch:
         finally:
             await connector.close()
 
-    async def test_404_on_repos_listing_skips_project(
-        self, make_repo
-    ) -> None:
+    async def test_404_on_repos_listing_skips_project(self, make_repo) -> None:
         # Race: project disappears between projects-list and repos-list.
         # Connector must skip silently and continue (no exception).
         repo = make_repo("a", {"f.txt": "x"})
@@ -498,17 +482,13 @@ class TestServerDiscoverFetch:
         )
         try:
             refs = [r async for r in connector.discover(SourceFilter(), None)]
-            assert all(
-                u.startswith("https://tfs.internal/Coll/") for u in seen_urls
-            )
+            assert all(u.startswith("https://tfs.internal/Coll/") for u in seen_urls)
             assert refs and refs[0].native_url is not None
             assert "https://tfs.internal/Coll/" in refs[0].native_url
         finally:
             await connector.close()
 
-    async def test_server_native_url_includes_project(
-        self, make_repo
-    ) -> None:
+    async def test_server_native_url_includes_project(self, make_repo) -> None:
         repo = make_repo("api", {"app.py": "x"})
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -544,9 +524,7 @@ class TestServerDiscoverFetch:
 
 
 class TestFetch:
-    async def test_fetch_yields_document_for_known_ref(
-        self, make_repo
-    ) -> None:
+    async def test_fetch_yields_document_for_known_ref(self, make_repo) -> None:
         repo = make_repo("svc", {"a.txt": "alpha", "b.txt": "beta"})
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -563,9 +541,7 @@ class TestFetch:
             raise AssertionError(url)
 
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="contoso", project="P"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="contoso", project="P"),
             auth=AzureDevOpsAuth.pat("p"),
             transport=httpx.MockTransport(handler),
             clone_fn=_stub_clone(lambda _: repo),
@@ -583,9 +559,7 @@ class TestFetch:
 
     async def test_fetch_unknown_ref_yields_empty(self) -> None:
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="x", project="P"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="x", project="P"),
             auth=AzureDevOpsAuth.pat("p"),
             transport=httpx.MockTransport(
                 lambda _: httpx.Response(200, json={"value": []})
@@ -605,9 +579,7 @@ class TestFetch:
 
     async def test_fetch_missing_metadata_yields_empty(self) -> None:
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="x", project="P"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="x", project="P"),
             auth=AzureDevOpsAuth.pat("p"),
             transport=httpx.MockTransport(
                 lambda _: httpx.Response(200, json={"value": []})
@@ -630,9 +602,7 @@ class TestFetch:
 
 
 class TestEnumerateSeam:
-    async def test_enumerate_fn_replaces_http_enumeration(
-        self, make_repo
-    ) -> None:
+    async def test_enumerate_fn_replaces_http_enumeration(self, make_repo) -> None:
         repo = make_repo("only", {"f.txt": "x"})
 
         async def fake_enum(
@@ -644,9 +614,7 @@ class TestEnumerateSeam:
             yield ("Acme", "only", "https://x/Acme/_git/only", False)
 
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="x"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="x"),
             auth=AzureDevOpsAuth.pat("p"),
             transport=httpx.MockTransport(
                 lambda _: httpx.Response(500)
@@ -660,9 +628,7 @@ class TestEnumerateSeam:
         finally:
             await connector.close()
 
-    async def test_enumerate_fn_disabled_filtered(
-        self, make_repo
-    ) -> None:
+    async def test_enumerate_fn_disabled_filtered(self, make_repo) -> None:
         repo = make_repo("svc", {"f.txt": "x"})
 
         async def enum(connector, filter, cursor):
@@ -706,9 +672,7 @@ class TestCloneLifecycle:
             )
 
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="x", project="P"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="x", project="P"),
             auth=AzureDevOpsAuth.pat("p"),
             transport=httpx.MockTransport(handler),
             clone_fn=counting,
@@ -720,9 +684,7 @@ class TestCloneLifecycle:
         finally:
             await connector.close()
 
-    async def test_close_drops_tempdirs_and_clients(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_close_drops_tempdirs_and_clients(self, tmp_path: Path) -> None:
         # We use a real tmp directory (not the make_repo one) and check
         # rmtree happens; the stub returns this dir and after close()
         # it must be gone.
@@ -741,9 +703,7 @@ class TestCloneLifecycle:
             )
 
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="x", project="P"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="x", project="P"),
             auth=AzureDevOpsAuth.pat("p"),
             transport=httpx.MockTransport(handler),
             clone_fn=lambda *_: clone_dir,
@@ -758,9 +718,7 @@ class TestCloneLifecycle:
 
     async def test_close_idempotent(self) -> None:
         connector = AzureDevOpsConnector(
-            AzureDevOpsConfig(
-                flavor="services", organization="x"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="x"),
             auth=AzureDevOpsAuth.pat("p"),
         )
         await connector.close()
@@ -917,9 +875,7 @@ class TestCloneIntoTempdir:
 
         path = _clone_into_tempdir(
             "https://dev/contoso/P/_git/svc",
-            AzureDevOpsConfig(
-                flavor="services", organization="contoso"
-            ),
+            AzureDevOpsConfig(flavor="services", organization="contoso"),
             "Bearer xyz",
         )
         assert path.exists()
@@ -927,9 +883,7 @@ class TestCloneIntoTempdir:
         assert "--depth=1" in captured["cmd"]
         assert "https://dev/contoso/P/_git/svc" in captured["cmd"]
         # CA bundle not configured -> no http.sslCAInfo flag.
-        assert not any(
-            "http.sslCAInfo" in part for part in captured["cmd"]
-        )
+        assert not any("http.sslCAInfo" in part for part in captured["cmd"])
 
     def test_subprocess_with_ca_bundle(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -955,9 +909,7 @@ class TestCloneIntoTempdir:
             ),
             "Basic Og==",
         )
-        assert any(
-            "http.sslCAInfo" in part for part in captured["cmd"]
-        )
+        assert any("http.sslCAInfo" in part for part in captured["cmd"])
 
     def test_subprocess_failure_cleans_up_tempdir(
         self, monkeypatch: pytest.MonkeyPatch
@@ -984,9 +936,7 @@ class TestCloneIntoTempdir:
         with pytest.raises(RuntimeError, match="git failed"):
             _clone_into_tempdir(
                 "https://x",
-                AzureDevOpsConfig(
-                    flavor="services", organization="x"
-                ),
+                AzureDevOpsConfig(flavor="services", organization="x"),
                 "Bearer t",
             )
         assert captured_paths

--- a/packages/pii-scanner-bigquery/src/pleno_pii_scanner_bigquery/connector.py
+++ b/packages/pii-scanner-bigquery/src/pleno_pii_scanner_bigquery/connector.py
@@ -117,11 +117,7 @@ class BigQueryConfig:
         if not self.project:
             raise ValueError("project must be non-empty")
         # Exactly-one auth mode — both is ambiguous, neither is unauthenticated.
-        modes = sum(
-            1
-            for v in (self.service_account_json, self.federated_token)
-            if v
-        )
+        modes = sum(1 for v in (self.service_account_json, self.federated_token) if v)
         if modes == 0:
             raise ValueError(
                 "exactly one of service_account_json or federated_token "
@@ -251,10 +247,7 @@ class BigQueryConnector:
         return out
 
     async def _list_tables(self, token: str, dataset: str) -> list[str]:
-        url = (
-            f"{_API_BASE}/projects/{self._config.project}"
-            f"/datasets/{dataset}/tables"
-        )
+        url = f"{_API_BASE}/projects/{self._config.project}/datasets/{dataset}/tables"
         out: list[str] = []
         page_token: str | None = None
         while True:
@@ -329,10 +322,7 @@ class BigQueryConnector:
             page_token = page.get("pageToken")
             if not page_token or not job_id:
                 return
-            page_url = (
-                f"{_API_BASE}/projects/{self._config.project}"
-                f"/queries/{job_id}"
-            )
+            page_url = f"{_API_BASE}/projects/{self._config.project}/queries/{job_id}"
             params: dict[str, str] = {
                 "pageToken": page_token,
                 "maxResults": str(self._config.page_size),
@@ -340,9 +330,7 @@ class BigQueryConnector:
             location = job_ref.get("location") or self._config.location
             if location:
                 params["location"] = location
-            page = await self._authed_get_json(
-                token, page_url, params=params
-            )
+            page = await self._authed_get_json(token, page_url, params=params)
 
     @staticmethod
     def _page_row_count(page: Mapping[str, Any]) -> int:
@@ -390,9 +378,7 @@ class BigQueryConnector:
             )
 
     async def _dry_run_or_raise(self, token: str, sql: str) -> None:
-        url = (
-            f"{_API_BASE}/projects/{self._config.project}/jobs?dryRun=true"
-        )
+        url = f"{_API_BASE}/projects/{self._config.project}/jobs?dryRun=true"
         # `jobs.insert` (not jobs.query) is the dry-run-supporting endpoint.
         body = await self._authed_post_json(
             token,
@@ -508,9 +494,7 @@ def _matches_any(s: str, patterns: tuple[str, ...]) -> bool:
     return any(fnmatch(s, p) for p in patterns)
 
 
-def _project_row(
-    row: Mapping[str, Any], column_names: list[str]
-) -> dict[str, Any]:
+def _project_row(row: Mapping[str, Any], column_names: list[str]) -> dict[str, Any]:
     """Project a BigQuery row (`{"f": [{"v": ...}, ...]}`) to a dict.
 
     BigQuery's REST API returns rows in a column-positional shape; we
@@ -531,9 +515,7 @@ def _project_row(
     return out
 
 
-def _sign_sa_jwt(
-    sa_data: Mapping[str, Any], *, scope: str, lifetime_secs: int
-) -> str:
+def _sign_sa_jwt(sa_data: Mapping[str, Any], *, scope: str, lifetime_secs: int) -> str:
     """Sign a Google service-account JWT (RS256).
 
     Keeps the dependency surface to stdlib + cryptography (which httpx
@@ -560,12 +542,8 @@ def _sign_sa_jwt(
     seg_p = _b64url(json.dumps(payload, separators=(",", ":")).encode())
     signing_input = f"{seg_h}.{seg_p}".encode()
     private_key_pem = sa_data["private_key"].encode()
-    private_key = serialization.load_pem_private_key(
-        private_key_pem, password=None
-    )
-    signature = private_key.sign(
-        signing_input, padding.PKCS1v15(), hashes.SHA256()
-    )
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    signature = private_key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
     return f"{seg_h}.{seg_p}.{_b64url(signature)}"
 
 
@@ -586,9 +564,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
             service_account_json=_opt_str(config, "service_account_json"),
             federated_token=_opt_str(config, "federated_token"),
             sample_percent=float(config.get("sample_percent", 1.0)),
-            max_bytes_billed=int(
-                config.get("max_bytes_billed", _DEFAULT_MAX_BYTES)
-            ),
+            max_bytes_billed=int(config.get("max_bytes_billed", _DEFAULT_MAX_BYTES)),
             page_size=int(config.get("page_size", 1000)),
             location=str(config.get("location", "US")),
             id=_opt_str(config, "id"),

--- a/packages/pii-scanner-bigquery/tests/test_connector.py
+++ b/packages/pii-scanner-bigquery/tests/test_connector.py
@@ -77,15 +77,11 @@ class TestConfig:
 
     def test_rejects_oversized_sample(self) -> None:
         with pytest.raises(ValueError, match="sample_percent"):
-            BigQueryConfig(
-                project="p", federated_token="t", sample_percent=200
-            )
+            BigQueryConfig(project="p", federated_token="t", sample_percent=200)
 
     def test_rejects_zero_max_bytes(self) -> None:
         with pytest.raises(ValueError, match="max_bytes_billed"):
-            BigQueryConfig(
-                project="p", federated_token="t", max_bytes_billed=0
-            )
+            BigQueryConfig(project="p", federated_token="t", max_bytes_billed=0)
 
     def test_rejects_zero_page_size(self) -> None:
         with pytest.raises(ValueError, match="page_size"):
@@ -106,12 +102,8 @@ class TestConfig:
         assert rid.startswith("bigquery:")
 
     def test_default_id_dataset_order_independent(self) -> None:
-        a = BigQueryConfig(
-            project="p", federated_token="t", datasets=("a", "b")
-        )
-        b = BigQueryConfig(
-            project="p", federated_token="t", datasets=("b", "a")
-        )
+        a = BigQueryConfig(project="p", federated_token="t", datasets=("a", "b"))
+        b = BigQueryConfig(project="p", federated_token="t", datasets=("b", "a"))
         assert a.resolved_id() == b.resolved_id()
 
 
@@ -120,15 +112,11 @@ class TestConfig:
 
 class TestProtocol:
     def test_runtime_isinstance(self) -> None:
-        c = BigQueryConnector(
-            BigQueryConfig(project="p", federated_token="t")
-        )
+        c = BigQueryConnector(BigQueryConfig(project="p", federated_token="t"))
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
-        c = BigQueryConnector(
-            BigQueryConfig(project="p", federated_token="t")
-        )
+        c = BigQueryConnector(BigQueryConfig(project="p", federated_token="t"))
         assert c.capabilities() == Capabilities(
             incremental=False,
             binary=False,
@@ -201,9 +189,7 @@ class TestTokenAcquisition:
     async def test_service_account_token_endpoint_missing_token(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(
-            _conn_mod, "_sign_sa_jwt", lambda *_a, **_kw: "fake.jwt"
-        )
+        monkeypatch.setattr(_conn_mod, "_sign_sa_jwt", lambda *_a, **_kw: "fake.jwt")
 
         def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json={})  # no access_token field
@@ -361,11 +347,7 @@ class TestDiscoverDatasets:
                 if "pageToken=tnext" in url:
                     return httpx.Response(
                         200,
-                        json={
-                            "tables": [
-                                {"tableReference": {"tableId": "t2"}}
-                            ]
-                        },
+                        json={"tables": [{"tableReference": {"tableId": "t2"}}]},
                     )
                 return httpx.Response(
                     200,
@@ -425,9 +407,7 @@ class TestDiscoverDatasets:
 class TestTableSampleClause:
     def test_omitted_at_100_percent(self) -> None:
         c = BigQueryConnector(
-            BigQueryConfig(
-                project="p", federated_token="t", sample_percent=100.0
-            )
+            BigQueryConfig(project="p", federated_token="t", sample_percent=100.0)
         )
         sql = c._build_sql("d", "t")
         assert "TABLESAMPLE" not in sql
@@ -435,9 +415,7 @@ class TestTableSampleClause:
 
     def test_included_below_100(self) -> None:
         c = BigQueryConnector(
-            BigQueryConfig(
-                project="p", federated_token="t", sample_percent=5.0
-            )
+            BigQueryConfig(project="p", federated_token="t", sample_percent=5.0)
         )
         sql = c._build_sql("d", "t")
         assert "TABLESAMPLE SYSTEM (5.0 PERCENT)" in sql
@@ -453,26 +431,16 @@ class TestDryRunCostCap:
             if url.endswith("/datasets"):
                 return httpx.Response(
                     200,
-                    json={
-                        "datasets": [
-                            {"datasetReference": {"datasetId": "d1"}}
-                        ]
-                    },
+                    json={"datasets": [{"datasetReference": {"datasetId": "d1"}}]},
                 )
             if url.endswith("/datasets/d1/tables"):
                 return httpx.Response(
                     200,
-                    json={
-                        "tables": [
-                            {"tableReference": {"tableId": "huge"}}
-                        ]
-                    },
+                    json={"tables": [{"tableReference": {"tableId": "huge"}}]},
                 )
             if "dryRun=true" in url:
                 # 10 GB estimate vs 1 KB cap.
-                return httpx.Response(
-                    200, json=_dry_run_response(10 * 1024**3)
-                )
+                return httpx.Response(200, json=_dry_run_response(10 * 1024**3))
             return httpx.Response(404)
 
         async with _client(handler) as client:
@@ -501,18 +469,12 @@ class TestDryRunCostCap:
             if url.endswith("/datasets"):
                 return httpx.Response(
                     200,
-                    json={
-                        "datasets": [
-                            {"datasetReference": {"datasetId": "d1"}}
-                        ]
-                    },
+                    json={"datasets": [{"datasetReference": {"datasetId": "d1"}}]},
                 )
             if url.endswith("/datasets/d1/tables"):
                 return httpx.Response(
                     200,
-                    json={
-                        "tables": [{"tableReference": {"tableId": "t1"}}]
-                    },
+                    json={"tables": [{"tableReference": {"tableId": "t1"}}]},
                 )
             if "dryRun=true" in url:
                 # Garbage value → falls through to 0, well under cap.
@@ -548,20 +510,12 @@ class TestPagination:
             if url.endswith("/datasets"):
                 return httpx.Response(
                     200,
-                    json={
-                        "datasets": [
-                            {"datasetReference": {"datasetId": "d1"}}
-                        ]
-                    },
+                    json={"datasets": [{"datasetReference": {"datasetId": "d1"}}]},
                 )
             if url.endswith("/datasets/d1/tables"):
                 return httpx.Response(
                     200,
-                    json={
-                        "tables": [
-                            {"tableReference": {"tableId": "t1"}}
-                        ]
-                    },
+                    json={"tables": [{"tableReference": {"tableId": "t1"}}]},
                 )
             if "dryRun=true" in url:
                 return httpx.Response(200, json=_dry_run_response(1))
@@ -625,20 +579,12 @@ class TestPagination:
             if url.endswith("/datasets"):
                 return httpx.Response(
                     200,
-                    json={
-                        "datasets": [
-                            {"datasetReference": {"datasetId": "d1"}}
-                        ]
-                    },
+                    json={"datasets": [{"datasetReference": {"datasetId": "d1"}}]},
                 )
             if url.endswith("/datasets/d1/tables"):
                 return httpx.Response(
                     200,
-                    json={
-                        "tables": [
-                            {"tableReference": {"tableId": "t1"}}
-                        ]
-                    },
+                    json={"tables": [{"tableReference": {"tableId": "t1"}}]},
                 )
             if "dryRun=true" in url:
                 return httpx.Response(200, json=_dry_run_response(1))
@@ -678,20 +624,12 @@ class TestFetchDocument:
             if url.endswith("/datasets"):
                 return httpx.Response(
                     200,
-                    json={
-                        "datasets": [
-                            {"datasetReference": {"datasetId": "d1"}}
-                        ]
-                    },
+                    json={"datasets": [{"datasetReference": {"datasetId": "d1"}}]},
                 )
             if url.endswith("/datasets/d1/tables"):
                 return httpx.Response(
                     200,
-                    json={
-                        "tables": [
-                            {"tableReference": {"tableId": "users"}}
-                        ]
-                    },
+                    json={"tables": [{"tableReference": {"tableId": "users"}}]},
                 )
             if "dryRun=true" in url:
                 return httpx.Response(200, json=_dry_run_response(1))
@@ -755,13 +693,12 @@ class TestFetchDocument:
         from pleno_pii_scanner_bigquery.connector import _project_row
 
         # Non-mapping cell falls back to None.
-        assert _project_row(
-            {"f": [{"v": "x"}, "garbage"]}, ["a", "b"]
-        ) == {"a": "x", "b": None}
+        assert _project_row({"f": [{"v": "x"}, "garbage"]}, ["a", "b"]) == {
+            "a": "x",
+            "b": None,
+        }
         # Cell list longer than schema is truncated.
-        assert _project_row(
-            {"f": [{"v": 1}, {"v": 2}]}, ["a"]
-        ) == {"a": 1}
+        assert _project_row({"f": [{"v": 1}, {"v": 2}]}, ["a"]) == {"a": 1}
         # Missing 'f' returns empty dict.
         assert _project_row({"x": 1}, ["a"]) == {}
         # Non-mapping row returns empty dict.
@@ -778,11 +715,7 @@ class TestFilter:
             if url.endswith("/datasets"):
                 return httpx.Response(
                     200,
-                    json={
-                        "datasets": [
-                            {"datasetReference": {"datasetId": "d1"}}
-                        ]
-                    },
+                    json={"datasets": [{"datasetReference": {"datasetId": "d1"}}]},
                 )
             if url.endswith("/datasets/d1/tables"):
                 return httpx.Response(
@@ -820,9 +753,7 @@ class TestFilter:
                     )
                 ]
                 assert all(r.path.startswith("d1/users/") for r in refs)
-                assert all(
-                    r.metadata["bq_table"] == "users" for r in refs
-                )
+                assert all(r.metadata["bq_table"] == "users" for r in refs)
             finally:
                 await c.close()
 
@@ -893,9 +824,7 @@ class TestSpec:
 
 class TestClose:
     async def test_close_owns_client(self) -> None:
-        c = BigQueryConnector(
-            BigQueryConfig(project="p", federated_token="t")
-        )
+        c = BigQueryConnector(BigQueryConfig(project="p", federated_token="t"))
         await c.close()
 
     async def test_close_external_client_not_closed(self) -> None:

--- a/packages/pii-scanner-bitbucket/src/pleno_pii_scanner_bitbucket/api.py
+++ b/packages/pii-scanner-bitbucket/src/pleno_pii_scanner_bitbucket/api.py
@@ -256,7 +256,11 @@ class BitbucketApi:
                 )
             request_params = next_params
             if self._flavor == "server" and next_start is not None and next_start > 0:
-                request_params = {**(params or {}), "limit": page_size, "start": next_start}
+                request_params = {
+                    **(params or {}),
+                    "limit": page_size,
+                    "start": next_start,
+                }
             response = await self.get(next_url, params=request_params)
             if response.status_code != 200:
                 # 401/403/404 on a paginated endpoint: yield nothing.

--- a/packages/pii-scanner-bitbucket/src/pleno_pii_scanner_bitbucket/connector.py
+++ b/packages/pii-scanner-bitbucket/src/pleno_pii_scanner_bitbucket/connector.py
@@ -95,9 +95,9 @@ class BitbucketConfig:
 
     flavor: Flavor
     workspace: str | None = None  # required when flavor=cloud and project unset
-    project: str | None = None    # required when flavor=server and repo_slug unset
+    project: str | None = None  # required when flavor=server and repo_slug unset
     repo_slug: str | None = None  # `workspace/repo` (cloud) or `PROJECT/repo` (server)
-    base_url: str | None = None   # default api.bitbucket.org/2.0 for cloud
+    base_url: str | None = None  # default api.bitbucket.org/2.0 for cloud
     include_archived: bool = False
     include_public: bool = True
     ca_bundle_path: str | None = None
@@ -240,9 +240,7 @@ class BitbucketConnector:
         repos = await self._enumerate_fn(self, self._config)
         for slug, clone_url in repos:
             repo_path = await self._ensure_clone(slug, clone_url)
-            inner = DirConnector(
-                DirConfig(root=repo_path, id=f"bitbucket:{slug}")
-            )
+            inner = DirConnector(DirConfig(root=repo_path, id=f"bitbucket:{slug}"))
             try:
                 async for inner_ref in inner.discover(filter, None):
                     yield self._wrap_ref(inner_ref, slug)
@@ -291,9 +289,7 @@ class BitbucketConnector:
         """
         async with self._lock:
             for path in self._tempdirs:
-                await asyncio.to_thread(
-                    shutil.rmtree, path, ignore_errors=True
-                )
+                await asyncio.to_thread(shutil.rmtree, path, ignore_errors=True)
             self._tempdirs.clear()
             self._clones.clear()
         await self._api.aclose()
@@ -431,11 +427,14 @@ def _build_auth(flavor: Flavor, credential: Credential) -> AuthMode:
         return BearerAuth(token=token)
     username = payload.get("username")
     password = (
-        payload.get("app_password")
-        if flavor == "cloud"
-        else payload.get("password")
+        payload.get("app_password") if flavor == "cloud" else payload.get("password")
     )
-    if isinstance(username, str) and isinstance(password, str) and username and password:
+    if (
+        isinstance(username, str)
+        and isinstance(password, str)
+        and username
+        and password
+    ):
         return BasicAuth(username=username, password=password)
     raise ValueError(
         f"bitbucket-{flavor} credential.payload requires either "
@@ -464,9 +463,7 @@ def _embed_credentials(clone_url: str, auth: AuthMode) -> str:
     if isinstance(auth, BearerAuth):
         userinfo = f"x-token-auth:{quote(auth.token, safe='')}"
     else:
-        userinfo = (
-            f"{quote(auth.username, safe='')}:{quote(auth.password, safe='')}"
-        )
+        userinfo = f"{quote(auth.username, safe='')}:{quote(auth.password, safe='')}"
     netloc = parsed.netloc
     # Strip any pre-existing userinfo on the URL — Bitbucket's clone
     # URLs sometimes carry one (`bitbucket-server@host/...`) and we
@@ -517,9 +514,7 @@ def _single_repo_clone_url(config: BitbucketConfig) -> str:
     return f"{host}/scm/{project.lower()}/{repo}.git"
 
 
-def _browse_url(
-    config: BitbucketConfig, slug: str, inner_path: str
-) -> str | None:
+def _browse_url(config: BitbucketConfig, slug: str, inner_path: str) -> str | None:
     """Render a human-clickable browse URL for findings dashboards."""
     if config.flavor == "cloud":
         return f"https://bitbucket.org/{slug}/src/HEAD/{inner_path}"
@@ -615,9 +610,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
                 else None
             ),
             project=(
-                str(config["project"])
-                if config.get("project") is not None
-                else None
+                str(config["project"]) if config.get("project") is not None else None
             ),
             repo_slug=(
                 str(config["repo_slug"])
@@ -625,9 +618,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
                 else None
             ),
             base_url=(
-                str(config["base_url"])
-                if config.get("base_url") is not None
-                else None
+                str(config["base_url"]) if config.get("base_url") is not None else None
             ),
             include_archived=bool(config.get("include_archived", False)),
             include_public=bool(config.get("include_public", True)),

--- a/packages/pii-scanner-bitbucket/tests/test_api.py
+++ b/packages/pii-scanner-bitbucket/tests/test_api.py
@@ -14,7 +14,6 @@ from pleno_pii_scanner_bitbucket.api import (
     BitbucketApiError,
     _retry_after_seconds,
 )
-from tests.conftest import make_handler
 
 
 # ---------------------------------------------------------------------
@@ -147,9 +146,7 @@ class TestCloudPagination:
             transport=httpx.MockTransport(handler),
         )
         try:
-            slugs = [
-                r["slug"] async for r in api.paginate("/repositories/acme")
-            ]
+            slugs = [r["slug"] async for r in api.paginate("/repositories/acme")]
             assert slugs == ["r1", "r2", "r3"]
         finally:
             await api.aclose()
@@ -208,9 +205,7 @@ class TestServerPagination:
             transport=httpx.MockTransport(handler),
         )
         try:
-            slugs = [
-                r["slug"] async for r in api.paginate("/projects/PROD/repos")
-            ]
+            slugs = [r["slug"] async for r in api.paginate("/projects/PROD/repos")]
             assert slugs == ["p1", "p2", "p3"]
             # First request must not include `start=`; second must.
             assert "start=" not in seen_starts[0]
@@ -234,9 +229,7 @@ class TestServerPagination:
             transport=httpx.MockTransport(handler),
         )
         try:
-            slugs = [
-                r["slug"] async for r in api.paginate("/projects/PROD/repos")
-            ]
+            slugs = [r["slug"] async for r in api.paginate("/projects/PROD/repos")]
             assert slugs == ["x"]
         finally:
             await api.aclose()
@@ -254,9 +247,7 @@ class TestServerPagination:
             transport=httpx.MockTransport(handler),
         )
         try:
-            slugs = [
-                r["slug"] async for r in api.paginate("/projects/PROD/repos")
-            ]
+            slugs = [r["slug"] async for r in api.paginate("/projects/PROD/repos")]
             assert slugs == ["y"]
         finally:
             await api.aclose()
@@ -272,9 +263,7 @@ class TestServerPagination:
             transport=httpx.MockTransport(handler),
         )
         try:
-            slugs = [
-                r async for r in api.paginate("/projects/MISSING/repos")
-            ]
+            slugs = [r async for r in api.paginate("/projects/MISSING/repos")]
             assert slugs == []
         finally:
             await api.aclose()

--- a/packages/pii-scanner-bitbucket/tests/test_connector.py
+++ b/packages/pii-scanner-bitbucket/tests/test_connector.py
@@ -301,7 +301,10 @@ class TestCloud:
                             "is_private": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/r1.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/r1.git",
+                                    }
                                 ]
                             },
                         }
@@ -326,9 +329,7 @@ class TestCloud:
         )
         try:
             await _drain(c.discover(SourceFilter(), None))
-            assert clones == [
-                "https://alice:ATBB-abc123@bitbucket.org/acme/r1.git"
-            ]
+            assert clones == ["https://alice:ATBB-abc123@bitbucket.org/acme/r1.git"]
         finally:
             await c.close()
 
@@ -347,7 +348,10 @@ class TestCloud:
                             "is_private": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/r1.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/r1.git",
+                                    }
                                 ]
                             },
                         }
@@ -362,9 +366,7 @@ class TestCloud:
             make_handler([("/repositories/acme", repos_handler)])
         )
         c = BitbucketConnector(
-            BitbucketConfig(
-                flavor="cloud", workspace="acme", include_archived=True
-            ),
+            BitbucketConfig(flavor="cloud", workspace="acme", include_archived=True),
             credential=cloud_token_credential,
             transport=transport,
             clone_fn=fake_clone,
@@ -390,7 +392,10 @@ class TestCloud:
                             "is_private": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/private.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/private.git",
+                                    }
                                 ]
                             },
                         },
@@ -401,7 +406,10 @@ class TestCloud:
                             "is_private": False,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/public.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/public.git",
+                                    }
                                 ]
                             },
                         },
@@ -416,9 +424,7 @@ class TestCloud:
             make_handler([("/repositories/acme", repos_handler)])
         )
         c = BitbucketConnector(
-            BitbucketConfig(
-                flavor="cloud", workspace="acme", include_public=False
-            ),
+            BitbucketConfig(flavor="cloud", workspace="acme", include_public=False),
             credential=cloud_token_credential,
             transport=transport,
             clone_fn=fake_clone,
@@ -472,7 +478,10 @@ class TestCloud:
                             "is_private": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/r1.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/r1.git",
+                                    }
                                 ]
                             },
                         }
@@ -540,7 +549,10 @@ class TestCloud:
                             "is_private": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/ok.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/ok.git",
+                                    }
                                 ]
                             },
                         },
@@ -586,7 +598,10 @@ class TestServer:
                             "public": False,
                             "links": {
                                 "clone": [
-                                    {"name": "http", "href": "https://bb.acme/scm/prod/alpha.git"}
+                                    {
+                                        "name": "http",
+                                        "href": "https://bb.acme/scm/prod/alpha.git",
+                                    }
                                 ]
                             },
                         },
@@ -602,7 +617,10 @@ class TestServer:
                             "public": False,
                             "links": {
                                 "clone": [
-                                    {"name": "http", "href": "https://bb.acme/scm/prod/beta.git"}
+                                    {
+                                        "name": "http",
+                                        "href": "https://bb.acme/scm/prod/beta.git",
+                                    }
                                 ]
                             },
                         },
@@ -612,7 +630,10 @@ class TestServer:
                             "public": False,
                             "links": {
                                 "clone": [
-                                    {"name": "http", "href": "https://bb.acme/scm/prod/gamma.git"}
+                                    {
+                                        "name": "http",
+                                        "href": "https://bb.acme/scm/prod/gamma.git",
+                                    }
                                 ]
                             },
                         },
@@ -648,9 +669,7 @@ class TestServer:
             for r in refs:
                 assert r.metadata["flavor"] == "server"
                 assert r.native_url is not None
-                assert (
-                    "bb.acme/projects/PROD/repos/" in r.native_url
-                )
+                assert "bb.acme/projects/PROD/repos/" in r.native_url
         finally:
             await c.close()
 
@@ -703,9 +722,7 @@ class TestServer:
             await _drain(c.discover(SourceFilter(), None))
             # Pre-existing `bitbucket-server@` userinfo is stripped and
             # replaced with the configured basic auth.
-            assert clones == [
-                "https://svc:p%4055@bb.acme/scm/prod/alpha.git"
-            ]
+            assert clones == ["https://svc:p%4055@bb.acme/scm/prod/alpha.git"]
         finally:
             await c.close()
 
@@ -723,7 +740,10 @@ class TestServer:
                             "public": False,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bb.acme/scm/prod/private.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bb.acme/scm/prod/private.git",
+                                    }
                                 ]
                             },
                         },
@@ -733,7 +753,10 @@ class TestServer:
                             "public": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bb.acme/scm/prod/public.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bb.acme/scm/prod/public.git",
+                                    }
                                 ]
                             },
                         },
@@ -781,7 +804,10 @@ class TestServer:
                             "public": False,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bb.acme/scm/prod/ok.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bb.acme/scm/prod/ok.git",
+                                    }
                                 ]
                             },
                         },
@@ -826,9 +852,7 @@ class TestServer:
         c = BitbucketConnector(
             BitbucketConfig(flavor="cloud", repo_slug="acme/r"),
             credential=cloud_token_credential,
-            transport=httpx.MockTransport(
-                lambda _: httpx.Response(404)
-            ),
+            transport=httpx.MockTransport(lambda _: httpx.Response(404)),
             clone_fn=fake_clone,
         )
         try:
@@ -895,7 +919,10 @@ class TestRateLimitDuringDiscover:
                                 "is_private": True,
                                 "links": {
                                     "clone": [
-                                        {"name": "https", "href": "https://bitbucket.org/acme/r1.git"}
+                                        {
+                                            "name": "https",
+                                            "href": "https://bitbucket.org/acme/r1.git",
+                                        }
                                     ]
                                 },
                             }
@@ -953,7 +980,10 @@ class TestLifecycle:
                             "is_private": True,
                             "links": {
                                 "clone": [
-                                    {"name": "https", "href": "https://bitbucket.org/acme/r1.git"}
+                                    {
+                                        "name": "https",
+                                        "href": "https://bitbucket.org/acme/r1.git",
+                                    }
                                 ]
                             },
                         }
@@ -1059,26 +1089,33 @@ class TestUrlHelpers:
     def test_pick_cloud_clone_url_missing_returns_none(self) -> None:
         assert _pick_cloud_clone_url({}) is None
         assert _pick_cloud_clone_url({"links": {"clone": []}}) is None
-        assert _pick_cloud_clone_url(
-            {"links": {"clone": [{"name": "ssh", "href": "x"}]}}
-        ) is None
+        assert (
+            _pick_cloud_clone_url({"links": {"clone": [{"name": "ssh", "href": "x"}]}})
+            is None
+        )
 
     def test_pick_server_clone_url_accepts_http_or_https(self) -> None:
-        assert _pick_server_clone_url(
-            {"links": {"clone": [{"name": "http", "href": "https://bb/scm/p/r.git"}]}}
-        ) == "https://bb/scm/p/r.git"
+        assert (
+            _pick_server_clone_url(
+                {
+                    "links": {
+                        "clone": [{"name": "http", "href": "https://bb/scm/p/r.git"}]
+                    }
+                }
+            )
+            == "https://bb/scm/p/r.git"
+        )
 
     def test_pick_server_clone_url_missing_returns_none(self) -> None:
         assert _pick_server_clone_url({}) is None
-        assert _pick_server_clone_url(
-            {"links": {"clone": [{"name": "ssh", "href": "x"}]}}
-        ) is None
+        assert (
+            _pick_server_clone_url({"links": {"clone": [{"name": "ssh", "href": "x"}]}})
+            is None
+        )
 
     def test_single_repo_clone_url_cloud(self) -> None:
         c = BitbucketConfig(flavor="cloud", repo_slug="acme/r")
-        assert (
-            _single_repo_clone_url(c) == "https://bitbucket.org/acme/r.git"
-        )
+        assert _single_repo_clone_url(c) == "https://bitbucket.org/acme/r.git"
 
     def test_single_repo_clone_url_server(self) -> None:
         c = BitbucketConfig(
@@ -1107,13 +1144,9 @@ class TestUrlHelpers:
         assert url == "https://bitbucket.org/acme/r1/src/HEAD/src/main.py"
 
     def test_browse_url_server(self) -> None:
-        c = BitbucketConfig(
-            flavor="server", project="PROD", base_url="https://bb.acme"
-        )
+        c = BitbucketConfig(flavor="server", project="PROD", base_url="https://bb.acme")
         url = _browse_url(c, "PROD/alpha", "src/main.py")
-        assert (
-            url == "https://bb.acme/projects/PROD/repos/alpha/browse/src/main.py"
-        )
+        assert url == "https://bb.acme/projects/PROD/repos/alpha/browse/src/main.py"
 
     def test_normalise_base_url_cloud_idempotent(self) -> None:
         assert (
@@ -1143,18 +1176,12 @@ class TestUrlHelpers:
         assert _pick_cloud_clone_url(repo_cloud) == "https://h"
         # And the case where the matching name is found but href is not
         # a string (defensive against schema drift).
-        assert _pick_cloud_clone_url(
-            {"links": {"clone": [{"name": "https"}]}}
-        ) is None
-        assert _pick_server_clone_url(
-            {"links": {"clone": [{"name": "https"}]}}
-        ) is None
+        assert _pick_cloud_clone_url({"links": {"clone": [{"name": "https"}]}}) is None
+        assert _pick_server_clone_url({"links": {"clone": [{"name": "https"}]}}) is None
 
     def test_normalise_base_url_server_idempotent(self) -> None:
         assert (
-            _normalise_base_url(
-                "server", "https://bb.acme/rest/api/1.0"
-            )
+            _normalise_base_url("server", "https://bb.acme/rest/api/1.0")
             == "https://bb.acme/rest/api/1.0"
         )
 
@@ -1177,9 +1204,7 @@ class TestSpec:
         assert SPEC.required_scopes == ("repository:read",)
         assert SPEC.capabilities.incremental is False
 
-    def test_factory_cloud_workspace(
-        self, cloud_token_credential: Credential
-    ) -> None:
+    def test_factory_cloud_workspace(self, cloud_token_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "cloud",
@@ -1190,9 +1215,7 @@ class TestSpec:
         assert isinstance(c, BitbucketConnector)
         assert c.id == "bitbucket-cloud:acme"
 
-    def test_factory_server_project(
-        self, server_token_credential: Credential
-    ) -> None:
+    def test_factory_server_project(self, server_token_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "server",
@@ -1209,9 +1232,7 @@ class TestSpec:
         assert isinstance(c, BitbucketConnector)
         assert c.id == "my-source"
 
-    def test_factory_repo_slug_only(
-        self, cloud_token_credential: Credential
-    ) -> None:
+    def test_factory_repo_slug_only(self, cloud_token_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "cloud",

--- a/packages/pii-scanner-ci-logs/src/pleno_pii_scanner_ci_logs/api.py
+++ b/packages/pii-scanner-ci-logs/src/pleno_pii_scanner_ci_logs/api.py
@@ -242,8 +242,7 @@ class CiLogsApi:
         response = await self.get(path_or_url, accept="application/zip")
         if response.status_code != 200:
             raise CiLogsApiError(
-                f"ci_logs[{self._flavor}] log-fetch returned "
-                f"{response.status_code}"
+                f"ci_logs[{self._flavor}] log-fetch returned {response.status_code}"
             )
         return response.content
 

--- a/packages/pii-scanner-ci-logs/src/pleno_pii_scanner_ci_logs/connector.py
+++ b/packages/pii-scanner-ci-logs/src/pleno_pii_scanner_ci_logs/connector.py
@@ -36,7 +36,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-import httpx
 
 from pleno_pii_scanner.credentials.broker import Credential
 from pleno_pii_scanner.sources.base import (
@@ -336,11 +335,11 @@ class CiLogsConnector:
                 native_url=str(entry.get("html_url"))
                 if entry.get("html_url")
                 else None,
-                parent_chain=(f"github_actions://{self._config.owner}/{self._config.repo}",),
+                parent_chain=(
+                    f"github_actions://{self._config.owner}/{self._config.repo}",
+                ),
                 content_type="application/zip",
-                etag=str(entry.get("head_sha"))
-                if entry.get("head_sha")
-                else None,
+                etag=str(entry.get("head_sha")) if entry.get("head_sha") else None,
                 last_modified=created_at,
                 metadata={
                     "flavor": "github_actions",
@@ -390,9 +389,7 @@ class CiLogsConnector:
                 source_id=self.id,
                 source_kind=self.kind,
                 path=f"{self._config.owner}/{self._config.repo}/jobs/{job_number}",
-                native_url=str(entry.get("web_url"))
-                if entry.get("web_url")
-                else None,
+                native_url=str(entry.get("web_url")) if entry.get("web_url") else None,
                 parent_chain=(f"circleci://{self._config.owner}/{self._config.repo}",),
                 content_type="text/plain",
                 last_modified=started_at,
@@ -459,11 +456,7 @@ class CiLogsConnector:
                     ),
                     native_url=str(job.get("web_url"))
                     if job.get("web_url")
-                    else (
-                        str(entry.get("web_url"))
-                        if entry.get("web_url")
-                        else None
-                    ),
+                    else (str(entry.get("web_url")) if entry.get("web_url") else None),
                     parent_chain=(
                         f"buildkite://{self._config.org}/{self._config.pipeline}",
                     ),
@@ -491,9 +484,7 @@ class CiLogsConnector:
         # `lastBuild=null` is the documented "no builds yet" response;
         # we filter that downstream.
         params = {
-            "tree": (
-                "jobs[name,builds[number,url,timestamp,result]]"
-            ),
+            "tree": ("jobs[name,builds[number,url,timestamp,result]]"),
         }
         response = await self._api.get("/api/json", params=params)
         if response.status_code != 200:
@@ -523,7 +514,11 @@ class CiLogsConnector:
                     if isinstance(ts, (int, float))
                     else None
                 )
-                if since is not None and last_modified is not None and last_modified < since:
+                if (
+                    since is not None
+                    and last_modified is not None
+                    and last_modified < since
+                ):
                     # Jenkins returns newest-first; stop early.
                     return
                 result = str(build.get("result") or "")
@@ -584,9 +579,7 @@ class CiLogsConnector:
         else:
             return
 
-    async def _fetch_github_actions(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document]:
+    async def _fetch_github_actions(self, ref: DocumentRef) -> AsyncIterator[Document]:
         owner = ref.metadata.get("owner")
         repo = ref.metadata.get("repo")
         run_id = ref.metadata.get("run_id")
@@ -636,9 +629,7 @@ class CiLogsConnector:
                 extra={"member": info.filename},
             )
 
-    async def _fetch_circleci(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document]:
+    async def _fetch_circleci(self, ref: DocumentRef) -> AsyncIterator[Document]:
         owner = ref.metadata.get("owner")
         repo = ref.metadata.get("repo")
         vcs = ref.metadata.get("vcs_type") or "gh"
@@ -667,9 +658,7 @@ class CiLogsConnector:
             fetched_at=datetime.now(UTC),
         )
 
-    async def _fetch_buildkite(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document]:
+    async def _fetch_buildkite(self, ref: DocumentRef) -> AsyncIterator[Document]:
         org = ref.metadata.get("org")
         pipeline = ref.metadata.get("pipeline")
         build_number = ref.metadata.get("build_number")
@@ -699,9 +688,7 @@ class CiLogsConnector:
             fetched_at=datetime.now(UTC),
         )
 
-    async def _fetch_jenkins(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document]:
+    async def _fetch_jenkins(self, ref: DocumentRef) -> AsyncIterator[Document]:
         build_url = ref.metadata.get("build_url")
         if not build_url:
             return
@@ -745,7 +732,12 @@ def _build_auth(flavor: Flavor, credential: Credential) -> AuthMode:
     if flavor == "jenkins":
         username = payload.get("username")
         password = payload.get("password") or payload.get("api_token")
-        if isinstance(username, str) and isinstance(password, str) and username and password:
+        if (
+            isinstance(username, str)
+            and isinstance(password, str)
+            and username
+            and password
+        ):
             return BasicAuth(username=username, password=password)
         raise ValueError(
             "ci_logs[jenkins] credential.payload requires "
@@ -754,8 +746,7 @@ def _build_auth(flavor: Flavor, credential: Credential) -> AuthMode:
     token = payload.get("token") or payload.get("access_token")
     if not isinstance(token, str) or not token:
         raise ValueError(
-            f"ci_logs[{flavor}] credential.payload requires `token` "
-            f"(or `access_token`)"
+            f"ci_logs[{flavor}] credential.payload requires `token` (or `access_token`)"
         )
     if flavor == "circleci":
         return CircleTokenAuth(token=token)
@@ -885,21 +876,15 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
             vcs_type=str(config.get("vcs_type", "gh")),
             org=str(config["org"]) if config.get("org") is not None else None,
             pipeline=(
-                str(config["pipeline"])
-                if config.get("pipeline") is not None
-                else None
+                str(config["pipeline"]) if config.get("pipeline") is not None else None
             ),
             base_url=(
-                str(config["base_url"])
-                if config.get("base_url") is not None
-                else None
+                str(config["base_url"]) if config.get("base_url") is not None else None
             ),
             since=since,
             max_builds=int(config.get("max_builds", DEFAULT_MAX_BUILDS)),
             failed_only=bool(config.get("failed_only", False)),
-            max_log_bytes=int(
-                config.get("max_log_bytes", DEFAULT_MAX_LOG_BYTES)
-            ),
+            max_log_bytes=int(config.get("max_log_bytes", DEFAULT_MAX_LOG_BYTES)),
             id=str(config["id"]) if config.get("id") is not None else None,
         ),
         credential=cred_obj,

--- a/packages/pii-scanner-ci-logs/tests/test_api.py
+++ b/packages/pii-scanner-ci-logs/tests/test_api.py
@@ -233,9 +233,7 @@ class TestLinkParser:
             '<https://api.buildkite.com/v2/p?page=2>; rel="next", '
             '<https://api.buildkite.com/v2/p?page=10>; rel="last"'
         )
-        assert (
-            _link_next(header) == "https://api.buildkite.com/v2/p?page=2"
-        )
+        assert _link_next(header) == "https://api.buildkite.com/v2/p?page=2"
 
     def test_returns_none_when_no_next(self) -> None:
         assert _link_next('<https://x>; rel="last"') is None
@@ -281,9 +279,7 @@ class TestGithubActionsPagination:
         try:
             ids = [
                 e["id"]
-                async for e in api.paginate(
-                    "/repos/o/r/actions/runs", page_size=2
-                )
+                async for e in api.paginate("/repos/o/r/actions/runs", page_size=2)
             ]
             assert ids == [0, 1, 2]
             assert "page=1" in seen_pages[0]
@@ -359,10 +355,7 @@ class TestCircleCiPagination:
             transport=httpx.MockTransport(handler),
         )
         try:
-            jobs = [
-                j["job_number"]
-                async for j in api.paginate("/project/gh/o/r/job")
-            ]
+            jobs = [j["job_number"] async for j in api.paginate("/project/gh/o/r/job")]
             assert jobs == [1, 2, 3]
             assert "page-token" not in seen_qs[0]
             assert "page-token=tok-2" in seen_qs[1]
@@ -384,8 +377,8 @@ class TestBuildkitePagination:
                     json=[{"number": 1}, {"number": 2}],
                     headers={
                         "Link": (
-                            '<https://api.buildkite.com/v2/'
-                            'organizations/o/pipelines/p/builds?page=2>; '
+                            "<https://api.buildkite.com/v2/"
+                            "organizations/o/pipelines/p/builds?page=2>; "
                             'rel="next"'
                         )
                     },
@@ -408,9 +401,7 @@ class TestBuildkitePagination:
         try:
             builds = [
                 e["number"]
-                async for e in api.paginate(
-                    "/organizations/o/pipelines/p/builds"
-                )
+                async for e in api.paginate("/organizations/o/pipelines/p/builds")
             ]
             assert builds == [1, 2, 3]
             # Second URL must be the absolute one from Link rel=next.
@@ -435,10 +426,7 @@ class TestBuildkitePagination:
         )
         try:
             entries = [
-                e
-                async for e in api.paginate(
-                    "/organizations/o/pipelines/p/builds"
-                )
+                e async for e in api.paginate("/organizations/o/pipelines/p/builds")
             ]
             assert entries == []
         finally:
@@ -456,12 +444,12 @@ class TestPaginationGuards:
             flavor="jenkins",
             base_url="https://j.local",
             auth=BasicAuth(username="u", password="p"),
-            transport=httpx.MockTransport(
-                lambda _: httpx.Response(200, json={})
-            ),
+            transport=httpx.MockTransport(lambda _: httpx.Response(200, json={})),
         )
         try:
-            with pytest.raises(CiLogsApiError, match="jenkins flavor does not paginate"):
+            with pytest.raises(
+                CiLogsApiError, match="jenkins flavor does not paginate"
+            ):
                 async for _ in api.paginate("/api/json"):
                     pass
         finally:

--- a/packages/pii-scanner-ci-logs/tests/test_connector.py
+++ b/packages/pii-scanner-ci-logs/tests/test_connector.py
@@ -71,15 +71,11 @@ class TestConfig:
 
     def test_invalid_vcs_type_rejected(self) -> None:
         with pytest.raises(ValueError, match="vcs_type"):
-            CiLogsConfig(
-                flavor="circleci", owner="o", repo="r", vcs_type="ghe"
-            )
+            CiLogsConfig(flavor="circleci", owner="o", repo="r", vcs_type="ghe")
 
     def test_max_builds_must_be_positive(self) -> None:
         with pytest.raises(ValueError, match="max_builds"):
-            CiLogsConfig(
-                flavor="github_actions", owner="o", repo="r", max_builds=0
-            )
+            CiLogsConfig(flavor="github_actions", owner="o", repo="r", max_builds=0)
 
     def test_max_log_bytes_must_be_positive(self) -> None:
         with pytest.raises(ValueError, match="max_log_bytes"):
@@ -107,9 +103,7 @@ class TestConfig:
         assert c.resolved_id() == "jenkins:https://j.local"
 
     def test_resolved_id_explicit_id_wins(self) -> None:
-        c = CiLogsConfig(
-            flavor="github_actions", owner="o", repo="r", id="custom-id"
-        )
+        c = CiLogsConfig(flavor="github_actions", owner="o", repo="r", id="custom-id")
         assert c.resolved_id() == "custom-id"
 
     def test_resolved_base_url_default_per_flavor(self) -> None:
@@ -158,9 +152,7 @@ class TestAuthSelection:
         assert auth.password == "jenkins_TESTTOKEN"
 
     def test_jenkins_password_alias_accepted(self) -> None:
-        cred = Credential(
-            kind="ci_logs", payload={"username": "u", "password": "pw"}
-        )
+        cred = Credential(kind="ci_logs", payload={"username": "u", "password": "pw"})
         auth = _build_auth("jenkins", cred)
         assert isinstance(auth, BasicAuth)
         assert auth.password == "pw"
@@ -213,9 +205,7 @@ class TestAuthSelection:
 
 
 class TestConstruction:
-    def test_runtime_protocol_isinstance(
-        self, gha_credential: Credential
-    ) -> None:
+    def test_runtime_protocol_isinstance(self, gha_credential: Credential) -> None:
         c = CiLogsConnector(
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
@@ -402,9 +392,7 @@ class TestGithubActions:
         finally:
             await c.close()
 
-    async def test_max_builds_caps_emission(
-        self, gha_credential: Credential
-    ) -> None:
+    async def test_max_builds_caps_emission(self, gha_credential: Credential) -> None:
         def runs(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -498,9 +486,7 @@ class TestGithubActions:
         finally:
             await c.close()
 
-    async def test_fetch_unpacks_zip_members(
-        self, gha_credential: Credential
-    ) -> None:
+    async def test_fetch_unpacks_zip_members(self, gha_credential: Credential) -> None:
         zip_blob = build_zip(
             {
                 "step1.txt": b"echo $TOKEN=ghp_secret\n",
@@ -513,9 +499,7 @@ class TestGithubActions:
             return httpx.Response(
                 200,
                 json={
-                    "workflow_runs": [
-                        {"id": 42, "created_at": "2026-05-04T00:00:00Z"}
-                    ],
+                    "workflow_runs": [{"id": 42, "created_at": "2026-05-04T00:00:00Z"}],
                     "total_count": 1,
                 },
             )
@@ -527,10 +511,12 @@ class TestGithubActions:
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/runs/42/logs", logs),
-                    ("/runs", runs),
-                ])
+                make_handler(
+                    [
+                        ("/runs/42/logs", logs),
+                        ("/runs", runs),
+                    ]
+                )
             ),
         )
         try:
@@ -563,9 +549,7 @@ class TestGithubActions:
             return httpx.Response(
                 200,
                 json={
-                    "workflow_runs": [
-                        {"id": 1, "created_at": "2026-05-04T00:00:00Z"}
-                    ],
+                    "workflow_runs": [{"id": 1, "created_at": "2026-05-04T00:00:00Z"}],
                     "total_count": 1,
                 },
             )
@@ -582,10 +566,12 @@ class TestGithubActions:
             ),
             credential=gha_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/runs/1/logs", logs),
-                    ("/runs", runs),
-                ])
+                make_handler(
+                    [
+                        ("/runs/1/logs", logs),
+                        ("/runs", runs),
+                    ]
+                )
             ),
         )
         try:
@@ -603,9 +589,7 @@ class TestGithubActions:
             return httpx.Response(
                 200,
                 json={
-                    "workflow_runs": [
-                        {"id": 1, "created_at": "2026-05-04T00:00:00Z"}
-                    ],
+                    "workflow_runs": [{"id": 1, "created_at": "2026-05-04T00:00:00Z"}],
                     "total_count": 1,
                 },
             )
@@ -617,10 +601,12 @@ class TestGithubActions:
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/runs/1/logs", logs),
-                    ("/runs", runs),
-                ])
+                make_handler(
+                    [
+                        ("/runs/1/logs", logs),
+                        ("/runs", runs),
+                    ]
+                )
             ),
         )
         try:
@@ -639,9 +625,7 @@ class TestGithubActions:
             return httpx.Response(
                 200,
                 json={
-                    "workflow_runs": [
-                        {"id": 1, "created_at": "2026-05-04T00:00:00Z"}
-                    ],
+                    "workflow_runs": [{"id": 1, "created_at": "2026-05-04T00:00:00Z"}],
                     "total_count": 1,
                 },
             )
@@ -653,10 +637,12 @@ class TestGithubActions:
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/runs/1/logs", logs),
-                    ("/runs", runs),
-                ])
+                make_handler(
+                    [
+                        ("/runs/1/logs", logs),
+                        ("/runs", runs),
+                    ]
+                )
             ),
         )
         try:
@@ -672,9 +658,7 @@ class TestGithubActions:
         c = CiLogsConnector(
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
-            transport=httpx.MockTransport(
-                lambda _: httpx.Response(404)
-            ),
+            transport=httpx.MockTransport(lambda _: httpx.Response(404)),
         )
         try:
             ghost = DocumentRef(
@@ -720,9 +704,7 @@ class TestCircleCi:
         c = CiLogsConnector(
             CiLogsConfig(flavor="circleci", owner="o", repo="r"),
             credential=circleci_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/job", jobs)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/job", jobs)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -766,9 +748,7 @@ class TestCircleCi:
             return httpx.Response(200, json=next(pages))
 
         c = CiLogsConnector(
-            CiLogsConfig(
-                flavor="circleci", owner="o", repo="r", max_builds=10
-            ),
+            CiLogsConfig(flavor="circleci", owner="o", repo="r", max_builds=10),
             credential=circleci_credential,
             transport=httpx.MockTransport(make_handler([("/job", jobs)])),
         )
@@ -812,9 +792,7 @@ class TestCircleCi:
         finally:
             await c.close()
 
-    async def test_since_short_circuits(
-        self, circleci_credential: Credential
-    ) -> None:
+    async def test_since_short_circuits(self, circleci_credential: Credential) -> None:
         def jobs(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -851,25 +829,20 @@ class TestCircleCi:
         finally:
             await c.close()
 
-    async def test_max_builds_caps(
-        self, circleci_credential: Credential
-    ) -> None:
+    async def test_max_builds_caps(self, circleci_credential: Credential) -> None:
         def jobs(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
                 json={
                     "items": [
-                        {"job_number": i, "status": "success"}
-                        for i in range(100)
+                        {"job_number": i, "status": "success"} for i in range(100)
                     ],
                     "next_page_token": None,
                 },
             )
 
         c = CiLogsConnector(
-            CiLogsConfig(
-                flavor="circleci", owner="o", repo="r", max_builds=3
-            ),
+            CiLogsConfig(flavor="circleci", owner="o", repo="r", max_builds=3),
             credential=circleci_credential,
             transport=httpx.MockTransport(make_handler([("/job", jobs)])),
         )
@@ -879,9 +852,7 @@ class TestCircleCi:
         finally:
             await c.close()
 
-    async def test_429_handled(
-        self, circleci_credential: Credential
-    ) -> None:
+    async def test_429_handled(self, circleci_credential: Credential) -> None:
         responses = iter(
             [
                 httpx.Response(429, headers={"Retry-After": "1"}),
@@ -969,10 +940,12 @@ class TestCircleCi:
             ),
             credential=circleci_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/job/7", detail),
-                    ("/job", jobs),
-                ])
+                make_handler(
+                    [
+                        ("/job/7", detail),
+                        ("/job", jobs),
+                    ]
+                )
             ),
         )
         try:
@@ -1141,7 +1114,7 @@ class TestBuildkite:
                     ],
                     headers={
                         "Link": (
-                            '<https://api.buildkite.com/v2/organizations/o/'
+                            "<https://api.buildkite.com/v2/organizations/o/"
                             'pipelines/p/builds?page=2>; rel="next"'
                         )
                     },
@@ -1172,9 +1145,7 @@ class TestBuildkite:
                 max_builds=10,
             ),
             credential=buildkite_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/builds", builds)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/builds", builds)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1217,9 +1188,7 @@ class TestBuildkite:
                 failed_only=True,
             ),
             credential=buildkite_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/builds", builds)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/builds", builds)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1228,9 +1197,7 @@ class TestBuildkite:
         finally:
             await c.close()
 
-    async def test_since_short_circuits(
-        self, buildkite_credential: Credential
-    ) -> None:
+    async def test_since_short_circuits(self, buildkite_credential: Credential) -> None:
         def builds(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -1250,7 +1217,7 @@ class TestBuildkite:
                 ],
                 headers={
                     "Link": (
-                        '<https://api.buildkite.com/v2/organizations/o/'
+                        "<https://api.buildkite.com/v2/organizations/o/"
                         'pipelines/p/builds?page=2>; rel="next"'
                     )
                 },
@@ -1264,9 +1231,7 @@ class TestBuildkite:
                 since=datetime(2026, 5, 1, tzinfo=UTC),
             ),
             credential=buildkite_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/builds", builds)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/builds", builds)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1298,9 +1263,7 @@ class TestBuildkite:
                 max_builds=2,
             ),
             credential=buildkite_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/builds", builds)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/builds", builds)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1308,9 +1271,7 @@ class TestBuildkite:
         finally:
             await c.close()
 
-    async def test_429_handled(
-        self, buildkite_credential: Credential
-    ) -> None:
+    async def test_429_handled(self, buildkite_credential: Credential) -> None:
         responses = iter(
             [
                 httpx.Response(429, headers={"Retry-After": "2"}),
@@ -1337,9 +1298,7 @@ class TestBuildkite:
         c = CiLogsConnector(
             CiLogsConfig(flavor="buildkite", org="o", pipeline="p"),
             credential=buildkite_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/builds", builds)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/builds", builds)])),
             sleep=fake_sleep,
         )
         try:
@@ -1374,9 +1333,7 @@ class TestBuildkite:
         c = CiLogsConnector(
             CiLogsConfig(flavor="buildkite", org="o", pipeline="p"),
             credential=buildkite_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/builds", builds)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/builds", builds)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1407,10 +1364,12 @@ class TestBuildkite:
             CiLogsConfig(flavor="buildkite", org="o", pipeline="p"),
             credential=buildkite_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/jobs/j-1/log", log),
-                    ("/builds", builds),
-                ])
+                make_handler(
+                    [
+                        ("/jobs/j-1/log", log),
+                        ("/builds", builds),
+                    ]
+                )
             ),
         )
         try:
@@ -1446,10 +1405,12 @@ class TestBuildkite:
             CiLogsConfig(flavor="buildkite", org="o", pipeline="p"),
             credential=buildkite_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/jobs/j-1/log", log),
-                    ("/builds", builds),
-                ])
+                make_handler(
+                    [
+                        ("/jobs/j-1/log", log),
+                        ("/builds", builds),
+                    ]
+                )
             ),
         )
         try:
@@ -1482,10 +1443,12 @@ class TestBuildkite:
             CiLogsConfig(flavor="buildkite", org="o", pipeline="p"),
             credential=buildkite_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/jobs/j-1/log", log),
-                    ("/builds", builds),
-                ])
+                make_handler(
+                    [
+                        ("/jobs/j-1/log", log),
+                        ("/builds", builds),
+                    ]
+                )
             ),
         )
         try:
@@ -1519,10 +1482,12 @@ class TestBuildkite:
             CiLogsConfig(flavor="buildkite", org="o", pipeline="p"),
             credential=buildkite_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/jobs/j-1/log", log),
-                    ("/builds", builds),
-                ])
+                make_handler(
+                    [
+                        ("/jobs/j-1/log", log),
+                        ("/builds", builds),
+                    ]
+                )
             ),
         )
         try:
@@ -1546,9 +1511,7 @@ class TestBuildkite:
 
 
 class TestJenkins:
-    async def test_auth_uses_basic(
-        self, jenkins_credential: Credential
-    ) -> None:
+    async def test_auth_uses_basic(self, jenkins_credential: Credential) -> None:
         seen: dict[str, str] = {}
 
         def api_json(request: httpx.Request) -> httpx.Response:
@@ -1575,9 +1538,7 @@ class TestJenkins:
         c = CiLogsConnector(
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1629,9 +1590,7 @@ class TestJenkins:
                 failed_only=True,
             ),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1640,9 +1599,7 @@ class TestJenkins:
         finally:
             await c.close()
 
-    async def test_since_short_circuits(
-        self, jenkins_credential: Credential
-    ) -> None:
+    async def test_since_short_circuits(self, jenkins_credential: Credential) -> None:
         # 2024-05-05 = 1714867200000 ms; 2026-04-01 = 1774953600000 ms.
         def api_json(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
@@ -1677,9 +1634,7 @@ class TestJenkins:
                 since=datetime(2025, 1, 1, tzinfo=UTC),
             ),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1687,9 +1642,7 @@ class TestJenkins:
         finally:
             await c.close()
 
-    async def test_max_builds_caps(
-        self, jenkins_credential: Credential
-    ) -> None:
+    async def test_max_builds_caps(self, jenkins_credential: Credential) -> None:
         def api_json(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -1717,9 +1670,7 @@ class TestJenkins:
                 max_builds=4,
             ),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1727,9 +1678,7 @@ class TestJenkins:
         finally:
             await c.close()
 
-    async def test_429_handled(
-        self, jenkins_credential: Credential
-    ) -> None:
+    async def test_429_handled(self, jenkins_credential: Credential) -> None:
         responses = iter(
             [
                 httpx.Response(429, headers={"Retry-After": "1"}),
@@ -1763,9 +1712,7 @@ class TestJenkins:
         c = CiLogsConnector(
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
             sleep=fake_sleep,
         )
         try:
@@ -1805,9 +1752,7 @@ class TestJenkins:
         c = CiLogsConnector(
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1825,9 +1770,7 @@ class TestJenkins:
         c = CiLogsConnector(
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1850,9 +1793,7 @@ class TestJenkins:
         c = CiLogsConnector(
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
-            transport=httpx.MockTransport(
-                make_handler([("/api/json", api_json)])
-            ),
+            transport=httpx.MockTransport(make_handler([("/api/json", api_json)])),
         )
         try:
             refs = await drain(c.discover(SourceFilter(), None))
@@ -1860,9 +1801,7 @@ class TestJenkins:
         finally:
             await c.close()
 
-    async def test_fetch_consoleText(
-        self, jenkins_credential: Credential
-    ) -> None:
+    async def test_fetch_consoleText(self, jenkins_credential: Credential) -> None:
         def api_json(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -1889,10 +1828,12 @@ class TestJenkins:
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/job/deploy/42/consoleText", console),
-                    ("/api/json", api_json),
-                ])
+                make_handler(
+                    [
+                        ("/job/deploy/42/consoleText", console),
+                        ("/api/json", api_json),
+                    ]
+                )
             ),
         )
         try:
@@ -1932,10 +1873,12 @@ class TestJenkins:
             CiLogsConfig(flavor="jenkins", base_url="https://j.local"),
             credential=jenkins_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/job/deploy/42/consoleText", console),
-                    ("/api/json", api_json),
-                ])
+                make_handler(
+                    [
+                        ("/job/deploy/42/consoleText", console),
+                        ("/api/json", api_json),
+                    ]
+                )
             ),
         )
         try:
@@ -2035,9 +1978,7 @@ class TestFetchZipDirEntry:
             return httpx.Response(
                 200,
                 json={
-                    "workflow_runs": [
-                        {"id": 1, "created_at": "2026-05-04T00:00:00Z"}
-                    ],
+                    "workflow_runs": [{"id": 1, "created_at": "2026-05-04T00:00:00Z"}],
                     "total_count": 1,
                 },
             )
@@ -2049,10 +1990,12 @@ class TestFetchZipDirEntry:
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
             transport=httpx.MockTransport(
-                make_handler([
-                    ("/runs/1/logs", logs),
-                    ("/runs", runs),
-                ])
+                make_handler(
+                    [
+                        ("/runs/1/logs", logs),
+                        ("/runs", runs),
+                    ]
+                )
             ),
         )
         try:
@@ -2082,7 +2025,7 @@ class TestExtractGuards:
     def test_buildkite_extract_log_rejects_non_mapping(self) -> None:
         # Defensive against a body that arrived as a list (proxy
         # rewrite, schema drift). Pass a list, expect None.
-        assert _buildkite_extract_log([])  is None  # type: ignore[arg-type]
+        assert _buildkite_extract_log([]) is None  # type: ignore[arg-type]
 
 
 class TestFetchUnknownFlavor:
@@ -2113,13 +2056,13 @@ class TestFetchUnknownFlavor:
 
 
 class TestLifecycle:
-    async def test_close_aclose_api(
-        self, gha_credential: Credential
-    ) -> None:
+    async def test_close_aclose_api(self, gha_credential: Credential) -> None:
         c = CiLogsConnector(
             CiLogsConfig(flavor="github_actions", owner="o", repo="r"),
             credential=gha_credential,
-            transport=httpx.MockTransport(lambda _: httpx.Response(200, json={"workflow_runs": []})),
+            transport=httpx.MockTransport(
+                lambda _: httpx.Response(200, json={"workflow_runs": []})
+            ),
         )
         # Drive at least one round-trip so the underlying client is
         # hot before close — exercises the same path production hits.
@@ -2201,9 +2144,7 @@ class TestSpec:
         assert isinstance(c, CiLogsConnector)
         assert c.id == "github_actions:o/r"
 
-    def test_factory_circleci(
-        self, circleci_credential: Credential
-    ) -> None:
+    def test_factory_circleci(self, circleci_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "circleci",
@@ -2218,9 +2159,7 @@ class TestSpec:
         assert isinstance(c, CiLogsConnector)
         assert c.id == "circleci:bb/o/r"
 
-    def test_factory_buildkite(
-        self, buildkite_credential: Credential
-    ) -> None:
+    def test_factory_buildkite(self, buildkite_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "buildkite",
@@ -2232,9 +2171,7 @@ class TestSpec:
         assert isinstance(c, CiLogsConnector)
         assert c.id == "buildkite:acme/api"
 
-    def test_factory_jenkins(
-        self, jenkins_credential: Credential
-    ) -> None:
+    def test_factory_jenkins(self, jenkins_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "jenkins",
@@ -2252,9 +2189,7 @@ class TestSpec:
         with pytest.raises(ValueError, match="Credential"):
             SPEC.factory({"flavor": "github_actions", "owner": "o", "repo": "r"})
 
-    def test_factory_rejects_invalid_flavor(
-        self, gha_credential: Credential
-    ) -> None:
+    def test_factory_rejects_invalid_flavor(self, gha_credential: Credential) -> None:
         with pytest.raises(ValueError, match="flavor"):
             SPEC.factory(
                 {
@@ -2263,9 +2198,7 @@ class TestSpec:
                 }
             )
 
-    def test_factory_parses_since_string(
-        self, gha_credential: Credential
-    ) -> None:
+    def test_factory_parses_since_string(self, gha_credential: Credential) -> None:
         c = SPEC.factory(
             {
                 "flavor": "github_actions",
@@ -2277,9 +2210,7 @@ class TestSpec:
         )
         assert c.config.since is not None
 
-    def test_factory_passes_datetime_since(
-        self, gha_credential: Credential
-    ) -> None:
+    def test_factory_passes_datetime_since(self, gha_credential: Credential) -> None:
         when = datetime(2026, 5, 1, tzinfo=UTC)
         c = SPEC.factory(
             {
@@ -2292,9 +2223,7 @@ class TestSpec:
         )
         assert c.config.since == when
 
-    def test_factory_rejects_bad_since_string(
-        self, gha_credential: Credential
-    ) -> None:
+    def test_factory_rejects_bad_since_string(self, gha_credential: Credential) -> None:
         with pytest.raises(ValueError, match="since"):
             SPEC.factory(
                 {

--- a/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/connector.py
+++ b/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/connector.py
@@ -261,7 +261,9 @@ class ConfluenceConnector:
                 keys.append(key)
         return keys
 
-    async def _enumerate_pages(self, space_key: str) -> AsyncIterator[Mapping[str, Any]]:
+    async def _enumerate_pages(
+        self, space_key: str
+    ) -> AsyncIterator[Mapping[str, Any]]:
         """Page through `/space/{key}/content/page` for a space."""
         params = {
             "expand": _PAGE_EXPAND,
@@ -297,9 +299,7 @@ class ConfluenceConnector:
         ):
             return None
         title = page.get("title") or page_id
-        body = (
-            (page.get("body") or {}).get("storage") or {}
-        ).get("value") or ""
+        body = ((page.get("body") or {}).get("storage") or {}).get("value") or ""
         # Hydrate comments + attachments now (rather than in fetch())
         # because each page-listing entry is already a fully-expanded
         # payload — issuing the supplementary calls here keeps the
@@ -354,9 +354,7 @@ class ConfluenceConnector:
             params={"expand": "body.storage"},
             page_size=self._config.page_size,
         ):
-            body = (
-                (comment.get("body") or {}).get("storage") or {}
-            ).get("value")
+            body = ((comment.get("body") or {}).get("storage") or {}).get("value")
             if isinstance(body, str) and body:
                 out.append(storage_to_text(body))
         return out
@@ -578,7 +576,7 @@ def _host_from_base_url(base_url: str) -> str:
     host = base_url
     for prefix in ("https://", "http://"):
         if host.startswith(prefix):
-            host = host[len(prefix):]
+            host = host[len(prefix) :]
             break
     # Drop trailing path (`/wiki` on Cloud) so Cloud + DC ids stay
     # comparable on the host portion alone.
@@ -685,15 +683,12 @@ def _string_tuple(value: Any) -> tuple[str, ...]:
             "must be a list, not a bare string"
         )
     if not isinstance(value, Iterable):
-        raise ValueError(
-            "confluence connector list-typed configs must be iterable"
-        )
+        raise ValueError("confluence connector list-typed configs must be iterable")
     out: list[str] = []
     for item in value:
         if not isinstance(item, str) or not item:
             raise ValueError(
-                "confluence connector list-typed configs must contain "
-                "non-empty strings"
+                "confluence connector list-typed configs must contain non-empty strings"
             )
         out.append(item)
     return tuple(out)

--- a/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/storage.py
+++ b/packages/pii-scanner-confluence/src/pleno_pii_scanner_confluence/storage.py
@@ -100,9 +100,7 @@ _DROP_TAGS: frozenset[str] = frozenset({"parameter"})
 # tag-strip fallback. `&nbsp;` is the only one Confluence emits in raw
 # storage in practice — the rest are already numeric refs by the time
 # they hit the wire.
-_ENTITY_FIXUPS: tuple[tuple[str, str], ...] = (
-    ("&nbsp;", " "),
-)
+_ENTITY_FIXUPS: tuple[tuple[str, str], ...] = (("&nbsp;", " "),)
 
 
 def storage_to_text(body: str | None) -> str:

--- a/packages/pii-scanner-confluence/tests/test_api.py
+++ b/packages/pii-scanner-confluence/tests/test_api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 
 import httpx
 import pytest
@@ -15,7 +14,7 @@ from pleno_pii_scanner_confluence.api import (
     ConfluenceApiError,
 )
 
-from .conftest import json_response, make_handler, queued
+from .conftest import json_response
 
 
 # Cloud + DC base URLs we use across the suite. Cloud is a fake
@@ -445,9 +444,7 @@ class TestAbsolutePassThrough:
         )
         try:
             await api.get("https://api.atlassian.com/ex/confluence/CID/pages")
-            assert seen_urls == [
-                "https://api.atlassian.com/ex/confluence/CID/pages"
-            ]
+            assert seen_urls == ["https://api.atlassian.com/ex/confluence/CID/pages"]
         finally:
             await api.aclose()
 

--- a/packages/pii-scanner-confluence/tests/test_connector.py
+++ b/packages/pii-scanner-confluence/tests/test_connector.py
@@ -9,8 +9,7 @@ its own classes.
 
 from __future__ import annotations
 
-import json
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
 
@@ -86,7 +85,9 @@ def _comment_payload(body: str) -> dict[str, Any]:
     return {"body": {"storage": {"value": body}}}
 
 
-def _attachment_payload(title: str, *, download: str = "/download/x.pdf") -> dict[str, Any]:
+def _attachment_payload(
+    title: str, *, download: str = "/download/x.pdf"
+) -> dict[str, Any]:
     return {"title": title, "_links": {"download": download}}
 
 
@@ -105,9 +106,7 @@ class TestConfig:
         assert cfg.resolved_id() == "confluence-cloud:acme.atlassian.net"
 
     def test_resolved_id_explicit_wins(self) -> None:
-        cfg = ConfluenceConfig(
-            flavor="cloud", base_url=_CLOUD_BASE, id="custom"
-        )
+        cfg = ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, id="custom")
         assert cfg.resolved_id() == "custom"
 
     def test_resolved_tenant_id_falls_back_to_resolved_id(self) -> None:
@@ -115,9 +114,7 @@ class TestConfig:
         assert cfg.resolved_tenant_id() == cfg.resolved_id()
 
     def test_resolved_tenant_id_explicit_wins(self) -> None:
-        cfg = ConfluenceConfig(
-            flavor="cloud", base_url=_CLOUD_BASE, tenant_id="acme"
-        )
+        cfg = ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, tenant_id="acme")
         assert cfg.resolved_tenant_id() == "acme"
 
     def test_invalid_flavor_rejected(self) -> None:
@@ -132,15 +129,11 @@ class TestConfig:
         with pytest.raises(ValueError, match="page_size"):
             ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, page_size=0)
         with pytest.raises(ValueError, match="page_size"):
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, page_size=10_000
-            )
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, page_size=10_000)
 
     def test_invalid_timeout_rejected(self) -> None:
         with pytest.raises(ValueError, match="request_timeout"):
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, request_timeout=0
-            )
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, request_timeout=0)
 
 
 class TestConstruction:
@@ -168,12 +161,12 @@ class TestConstruction:
 
     def test_bucket_key(self) -> None:
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, tenant_id="acme"
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, tenant_id="acme"),
             credential=_bearer_credential(),
         )
-        assert c.bucket_key() == BucketKey(connector_kind="confluence", tenant_id="acme")
+        assert c.bucket_key() == BucketKey(
+            connector_kind="confluence", tenant_id="acme"
+        )
 
     def test_api_and_config_properties(self) -> None:
         # Both accessors are how the default-enumerate path reaches
@@ -200,9 +193,7 @@ class TestCloud:
 
         def page_handler(request: httpx.Request) -> httpx.Response:
             seen_auth.append(request.headers.get("authorization", ""))
-            return json_response(
-                {"results": [_page_payload("p1")], "_links": {}}
-            )
+            return json_response({"results": [_page_payload("p1")], "_links": {}})
 
         def comment_handler(_: httpx.Request) -> httpx.Response:
             return json_response({"results": [], "_links": {}})
@@ -254,9 +245,7 @@ class TestCloud:
             payload={"email": "alice@x.test", "api_token": "atl-secret"},
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=cred,
             transport=transport,
         )
@@ -300,9 +289,7 @@ class TestCloud:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -334,9 +321,7 @@ class TestCloud:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -367,9 +352,7 @@ class TestCloud:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -385,13 +368,9 @@ class TestCloud:
         def page_handler(_: httpx.Request) -> httpx.Response:
             return json_response({"results": [bad], "_links": {}})
 
-        transport = httpx.MockTransport(
-            make_handler([("/content/page", page_handler)])
-        )
+        transport = httpx.MockTransport(make_handler([("/content/page", page_handler)]))
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -425,9 +404,7 @@ class TestCloud:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -527,9 +504,7 @@ class TestCloud:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -593,9 +568,7 @@ class TestCloud:
 
         transport = httpx.MockTransport(handler)
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
             sleep=fake_sleep,
@@ -707,9 +680,7 @@ class TestDatacenter:
 
         transport = httpx.MockTransport(handler)
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)),
             credential=_bearer_credential("dc-pat"),
             transport=transport,
         )
@@ -732,9 +703,7 @@ class TestDatacenter:
             payload={"username": "alice", "password": "dc-secret"},
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)),
             credential=cred,
             transport=transport,
         )
@@ -757,9 +726,7 @@ class TestDatacenter:
 
         transport = httpx.MockTransport(handler)
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
             sleep=fake_sleep,
@@ -803,9 +770,7 @@ class TestDatacenter:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -861,9 +826,7 @@ class TestDatacenter:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="datacenter", base_url=_DC_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -963,9 +926,7 @@ class TestCursor:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -1087,7 +1048,10 @@ class TestHelpers:
         assert _is_archived({"status": 42}) is False  # type: ignore[dict-item]
 
     def test_host_from_base_url_strips_scheme_and_path(self) -> None:
-        assert _host_from_base_url("https://acme.atlassian.net/wiki") == "acme.atlassian.net"
+        assert (
+            _host_from_base_url("https://acme.atlassian.net/wiki")
+            == "acme.atlassian.net"
+        )
         assert _host_from_base_url("http://host/") == "host"
         assert _host_from_base_url("https://host/sub/path") == "host"
 
@@ -1174,7 +1138,9 @@ class TestFactoryAndSpec:
 
     def test_factory_minimal_cloud(self) -> None:
         cred = _bearer_credential()
-        c = SPEC.factory({"flavor": "cloud", "base_url": _CLOUD_BASE, "_credential": cred})
+        c = SPEC.factory(
+            {"flavor": "cloud", "base_url": _CLOUD_BASE, "_credential": cred}
+        )
         assert isinstance(c, ConfluenceConnector)
         assert c.config.flavor == "cloud"
 
@@ -1186,7 +1152,6 @@ class TestFactoryAndSpec:
         # stub that out with a no-op so the test does not need a real
         # PEM (which would otherwise require either checked-in fixture
         # data or a `cryptography` test-only dependency).
-        import ssl as _ssl
 
         from pleno_pii_scanner_confluence import api as api_mod
 
@@ -1272,9 +1237,7 @@ class TestPackageInit:
 class TestLifecycle:
     async def test_close_clears_cache(self) -> None:
         def page_handler(_: httpx.Request) -> httpx.Response:
-            return json_response(
-                {"results": [_page_payload("p1")], "_links": {}}
-            )
+            return json_response({"results": [_page_payload("p1")], "_links": {}})
 
         def empty(_: httpx.Request) -> httpx.Response:
             return json_response({"results": [], "_links": {}})
@@ -1289,9 +1252,7 @@ class TestLifecycle:
             )
         )
         c = ConfluenceConnector(
-            ConfluenceConfig(
-                flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-            ),
+            ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
             credential=_bearer_credential(),
             transport=transport,
         )
@@ -1334,18 +1295,14 @@ class TestNoLeakedTokens:
         secret_password = "very-secret-pwd-xyz"
         # Cover both auth shapes by switching connectors mid-test.
         for cred in (
-            Credential(
-                kind="confluence", payload={"access_token": secret_token}
-            ),
+            Credential(kind="confluence", payload={"access_token": secret_token}),
             Credential(
                 kind="confluence",
                 payload={"email": "a@x.test", "api_token": secret_password},
             ),
         ):
             c = ConfluenceConnector(
-                ConfluenceConfig(
-                    flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)
-                ),
+                ConfluenceConfig(flavor="cloud", base_url=_CLOUD_BASE, spaces=("ENG",)),
                 credential=cred,
                 transport=transport,
             )

--- a/packages/pii-scanner-confluence/tests/test_storage.py
+++ b/packages/pii-scanner-confluence/tests/test_storage.py
@@ -14,7 +14,6 @@ under the `ac:` and `ri:` prefixes. The converter must:
 
 from __future__ import annotations
 
-import pytest
 
 from pleno_pii_scanner_confluence.storage import storage_to_text
 
@@ -51,9 +50,7 @@ class TestStorageBasicHtml:
         assert "alphabeta" not in out
 
     def test_table_cells_extracted(self) -> None:
-        out = storage_to_text(
-            "<table><tr><td>name</td><td>alice</td></tr></table>"
-        )
+        out = storage_to_text("<table><tr><td>name</td><td>alice</td></tr></table>")
         assert "name" in out
         assert "alice" in out
 
@@ -80,7 +77,7 @@ class TestStorageMacros:
     def test_panel_macro_rich_text_body_extracted(self) -> None:
         body = (
             '<ac:structured-macro ac:name="info">'
-            '<ac:rich-text-body><p>note me</p></ac:rich-text-body>'
+            "<ac:rich-text-body><p>note me</p></ac:rich-text-body>"
             "</ac:structured-macro>"
         )
         assert "note me" in storage_to_text(body)
@@ -126,11 +123,7 @@ class TestStorageMacros:
         # its attributes are pointers, not surface text. The walker
         # must produce no output for it (and not crash on the prefixed
         # attribute).
-        body = (
-            "<p>before</p>"
-            '<ri:user ri:userkey="ff8080816a8a8a8a"/>'
-            "<p>after</p>"
-        )
+        body = '<p>before</p><ri:user ri:userkey="ff8080816a8a8a8a"/><p>after</p>'
         out = storage_to_text(body)
         assert "before" in out
         assert "after" in out

--- a/packages/pii-scanner-discord/src/pleno_pii_scanner_discord/connector.py
+++ b/packages/pii-scanner-discord/src/pleno_pii_scanner_discord/connector.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -223,9 +223,7 @@ class DiscordConnector:
         async with self._sem:
             resp = await self._request("GET", f"/guilds/{guild_id}/channels")
         all_channels = resp.json()
-        out = [
-            c for c in all_channels if c.get("type") in self._config.channel_types
-        ]
+        out = [c for c in all_channels if c.get("type") in self._config.channel_types]
         if self._config.include_threads:
             # Public threads enumerated via the parent channel; we
             # approximate by including thread-typed channels here.
@@ -361,12 +359,8 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
         DiscordConfig(
             token=str(config["token"]),
             guilds=tuple(str(g) for g in config.get("guilds", ())),
-            channel_types=tuple(
-                int(c) for c in config.get("channel_types", (0, 5))
-            ),
-            max_messages_per_channel=int(
-                config.get("max_messages_per_channel", 5000)
-            ),
+            channel_types=tuple(int(c) for c in config.get("channel_types", (0, 5))),
+            max_messages_per_channel=int(config.get("max_messages_per_channel", 5000)),
             include_threads=bool(config.get("include_threads", True)),
             concurrency=int(config.get("concurrency", 2)),
             id=str(config["id"]) if config.get("id") is not None else None,

--- a/packages/pii-scanner-discord/tests/test_connector.py
+++ b/packages/pii-scanner-discord/tests/test_connector.py
@@ -308,10 +308,7 @@ class TestDiscover:
             c = DiscordConnector(DiscordConfig(token="t"), client=client)
             try:
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("g1/c1",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("g1/c1",)), None)
                 ]
                 assert all(r.metadata["channel_id"] == "c1" for r in refs)
             finally:
@@ -320,10 +317,7 @@ class TestDiscover:
             c2 = DiscordConnector(DiscordConfig(token="t"), client=client2)
             try:
                 refs2 = [
-                    r
-                    async for r in c2.discover(
-                        SourceFilter(exclude=("g1/c2",)), None
-                    )
+                    r async for r in c2.discover(SourceFilter(exclude=("g1/c2",)), None)
                 ]
                 assert all(r.metadata["channel_id"] == "c1" for r in refs2)
             finally:
@@ -394,9 +388,7 @@ class TestThreads:
 
         async with _client(handler) as client:
             c = DiscordConnector(
-                DiscordConfig(
-                    token="t", channel_types=(0,), include_threads=False
-                ),
+                DiscordConfig(token="t", channel_types=(0,), include_threads=False),
                 client=client,
             )
             try:

--- a/packages/pii-scanner-elasticsearch/src/pleno_pii_scanner_elasticsearch/connector.py
+++ b/packages/pii-scanner-elasticsearch/src/pleno_pii_scanner_elasticsearch/connector.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import base64
 import json
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -121,9 +121,7 @@ class ElasticsearchConnector:
         self._config = config
         self.id = config.resolved_id()
         if client is None:
-            self._client = httpx.AsyncClient(
-                base_url=config.hosts[0], timeout=60.0
-            )
+            self._client = httpx.AsyncClient(base_url=config.hosts[0], timeout=60.0)
             self._owns_client = True
         else:
             self._client = client
@@ -174,9 +172,7 @@ class ElasticsearchConnector:
                     idx = hit.get("_index", "")
                     doc_id = hit.get("_id", "")
                     full = f"{idx}/{doc_id}"
-                    if filter.include and not _matches_any(
-                        full, filter.include
-                    ):
+                    if filter.include and not _matches_any(full, filter.include):
                         continue
                     if filter.exclude and _matches_any(full, filter.exclude):
                         continue
@@ -278,9 +274,7 @@ class ElasticsearchConnector:
         else:
             url = f"/{index_csv}/_pit"
             params = {"keep_alive": self._config.keep_alive}
-        resp = await self._client.post(
-            url, params=params, headers=self._headers
-        )
+        resp = await self._client.post(url, params=params, headers=self._headers)
         if resp.status_code == 404:
             # OpenSearch <2 has no PIT. We can't transparently recover here
             # without a scroll fallback; surface a clear error rather than
@@ -303,9 +297,7 @@ class ElasticsearchConnector:
             url = "/_pit"
             payload = {"id": pit_id}
         # httpx requires DELETE to use `request("DELETE", ...)` for body.
-        await self._client.request(
-            "DELETE", url, json=payload, headers=self._headers
-        )
+        await self._client.request("DELETE", url, json=payload, headers=self._headers)
 
     def _build_search_body(
         self,
@@ -347,9 +339,7 @@ class ElasticsearchConnector:
         body: dict[str, Any],
     ) -> list[dict[str, Any]]:
         del pit_id  # PIT pins the indices, so the URL is just `/_search`
-        resp = await self._client.post(
-            "/_search", json=body, headers=self._headers
-        )
+        resp = await self._client.post("/_search", json=body, headers=self._headers)
         resp.raise_for_status()
         return resp.json().get("hits", {}).get("hits", []) or []
 

--- a/packages/pii-scanner-elasticsearch/tests/test_connector.py
+++ b/packages/pii-scanner-elasticsearch/tests/test_connector.py
@@ -50,9 +50,7 @@ class TestConfig:
 
     def test_rejects_multiple_auth_modes(self) -> None:
         with pytest.raises(ValueError, match="at most one"):
-            ElasticsearchConfig(
-                hosts=("https://x",), api_key="k", bearer_token="b"
-            )
+            ElasticsearchConfig(hosts=("https://x",), api_key="k", bearer_token="b")
 
     def test_basic_user_requires_password(self) -> None:
         with pytest.raises(ValueError, match="basic_password"):
@@ -73,20 +71,14 @@ class TestConfig:
         assert cfg.resolved_id() == "explicit"
 
     def test_default_id_no_secret_leak(self) -> None:
-        cfg = ElasticsearchConfig(
-            hosts=("https://x",), api_key="VERY-SECRET"
-        )
+        cfg = ElasticsearchConfig(hosts=("https://x",), api_key="VERY-SECRET")
         rid = cfg.resolved_id()
         assert "VERY-SECRET" not in rid
         assert rid.startswith("elasticsearch:")
 
     def test_default_id_order_independent(self) -> None:
-        a = ElasticsearchConfig(
-            hosts=("https://a", "https://b"), indices=("x", "y")
-        )
-        b = ElasticsearchConfig(
-            hosts=("https://b", "https://a"), indices=("y", "x")
-        )
+        a = ElasticsearchConfig(hosts=("https://a", "https://b"), indices=("x", "y"))
+        b = ElasticsearchConfig(hosts=("https://b", "https://a"), indices=("y", "x"))
         assert a.resolved_id() == b.resolved_id()
 
 
@@ -175,9 +167,7 @@ class TestDiscover:
             assert request.headers.get("Authorization") == "ApiKey k"
             url = request.url
             if url.path.startswith("/_resolve/index/"):
-                return httpx.Response(
-                    200, json=_resolve_response("logs-2026.05")
-                )
+                return httpx.Response(200, json=_resolve_response("logs-2026.05"))
             if url.path.endswith("/_pit") and request.method == "DELETE":
                 closed_pit["yes"] = True
                 return httpx.Response(200, json={"succeeded": True})
@@ -243,8 +233,18 @@ class TestDiscover:
                         json={
                             "hits": {
                                 "hits": [
-                                    {"_index": "idx", "_id": "1", "_source": {}, "sort": [10]},
-                                    {"_index": "idx", "_id": "2", "_source": {}, "sort": [20]},
+                                    {
+                                        "_index": "idx",
+                                        "_id": "1",
+                                        "_source": {},
+                                        "sort": [10],
+                                    },
+                                    {
+                                        "_index": "idx",
+                                        "_id": "2",
+                                        "_source": {},
+                                        "sort": [20],
+                                    },
                                 ]
                             }
                         },
@@ -255,8 +255,18 @@ class TestDiscover:
                         json={
                             "hits": {
                                 "hits": [
-                                    {"_index": "idx", "_id": "3", "_source": {}, "sort": [30]},
-                                    {"_index": "idx", "_id": "4", "_source": {}, "sort": [40]},
+                                    {
+                                        "_index": "idx",
+                                        "_id": "3",
+                                        "_source": {},
+                                        "sort": [30],
+                                    },
+                                    {
+                                        "_index": "idx",
+                                        "_id": "4",
+                                        "_source": {},
+                                        "sort": [40],
+                                    },
                                 ]
                             }
                         },
@@ -303,7 +313,12 @@ class TestDiscover:
                     json={
                         "hits": {
                             "hits": [
-                                {"_index": "idx", "_id": "1", "_source": {}, "sort": [1]},
+                                {
+                                    "_index": "idx",
+                                    "_id": "1",
+                                    "_source": {},
+                                    "sort": [1],
+                                },
                             ]
                         }
                     },
@@ -349,15 +364,11 @@ class TestDiscover:
 
         async with _client(handler) as client:
             c = ElasticsearchConnector(
-                ElasticsearchConfig(
-                    hosts=("https://es.example.com",), api_key="k"
-                ),
+                ElasticsearchConfig(hosts=("https://es.example.com",), api_key="k"),
                 client=client,
             )
             try:
-                cursor = json.dumps(
-                    {"pit_id": "PIT-RESUMED", "search_after": [99]}
-                )
+                cursor = json.dumps({"pit_id": "PIT-RESUMED", "search_after": [99]})
                 refs = [r async for r in c.discover(SourceFilter(), cursor)]
                 assert refs == []
                 # Did not open a fresh PIT when one was supplied.
@@ -422,20 +433,14 @@ class TestDiscover:
                 return httpx.Response(
                     200,
                     json={
-                        "hits": {
-                            "hits": [
-                                {"_index": "idx", "_id": "x", "_source": {}}
-                            ]
-                        }
+                        "hits": {"hits": [{"_index": "idx", "_id": "x", "_source": {}}]}
                     },
                 )
             return httpx.Response(404)
 
         async with _client(handler) as client:
             c = ElasticsearchConnector(
-                ElasticsearchConfig(
-                    hosts=("https://x",), api_key="k", page_size=100
-                ),
+                ElasticsearchConfig(hosts=("https://x",), api_key="k", page_size=100),
                 client=client,
             )
             try:
@@ -560,8 +565,18 @@ class TestFilter:
                     json={
                         "hits": {
                             "hits": [
-                                {"_index": "logs", "_id": "1", "_source": {}, "sort": [1]},
-                                {"_index": "audit", "_id": "2", "_source": {}, "sort": [2]},
+                                {
+                                    "_index": "logs",
+                                    "_id": "1",
+                                    "_source": {},
+                                    "sort": [1],
+                                },
+                                {
+                                    "_index": "audit",
+                                    "_id": "2",
+                                    "_source": {},
+                                    "sort": [2],
+                                },
                             ]
                         }
                     },
@@ -570,34 +585,25 @@ class TestFilter:
 
         async with _client(handler) as client:
             c = ElasticsearchConnector(
-                ElasticsearchConfig(
-                    hosts=("https://x",), api_key="k", page_size=10
-                ),
+                ElasticsearchConfig(hosts=("https://x",), api_key="k", page_size=10),
                 client=client,
             )
             try:
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("logs/*",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("logs/*",)), None)
                 ]
                 assert [r.path for r in refs] == ["logs/1"]
             finally:
                 await c.close()
         async with _client(handler) as client2:
             c2 = ElasticsearchConnector(
-                ElasticsearchConfig(
-                    hosts=("https://x",), api_key="k", page_size=10
-                ),
+                ElasticsearchConfig(hosts=("https://x",), api_key="k", page_size=10),
                 client=client2,
             )
             try:
                 refs2 = [
                     r
-                    async for r in c2.discover(
-                        SourceFilter(exclude=("audit/*",)), None
-                    )
+                    async for r in c2.discover(SourceFilter(exclude=("audit/*",)), None)
                 ]
                 assert [r.path for r in refs2] == ["logs/1"]
             finally:
@@ -640,9 +646,7 @@ class TestRenderSource:
 
         async with _client(handler) as client:
             c = ElasticsearchConnector(
-                ElasticsearchConfig(
-                    hosts=("https://x",), api_key="k", page_size=10
-                ),
+                ElasticsearchConfig(hosts=("https://x",), api_key="k", page_size=10),
                 client=client,
             )
             try:
@@ -724,9 +728,7 @@ class TestFetchEdges:
                 client=client,
             )
             try:
-                ref = DocumentRef(
-                    source_id=c.id, source_kind=c.kind, path="missing"
-                )
+                ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="missing")
                 docs = [d async for d in c.fetch(ref)]
                 assert docs == []
             finally:

--- a/packages/pii-scanner-gcs/src/pleno_pii_scanner_gcs/_oauth_token.py
+++ b/packages/pii-scanner-gcs/src/pleno_pii_scanner_gcs/_oauth_token.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -56,9 +55,7 @@ _GCE_METADATA_TOKEN_URL = (
 )
 # Default OAuth scope for read-only GCS + Cloud Asset Inventory access.
 # Callers can override per `TokenSource` via `scopes=`.
-DEFAULT_SCOPES = (
-    "https://www.googleapis.com/auth/cloud-platform.read-only",
-)
+DEFAULT_SCOPES = ("https://www.googleapis.com/auth/cloud-platform.read-only",)
 # Refresh tokens this many seconds before the upstream `expires_at` so
 # in-flight paginates do not 401 mid-walk. 30 s mirrors the AWS S3
 # connector's safety margin.
@@ -171,25 +168,17 @@ class WorkloadIdentityTokenSource(TokenSource):
             _GOOGLE_STS_TOKEN_URL,
             json={
                 "audience": self.audience,
-                "grantType": (
-                    "urn:ietf:params:oauth:grant-type:token-exchange"
-                ),
-                "requestedTokenType": (
-                    "urn:ietf:params:oauth:token-type:access_token"
-                ),
+                "grantType": ("urn:ietf:params:oauth:grant-type:token-exchange"),
+                "requestedTokenType": ("urn:ietf:params:oauth:token-type:access_token"),
                 "scope": " ".join(self.scopes),
-                "subjectTokenType": (
-                    "urn:ietf:params:oauth:token-type:jwt"
-                ),
+                "subjectTokenType": ("urn:ietf:params:oauth:token-type:jwt"),
                 "subjectToken": external,
             },
         )
         sts_resp.raise_for_status()
         federated = sts_resp.json().get("access_token")
         if not federated:
-            raise ValueError(
-                "STS token exchange returned no access_token"
-            )
+            raise ValueError("STS token exchange returned no access_token")
         if self.service_account_email is None:
             # Operator opted out of impersonation; trust them. Expiry
             # comes from STS `expires_in`.
@@ -250,9 +239,7 @@ class ApplicationDefaultTokenSource(TokenSource):
     env_get: Callable[[str], str | None] = field(
         default_factory=lambda: _default_env_get
     )
-    file_reader: Callable[[str], str] = field(
-        default_factory=lambda: _read_text_file
-    )
+    file_reader: Callable[[str], str] = field(default_factory=lambda: _read_text_file)
     now: Callable[[], datetime] = field(
         default_factory=lambda: lambda: datetime.now(UTC)
     )
@@ -281,9 +268,7 @@ class ApplicationDefaultTokenSource(TokenSource):
         ttl = int(body.get("expires_in", 3600))
         token = body.get("access_token")
         if not token:
-            raise ValueError(
-                "GCE metadata server returned no access_token"
-            )
+            raise ValueError("GCE metadata server returned no access_token")
         return AccessToken(
             value=token,
             expires_at=self.now() + timedelta(seconds=ttl),
@@ -311,9 +296,7 @@ class TokenCache:
 
     async def get(self, client: httpx.AsyncClient) -> AccessToken:
         async with self._lock:
-            if self._cached is not None and not self._cached.is_expired(
-                self.now()
-            ):
+            if self._cached is not None and not self._cached.is_expired(self.now()):
                 return self._cached
             self._cached = await self.source.acquire(client)
             return self._cached
@@ -366,9 +349,7 @@ def _sign_service_account_jwt(
     header: dict[str, Any] = {"alg": "RS256", "typ": "JWT"}
     if key_id:
         header["kid"] = key_id
-    signing_input = (
-        _b64url_json(header) + b"." + _b64url_json(payload)
-    )
+    signing_input = _b64url_json(header) + b"." + _b64url_json(payload)
     signature = _rs256_sign(private_key_pem, signing_input)
     return (signing_input + b"." + _b64url(signature)).decode("ascii")
 
@@ -389,9 +370,7 @@ def _rs256_sign(private_key_pem: str, data: bytes) -> bytes:
     return private_key.sign(data, padding.PKCS1v15(), hashes.SHA256())
 
 
-def _parse_token_response(
-    resp: httpx.Response, now: datetime
-) -> AccessToken:
+def _parse_token_response(resp: httpx.Response, now: datetime) -> AccessToken:
     """Convert a Google OAuth2 token response into our AccessToken.
 
     Google returns `access_token` + `expires_in` (seconds). We compute
@@ -410,9 +389,7 @@ def _parse_token_response(
     body = resp.json()
     token = body.get("access_token")
     if not token:
-        raise ValueError(
-            "OAuth token response missing access_token"
-        )
+        raise ValueError("OAuth token response missing access_token")
     ttl = int(body.get("expires_in", 3600))
     return AccessToken(value=token, expires_at=now + timedelta(seconds=ttl))
 
@@ -423,9 +400,7 @@ def _b64url(data: bytes) -> bytes:
 
 
 def _b64url_json(obj: Any) -> bytes:
-    return _b64url(
-        json.dumps(obj, separators=(",", ":")).encode("utf-8")
-    )
+    return _b64url(json.dumps(obj, separators=(",", ":")).encode("utf-8"))
 
 
 def _parse_iso_utc(value: str) -> datetime:

--- a/packages/pii-scanner-gcs/src/pleno_pii_scanner_gcs/connector.py
+++ b/packages/pii-scanner-gcs/src/pleno_pii_scanner_gcs/connector.py
@@ -34,7 +34,7 @@ import fnmatch
 import json
 import logging
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -280,9 +280,7 @@ class GcsConnector:
                 continue
             page_token = decoded.page_token if idx == decoded.bucket_index else None
             try:
-                async for ref in self._discover_bucket(
-                    bucket, idx, page_token, filter
-                ):
+                async for ref in self._discover_bucket(bucket, idx, page_token, filter):
                     yield ref
             except _AccessDenied as denied:
                 # Per requirement #8: surface as a single warning ref
@@ -316,9 +314,7 @@ class GcsConnector:
         assert project is not None
         return await self._cloud_asset_inventory_buckets(project)
 
-    async def _cloud_asset_inventory_buckets(
-        self, project: str
-    ) -> tuple[str, ...]:
+    async def _cloud_asset_inventory_buckets(self, project: str) -> tuple[str, ...]:
         """Enumerate `storage.googleapis.com/Bucket` assets for a project.
 
         Cloud Asset Inventory returns a paginated list of `Asset`s
@@ -459,20 +455,15 @@ class GcsConnector:
             source_id=self.id,
             source_kind=self.kind,
             path=f"gs://{bucket}/{name}",
-            native_url=(
-                f"https://storage.cloud.google.com/{bucket}/{name}"
-            ),
-            content_type=item.get("contentType")
-            or "application/octet-stream",
+            native_url=(f"https://storage.cloud.google.com/{bucket}/{name}"),
+            content_type=item.get("contentType") or "application/octet-stream",
             size=size,
             etag=item.get("etag"),
             last_modified=last_modified,
             metadata=metadata,
         )
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         """Stream the object body via `objects.get?alt=media`.
 
         Bounded by `_fetch_semaphore` so the per-connector concurrency
@@ -481,9 +472,7 @@ class GcsConnector:
         bucket = ref.metadata.get("gcs_bucket")
         name = ref.metadata.get("gcs_name")
         if not bucket or not name:
-            raise ValueError(
-                "DocumentRef metadata missing gcs_bucket / gcs_name"
-            )
+            raise ValueError("DocumentRef metadata missing gcs_bucket / gcs_name")
         url = f"{_GCS_BASE}/b/{bucket}/o/{_url_quote(name)}"
         params: dict[str, str] = {"alt": "media"}
         gen = ref.metadata.get("gcs_generation")
@@ -628,9 +617,7 @@ def _build_token_source(auth: GcsAuthConfig) -> TokenSource:
     if auth.credentials_path is not None:
         with open(auth.credentials_path, encoding="utf-8") as handle:
             key_data = json.load(handle)
-        return ServiceAccountKeyTokenSource(
-            key_data=key_data, scopes=auth.scopes
-        )
+        return ServiceAccountKeyTokenSource(key_data=key_data, scopes=auth.scopes)
     if auth.audience is not None and auth.token_path is not None:
         return WorkloadIdentityTokenSource(
             audience=auth.audience,

--- a/packages/pii-scanner-gcs/tests/test_connector.py
+++ b/packages/pii-scanner-gcs/tests/test_connector.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
 import httpx
 import pytest
@@ -61,9 +60,7 @@ def _make_handler(
         for suffix, responder in routes.items():
             if request.url.path.endswith(suffix) or suffix in str(request.url):
                 return responder(request)
-        return httpx.Response(
-            404, content=b"unmatched: " + str(request.url).encode()
-        )
+        return httpx.Response(404, content=b"unmatched: " + str(request.url).encode())
 
     return handler
 
@@ -142,9 +139,7 @@ class TestProtocol:
             await c.close()
 
     async def test_capabilities_reflect_concurrency(self) -> None:
-        c = GcsConnector(
-            _explicit_config("b1", concurrency=4), _canned_cache()
-        )
+        c = GcsConnector(_explicit_config("b1", concurrency=4), _canned_cache())
         try:
             caps = c.capabilities()
             assert caps == Capabilities(
@@ -161,9 +156,7 @@ class TestProtocol:
         # We assert the limit by reading the semaphore's `_value`
         # rather than racing real fetches — the ADR §7 covers the
         # parallel-test orthogonally.
-        c = GcsConnector(
-            _explicit_config("b1", concurrency=3), _canned_cache()
-        )
+        c = GcsConnector(_explicit_config("b1", concurrency=3), _canned_cache())
         try:
             assert c._fetch_semaphore._value == 3
         finally:
@@ -216,13 +209,9 @@ class TestDiscoverExplicit:
             assert "/b/bucket-a/o" in str(request.url)
             token = request.url.params.get("pageToken")
             seen_tokens.append(token)
-            return httpx.Response(
-                200, json=page2 if token == "page2" else page1
-            )
+            return httpx.Response(200, json=page2 if token == "page2" else page1)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(
                 _explicit_config("bucket-a"), _canned_cache(), client=client
             )
@@ -250,9 +239,7 @@ class TestDiscoverExplicit:
             seen_prefix["v"] = request.url.params.get("prefix")
             return httpx.Response(200, json={"items": []})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(
                 _explicit_config("b1", prefix="logs/"),
                 _canned_cache(),
@@ -276,9 +263,7 @@ class TestDiscoverExplicit:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(
                 _explicit_config("b1", glob="*.log"),
                 _canned_cache(),
@@ -304,18 +289,11 @@ class TestDiscoverExplicit:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("*.csv",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("*.csv",)), None)
                 ]
             finally:
                 await c.close()
@@ -332,12 +310,8 @@ class TestDiscoverExplicit:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [
                     r
@@ -374,9 +348,7 @@ class TestVersioning:
                 },
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(
                 _explicit_config("b1", include_deleted=True),
                 _canned_cache(),
@@ -410,12 +382,8 @@ class TestVersioning:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -448,9 +416,7 @@ class TestAccessDenied:
                 )
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(
                 _explicit_config("denied", "ok"),
                 _canned_cache(),
@@ -496,9 +462,7 @@ class TestCloudAssetInventory:
             # Per-bucket listing: empty body.
             return httpx.Response(200, json={"items": []})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             cfg = GcsConfig(
                 auth=GcsAuthConfig(),
                 discovery=GcsBucketDiscovery(project="proj"),
@@ -531,9 +495,7 @@ class TestCloudAssetInventory:
                 return httpx.Response(200, json=body)
             return httpx.Response(200, json={"items": []})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             cfg = GcsConfig(
                 auth=GcsAuthConfig(),
                 discovery=GcsBucketDiscovery(project="p", cai_filter="loc:us"),
@@ -555,9 +517,7 @@ class TestCloudAssetInventory:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             cfg = GcsConfig(
                 auth=GcsAuthConfig(),
                 discovery=GcsBucketDiscovery(project="p"),
@@ -596,12 +556,8 @@ class TestFetch:
                 return httpx.Response(200, content=payload)
             return httpx.Response(200, json=list_body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
                 docs = []
@@ -617,9 +573,7 @@ class TestFetch:
     async def test_fetch_rejects_ref_without_metadata(self) -> None:
         c = GcsConnector(_explicit_config("b1"), _canned_cache())
         try:
-            ref = DocumentRef(
-                source_id=c.id, source_kind=c.kind, path="gs://b1/x"
-            )
+            ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="gs://b1/x")
             with pytest.raises(ValueError, match="gcs_bucket"):
                 async for _ in c.fetch(ref):
                     pass
@@ -636,12 +590,8 @@ class TestFetch:
             seen_path["v"] = request.url.raw_path.decode()
             return httpx.Response(200, content=b"x")
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 ref = DocumentRef(
                     source_id=c.id,
@@ -688,9 +638,7 @@ class TestAuthRetry:
             assert request.headers["Authorization"] == "Bearer tok-2"
             return httpx.Response(200, json={"items": []})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(_explicit_config("b1"), cache, client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -707,20 +655,14 @@ class TestAuthRetry:
 class TestCursor:
     async def test_cursor_dumps_and_loads(self) -> None:
         body = {
-            "items": [
-                {"name": "a", "size": "1", "updated": "2026-01-01T00:00:00Z"}
-            ]
+            "items": [{"name": "a", "size": "1", "updated": "2026-01-01T00:00:00Z"}]
         }
 
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
                 # Yielded refs carry the cursor for the scheduler.
@@ -745,9 +687,7 @@ class TestCursor:
                     return httpx.Response(200, json={"items": []})
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = GcsConnector(
                 _explicit_config("first-bucket", "second-bucket"),
                 _canned_cache(),
@@ -851,9 +791,7 @@ class TestFactory:
 
     def test_factory_rejects_non_mapping_auth(self) -> None:
         with pytest.raises(ValueError, match="auth.*mapping"):
-            SPEC.factory(
-                {"auth": "wrong", "discovery": {"buckets": ["b"]}}
-            )
+            SPEC.factory({"auth": "wrong", "discovery": {"buckets": ["b"]}})
 
     def test_factory_rejects_non_mapping_discovery(self) -> None:
         with pytest.raises(ValueError, match="discovery.*mapping"):
@@ -871,9 +809,7 @@ class TestLifecycle:
 
     async def test_close_does_not_close_external_client(self) -> None:
         client = httpx.AsyncClient()
-        c = GcsConnector(
-            _explicit_config("b1"), _canned_cache(), client=client
-        )
+        c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
         await c.close()
         assert not client.is_closed
         await client.aclose()
@@ -902,12 +838,8 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -925,12 +857,8 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -951,12 +879,8 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -967,21 +891,13 @@ class TestRefParsing:
         # Defensive: GCS always emits Z-suffixed timestamps, but if a
         # mock/test/fork ever returns naive ISO, we still produce a UTC
         # datetime rather than raising.
-        body = {
-            "items": [
-                {"name": "x", "size": "1", "updated": "2026-01-01T00:00:00"}
-            ]
-        }
+        body = {"items": [{"name": "x", "size": "1", "updated": "2026-01-01T00:00:00"}]}
 
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -997,12 +913,8 @@ class TestRefParsing:
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -1010,21 +922,13 @@ class TestRefParsing:
         assert refs[0].last_modified is None
 
     async def test_ref_handles_invalid_updated(self) -> None:
-        body = {
-            "items": [
-                {"name": "x", "size": "1", "updated": "not-a-date"}
-            ]
-        }
+        body = {"items": [{"name": "x", "size": "1", "updated": "not-a-date"}]}
 
         def handler(_r: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=body)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
-            c = GcsConnector(
-                _explicit_config("b1"), _canned_cache(), client=client
-            )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            c = GcsConnector(_explicit_config("b1"), _canned_cache(), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
             finally:

--- a/packages/pii-scanner-gcs/tests/test_oauth_token.py
+++ b/packages/pii-scanner-gcs/tests/test_oauth_token.py
@@ -49,7 +49,6 @@ class TestServiceAccountKey:
             # `assertion=`. Verify the signature roundtrips against the
             # fixture's public key.
             body = request.content.decode()
-            params = dict(p.split("=", 1) for p in body.split("&"))
             assertion = httpx.QueryParams(body).get("assertion")
             assert assertion is not None
             captured["assertion"] = assertion
@@ -58,9 +57,7 @@ class TestServiceAccountKey:
                 json={"access_token": "tok-abc", "expires_in": 3600},
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = ServiceAccountKeyTokenSource(key_data=service_account_key)
             token = await src.acquire(client)
         assert token.value == "tok-abc"
@@ -147,9 +144,7 @@ class TestServiceAccountKey:
 
 
 class TestWorkloadIdentity:
-    async def test_two_step_exchange_with_impersonation(
-        self, tmp_path
-    ) -> None:
+    async def test_two_step_exchange_with_impersonation(self, tmp_path) -> None:
         token_file = tmp_path / "oidc.jwt"
         token_file.write_text("external-oidc-token")
         calls: list[str] = []
@@ -182,9 +177,7 @@ class TestWorkloadIdentity:
                 )
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 audience=(
                     "//iam.googleapis.com/projects/123/locations/global/"
@@ -200,21 +193,15 @@ class TestWorkloadIdentity:
         assert any("sts.googleapis" in c for c in calls)
         assert any("iamcredentials.googleapis" in c for c in calls)
 
-    async def test_no_impersonation_returns_federated_directly(
-        self, tmp_path
-    ) -> None:
+    async def test_no_impersonation_returns_federated_directly(self, tmp_path) -> None:
         token_file = tmp_path / "oidc.jwt"
         token_file.write_text("ext-tok")
 
         def handler(request: httpx.Request) -> httpx.Response:
             assert "sts.googleapis.com" in str(request.url)
-            return httpx.Response(
-                200, json={"access_token": "fed", "expires_in": 1800}
-            )
+            return httpx.Response(200, json={"access_token": "fed", "expires_in": 1800})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 audience="//iam.googleapis.com/x",
                 token_path=str(token_file),
@@ -224,9 +211,7 @@ class TestWorkloadIdentity:
         # ~30 minutes ahead, allow a 5-second clock skew.
         assert (token.expires_at - datetime.now(UTC)).total_seconds() > 1700
 
-    async def test_sts_missing_access_token_rejected(
-        self, tmp_path
-    ) -> None:
+    async def test_sts_missing_access_token_rejected(self, tmp_path) -> None:
         token_file = tmp_path / "oidc.jwt"
         token_file.write_text("ext")
         async with httpx.AsyncClient(
@@ -264,9 +249,7 @@ class TestWorkloadIdentity:
                 )
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 audience="//iam.googleapis.com/x",
                 token_path=str(token_file),
@@ -275,9 +258,7 @@ class TestWorkloadIdentity:
             token = await src.acquire(client)
         assert token.expires_at.tzinfo == UTC
 
-    async def test_impersonate_missing_fields_rejected(
-        self, tmp_path
-    ) -> None:
+    async def test_impersonate_missing_fields_rejected(self, tmp_path) -> None:
         token_file = tmp_path / "oidc.jwt"
         token_file.write_text("ext")
 
@@ -289,9 +270,7 @@ class TestWorkloadIdentity:
             # iamcredentials returns body without expireTime.
             return httpx.Response(200, json={"accessToken": "x"})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 audience="//iam.googleapis.com/x",
                 token_path=str(token_file),
@@ -308,13 +287,9 @@ class TestWorkloadIdentity:
         def handler(request: httpx.Request) -> httpx.Response:
             body = json.loads(request.content)
             assert body["subjectToken"] == "from-seam"
-            return httpx.Response(
-                200, json={"access_token": "tok", "expires_in": 60}
-            )
+            return httpx.Response(200, json={"access_token": "tok", "expires_in": 60})
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = WorkloadIdentityTokenSource(
                 audience="//iam.googleapis.com/x",
                 token_path="/no/such/file",
@@ -345,9 +320,7 @@ class TestApplicationDefault:
                 200, json={"access_token": "adc-tok", "expires_in": 60}
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = ApplicationDefaultTokenSource(
                 env_get=env_get, file_reader=file_reader
             )
@@ -365,9 +338,7 @@ class TestApplicationDefault:
                 200, json={"access_token": "metadata-tok", "expires_in": 900}
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             src = ApplicationDefaultTokenSource(env_get=env_get)
             token = await src.acquire(client)
         assert token.value == "metadata-tok"
@@ -378,9 +349,7 @@ class TestApplicationDefault:
 
         async with httpx.AsyncClient(
             transport=httpx.MockTransport(
-                lambda _r: httpx.Response(
-                    200, json={"expires_in": 60}
-                )
+                lambda _r: httpx.Response(200, json={"expires_in": 60})
             )
         ) as client:
             src = ApplicationDefaultTokenSource(env_get=env_get)

--- a/packages/pii-scanner-gdrive/src/pleno_pii_scanner_gdrive/connector.py
+++ b/packages/pii-scanner-gdrive/src/pleno_pii_scanner_gdrive/connector.py
@@ -175,9 +175,7 @@ class GdriveConnector:
         try:
             self._sa = json.loads(config.service_account_json)
         except (TypeError, ValueError) as exc:
-            raise ValueError(
-                "service_account_json must be valid JSON"
-            ) from exc
+            raise ValueError("service_account_json must be valid JSON") from exc
 
     def capabilities(self) -> Capabilities:
         # incremental=True because Drive exposes per-drive pageTokens
@@ -226,22 +224,16 @@ class GdriveConnector:
                     ref = self._ref_from_file(drive_id, entry, cursor_str)
                     if ref is None:
                         continue
-                    if filter.include and not _matches_any(
-                        ref.path, filter.include
-                    ):
+                    if filter.include and not _matches_any(ref.path, filter.include):
                         continue
-                    if filter.exclude and _matches_any(
-                        ref.path, filter.exclude
-                    ):
+                    if filter.exclude and _matches_any(ref.path, filter.exclude):
                         continue
                     yield ref
                 if not next_page:
                     break
                 page_token = next_page
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         size_str = ref.metadata.get("size")
         # Skip oversized files — emit no Document so the pipeline
         # records a fetch-skip rather than buffering 100 MiB into
@@ -260,9 +252,7 @@ class GdriveConnector:
         if mime_type in _NATIVE_DOC_MIMES:
             export_mime = self._config.export_google_docs_as
             url = f"{self._drive_base}/files/{file_id}/export"
-            resp = await self._authed_get(
-                url, params={"mimeType": export_mime}
-            )
+            resp = await self._authed_get(url, params={"mimeType": export_mime})
             resp.raise_for_status()
             if export_mime == "text/plain":
                 yield Document(
@@ -313,9 +303,7 @@ class GdriveConnector:
             params: dict[str, str] = {"pageSize": "100"}
             if page_token:
                 params["pageToken"] = page_token
-            resp = await self._authed_get(
-                f"{self._drive_base}/drives", params=params
-            )
+            resp = await self._authed_get(f"{self._drive_base}/drives", params=params)
             resp.raise_for_status()
             body = resp.json()
             for entry in body.get("drives", ()) or ():
@@ -431,9 +419,7 @@ class GdriveConnector:
             + b"."
             + _b64url(json.dumps(claim, separators=(",", ":")).encode())
         )
-        signature = _sign_rs256(
-            signing_input, self._sa.get("private_key", "")
-        )
+        signature = _sign_rs256(signing_input, self._sa.get("private_key", ""))
         return (signing_input + b"." + _b64url(signature)).decode("ascii")
 
 
@@ -459,9 +445,7 @@ def _sign_rs256(signing_input: bytes, private_key_pem: str) -> bytes:
     except ImportError:  # pragma: no cover — exercised only when crypto missing
         digest = hashlib.sha256(signing_input).digest()
         return digest
-    key = serialization.load_pem_private_key(
-        private_key_pem.encode(), password=None
-    )
+    key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
     return key.sign(  # type: ignore[union-attr]
         signing_input, padding.PKCS1v15(), hashes.SHA256()
     )
@@ -479,8 +463,7 @@ def _list_files_params(drive_id: str, page_token: str | None) -> dict[str, str]:
         "q": "trashed=false",
         "pageSize": "1000",
         "fields": (
-            "files(id,name,mimeType,modifiedTime,size,md5Checksum),"
-            "nextPageToken"
+            "files(id,name,mimeType,modifiedTime,size,md5Checksum),nextPageToken"
         ),
     }
     if drive_id == "root":
@@ -538,9 +521,7 @@ def _parse_iso_utc(value: Any) -> datetime | None:
 
 def _factory(config: Mapping[str, Any]) -> SourceConnector:
     if "service_account_json" not in config:
-        raise ValueError(
-            "gdrive connector config requires 'service_account_json'"
-        )
+        raise ValueError("gdrive connector config requires 'service_account_json'")
     return GdriveConnector(
         GdriveConfig(
             service_account_json=str(config["service_account_json"]),
@@ -550,9 +531,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
                 else None
             ),
             drives=tuple(str(d) for d in config.get("drives", ()) or ()),
-            include_shared_drives=bool(
-                config.get("include_shared_drives", True)
-            ),
+            include_shared_drives=bool(config.get("include_shared_drives", True)),
             max_file_size_bytes=int(
                 config.get("max_file_size_bytes", _DEFAULT_MAX_FILE_SIZE)
             ),

--- a/packages/pii-scanner-gdrive/tests/test_connector.py
+++ b/packages/pii-scanner-gdrive/tests/test_connector.py
@@ -105,14 +105,10 @@ class TestConfig:
 
     def test_requires_impersonate_when_shared_drives(self) -> None:
         with pytest.raises(ValueError, match="impersonate"):
-            GdriveConfig(
-                service_account_json=SA_JSON, include_shared_drives=True
-            )
+            GdriveConfig(service_account_json=SA_JSON, include_shared_drives=True)
 
     def test_allows_no_impersonate_when_shared_drives_off(self) -> None:
-        cfg = GdriveConfig(
-            service_account_json=SA_JSON, include_shared_drives=False
-        )
+        cfg = GdriveConfig(service_account_json=SA_JSON, include_shared_drives=False)
         assert cfg.impersonate is None
 
     def test_rejects_bad_export_mime(self) -> None:
@@ -178,17 +174,13 @@ class TestConfig:
 class TestProtocol:
     def test_runtime_isinstance(self) -> None:
         c = GdriveConnector(
-            GdriveConfig(
-                service_account_json=SA_JSON, impersonate="x@y.com"
-            )
+            GdriveConfig(service_account_json=SA_JSON, impersonate="x@y.com")
         )
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
         c = GdriveConnector(
-            GdriveConfig(
-                service_account_json=SA_JSON, impersonate="x@y.com"
-            )
+            GdriveConfig(service_account_json=SA_JSON, impersonate="x@y.com")
         )
         assert c.capabilities() == Capabilities(
             incremental=True,
@@ -280,9 +272,7 @@ class TestDiscover:
         # /drives was hit
         assert any(p.endswith("/drives") for p in seen_paths)
 
-    async def test_pagination(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_pagination(self, monkeypatch: pytest.MonkeyPatch) -> None:
         page_calls: list[str | None] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -293,14 +283,10 @@ class TestDiscover:
                 if token is None:
                     return httpx.Response(
                         200,
-                        json=_files_response(
-                            _file("f1"), next_page="page2"
-                        ),
+                        json=_files_response(_file("f1"), next_page="page2"),
                     )
                 if token == "page2":
-                    return httpx.Response(
-                        200, json=_files_response(_file("f2"))
-                    )
+                    return httpx.Response(200, json=_files_response(_file("f2")))
             return httpx.Response(404)
 
         cfg = GdriveConfig(
@@ -359,9 +345,7 @@ class TestDiscover:
                 drive_id = request.url.params.get("driveId")
                 return httpx.Response(
                     200,
-                    json=_files_response(
-                        _file(f"f-{drive_id or 'root'}")
-                    ),
+                    json=_files_response(_file(f"f-{drive_id or 'root'}")),
                 )
             return httpx.Response(404)
 
@@ -382,9 +366,7 @@ class TestDiscover:
             await c.close()
             await client.aclose()
 
-    async def test_drives_pagination(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_drives_pagination(self, monkeypatch: pytest.MonkeyPatch) -> None:
         drives_pages = [
             {"drives": [{"id": "d1"}], "nextPageToken": "p2"},
             {"drives": [{"id": "d2", "name": "n2"}, "garbage", {}]},
@@ -399,9 +381,7 @@ class TestDiscover:
                 return httpx.Response(200, json=resp)
             if path.endswith("/files"):
                 drive_id = request.url.params.get("driveId") or "root"
-                return httpx.Response(
-                    200, json=_files_response(_file(f"f-{drive_id}"))
-                )
+                return httpx.Response(200, json=_files_response(_file(f"f-{drive_id}")))
             return httpx.Response(404)
 
         c, client = _make(handler, monkeypatch)
@@ -438,9 +418,7 @@ class TestDiscover:
         try:
             refs = [
                 r
-                async for r in c.discover(
-                    SourceFilter(include=("root/keep-*",)), None
-                )
+                async for r in c.discover(SourceFilter(include=("root/keep-*",)), None)
             ]
             assert [r.path for r in refs] == ["root/keep-me"]
         finally:
@@ -451,9 +429,7 @@ class TestDiscover:
         try:
             refs = [
                 r
-                async for r in c2.discover(
-                    SourceFilter(exclude=("root/drop-*",)), None
-                )
+                async for r in c2.discover(SourceFilter(exclude=("root/drop-*",)), None)
             ]
             assert [r.path for r in refs] == ["root/keep-me"]
         finally:
@@ -544,9 +520,7 @@ class TestCursor:
             path = request.url.path
             if path.endswith("/files"):
                 called_files["n"] += 1
-                return httpx.Response(
-                    200, json=_files_response(_file("after-resume"))
-                )
+                return httpx.Response(200, json=_files_response(_file("after-resume")))
             return httpx.Response(404)
 
         cfg = GdriveConfig(
@@ -557,9 +531,7 @@ class TestCursor:
         c, client = _make(handler, monkeypatch, cfg=cfg)
         try:
             cursor = json.dumps({"root": "__done__"})
-            refs = [
-                r async for r in c.discover(SourceFilter(), cursor)
-            ]
+            refs = [r async for r in c.discover(SourceFilter(), cursor)]
             # Only d2 walked
             assert [r.path for r in refs] == ["d2/after-resume"]
             assert called_files["n"] == 1
@@ -579,9 +551,7 @@ class TestCursor:
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.path.endswith("/files"):
                 observed_token["v"] = request.url.params.get("pageToken")
-                return httpx.Response(
-                    200, json=_files_response(_file("late"))
-                )
+                return httpx.Response(200, json=_files_response(_file("late")))
             return httpx.Response(404)
 
         cfg = GdriveConfig(
@@ -639,9 +609,7 @@ class TestCursor:
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.path.endswith("/files"):
                 observed["v"] = request.url.params.get("pageToken")
-                return httpx.Response(
-                    200, json=_files_response(_file("ok"))
-                )
+                return httpx.Response(200, json=_files_response(_file("ok")))
             return httpx.Response(404)
 
         cfg = GdriveConfig(
@@ -702,9 +670,7 @@ class TestFetch:
             await c.close()
             await client.aclose()
 
-    async def test_native_doc_pdf_export(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_native_doc_pdf_export(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pdf_bytes = b"%PDF-1.7 ... bytes ..."
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -722,10 +688,7 @@ class TestFetch:
                     ),
                 )
             if path.endswith("/files/sheet-1/export"):
-                assert (
-                    request.url.params.get("mimeType")
-                    == "application/pdf"
-                )
+                assert request.url.params.get("mimeType") == "application/pdf"
                 return httpx.Response(
                     200, content=pdf_bytes, headers={"content-type": "application/pdf"}
                 )
@@ -747,9 +710,7 @@ class TestFetch:
             await c.close()
             await client.aclose()
 
-    async def test_binary_alt_media(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_binary_alt_media(self, monkeypatch: pytest.MonkeyPatch) -> None:
         body = b"\x89PNG\r\n\x1a\n binary"
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -757,9 +718,7 @@ class TestFetch:
             if path.endswith("/files"):
                 return httpx.Response(
                     200,
-                    json=_files_response(
-                        _file("png-1", mime="image/png", size="20")
-                    ),
+                    json=_files_response(_file("png-1", mime="image/png", size="20")),
                 )
             if path.endswith("/files/png-1"):
                 assert request.url.params.get("alt") == "media"
@@ -782,9 +741,7 @@ class TestFetch:
             await c.close()
             await client.aclose()
 
-    async def test_max_size_skip(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_max_size_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         called_get = {"n": 0}
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -885,13 +842,8 @@ class TestToken:
                     json={"access_token": "tok-fresh", "expires_in": 3600},
                 )
             if path.endswith("/files"):
-                assert (
-                    request.headers.get("Authorization")
-                    == "Bearer tok-fresh"
-                )
-                return httpx.Response(
-                    200, json=_files_response(_file("a"), _file("b"))
-                )
+                assert request.headers.get("Authorization") == "Bearer tok-fresh"
+                return httpx.Response(200, json=_files_response(_file("a"), _file("b")))
             return httpx.Response(404)
 
         # NOTE: do NOT inject `_acquire_token` here — exercise the real path.
@@ -906,7 +858,9 @@ class TestToken:
         # Make signing deterministic by stubbing `_build_jwt_assertion`
         # so we do not require the cryptography backend in tests.
         monkeypatch.setattr(
-            GdriveConnector, "_build_jwt_assertion", lambda self, now: "stub.jwt.assertion"
+            GdriveConnector,
+            "_build_jwt_assertion",
+            lambda self, now: "stub.jwt.assertion",
         )
         try:
             # Two iterations exhaust files; token should refresh only once.
@@ -941,9 +895,7 @@ class TestToken:
                     },
                 )
             if request.url.path.endswith("/files"):
-                return httpx.Response(
-                    200, json=_files_response(_file("x"))
-                )
+                return httpx.Response(200, json=_files_response(_file("x")))
             return httpx.Response(404)
 
         client = _client(handler)
@@ -1006,9 +958,7 @@ class TestToken:
 
         client = _client(handler)
         c = GdriveConnector(
-            GdriveConfig(
-                service_account_json=SA_JSON, impersonate="x@y.com"
-            ),
+            GdriveConfig(service_account_json=SA_JSON, impersonate="x@y.com"),
             client=client,
         )
         monkeypatch.setattr(
@@ -1106,18 +1056,14 @@ class TestSpec:
 class TestClose:
     async def test_close_owns_client(self) -> None:
         c = GdriveConnector(
-            GdriveConfig(
-                service_account_json=SA_JSON, impersonate="x@y.com"
-            )
+            GdriveConfig(service_account_json=SA_JSON, impersonate="x@y.com")
         )
         await c.close()
 
     async def test_close_external_client_not_closed(self) -> None:
         client = httpx.AsyncClient()
         c = GdriveConnector(
-            GdriveConfig(
-                service_account_json=SA_JSON, impersonate="x@y.com"
-            ),
+            GdriveConfig(service_account_json=SA_JSON, impersonate="x@y.com"),
             client=client,
         )
         await c.close()

--- a/packages/pii-scanner-github/src/pleno_pii_scanner_github/api.py
+++ b/packages/pii-scanner-github/src/pleno_pii_scanner_github/api.py
@@ -184,9 +184,7 @@ def _raise_for_rate_limit(response: httpx.Response) -> None:
     status = response.status_code
     if status == 429:
         retry_after = response.headers.get("Retry-After")
-        raise RateLimited(
-            f"github primary 429; retry_after={retry_after!r}"
-        )
+        raise RateLimited(f"github primary 429; retry_after={retry_after!r}")
     if status == 403 and response.headers.get("Retry-After") is not None:
         raise RateLimited(
             f"github secondary 403; retry_after={response.headers['Retry-After']!r}"

--- a/packages/pii-scanner-github/src/pleno_pii_scanner_github/app_auth.py
+++ b/packages/pii-scanner-github/src/pleno_pii_scanner_github/app_auth.py
@@ -85,8 +85,7 @@ def mint_app_jwt(
     key = serialization.load_pem_private_key(pem_bytes, password=None)
     if not isinstance(key, rsa.RSAPrivateKey):
         raise ValueError(
-            "GitHub App private key must be RSA; got "
-            f"{type(key).__name__}"
+            f"GitHub App private key must be RSA; got {type(key).__name__}"
         )
     signature = key.sign(
         signing_input.encode("ascii"),
@@ -144,7 +143,10 @@ class AppAuth:
             return cached.token
         async with self._lock:
             cached = self._cached
-            if cached is not None and cached.expires_at - self.skew_seconds > self.now():
+            if (
+                cached is not None
+                and cached.expires_at - self.skew_seconds > self.now()
+            ):
                 return cached.token
             fresh = await self._mint_installation_token()
             self._cached = fresh
@@ -190,6 +192,7 @@ def _parse_expiry(payload: dict[str, object], *, now: float) -> float:
         # GitHub uses `Z` suffix; datetime.fromisoformat in 3.11+ handles
         # it natively but we keep the fallback for paranoia.
         from datetime import datetime
+
         try:
             return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
         except ValueError as exc:

--- a/packages/pii-scanner-github/src/pleno_pii_scanner_github/connector.py
+++ b/packages/pii-scanner-github/src/pleno_pii_scanner_github/connector.py
@@ -81,8 +81,7 @@ class GithubAppConfig:
         targets = [t for t in (self.repo, self.org, self.enterprise) if t is not None]
         if len(targets) != 1:
             raise ValueError(
-                "GithubAppConfig must set exactly one of "
-                "`repo` / `org` / `enterprise`"
+                "GithubAppConfig must set exactly one of `repo` / `org` / `enterprise`"
             )
 
     def resolved_id(self) -> str:
@@ -143,7 +142,8 @@ class GithubAppConnector:
             app_id=app_id,
             installation_id=installation_id,
             private_key_pem=(
-                private_key if isinstance(private_key, str)
+                private_key
+                if isinstance(private_key, str)
                 else private_key.decode("utf-8")
             ),
             api=self._api,
@@ -204,9 +204,7 @@ class GithubAppConnector:
             return tuple(out)
 
         assert self._config.enterprise is not None
-        async for org_name in self._iter_enterprise_orgs(
-            self._config.enterprise
-        ):
+        async for org_name in self._iter_enterprise_orgs(self._config.enterprise):
             async for slug, sha in self._iter_org_subsources(
                 org_name,
                 include_archived=self._config.include_archived,
@@ -222,9 +220,7 @@ class GithubAppConnector:
     def set_subsource_skip(self, skip: frozenset[str]) -> None:
         self._skip_subsources = skip
 
-    async def _resolve_repo_head_sha(
-        self, owner: str, name: str
-    ) -> str | None:
+    async def _resolve_repo_head_sha(self, owner: str, name: str) -> str | None:
         """Single-repo HEAD SHA via REST. Returns None on any error so
         the runner falls back to a normal walk instead of caching a
         stale entry."""
@@ -322,17 +318,13 @@ class GithubAppConnector:
                 after=page_cursor,
                 since=filter.since,
             ):
-                async for ref in self._iter_repo_refs(
-                    owner, name, filter, next_cursor
-                ):
+                async for ref in self._iter_repo_refs(owner, name, filter, next_cursor):
                     yield ref
                 page_cursor = next_cursor
             return
         else:
             assert self._config.enterprise is not None
-            async for org_name in self._iter_enterprise_orgs(
-                self._config.enterprise
-            ):
+            async for org_name in self._iter_enterprise_orgs(self._config.enterprise):
                 async for owner, name, next_cursor in self._iter_org_repos(
                     org_name,
                     include_archived=self._config.include_archived,
@@ -384,13 +376,9 @@ class GithubAppConnector:
             size = entry.get("size")
             if max_size is not None and isinstance(size, int) and size > max_size:
                 continue
-            if filter.exclude and any(
-                _glob_match(path, p) for p in filter.exclude
-            ):
+            if filter.exclude and any(_glob_match(path, p) for p in filter.exclude):
                 continue
-            if filter.include and not any(
-                _glob_match(path, p) for p in filter.include
-            ):
+            if filter.include and not any(_glob_match(path, p) for p in filter.include):
                 continue
             sha = entry["sha"]
             yield DocumentRef(
@@ -458,9 +446,7 @@ class GithubAppConnector:
                 return
             cursor = page_info.get("endCursor")
 
-    async def _iter_enterprise_orgs(
-        self, enterprise: str
-    ) -> AsyncIterator[str]:
+    async def _iter_enterprise_orgs(self, enterprise: str) -> AsyncIterator[str]:
         """Page through `enterprise.organizations` (GHES only).
 
         Returns just org logins; downstream re-enters
@@ -508,9 +494,7 @@ class GithubAppConnector:
             # Stale ref or wrong connector — yield nothing rather than
             # crashing the scheduler's gather().
             return
-        response = await self._api.get(
-            f"/repos/{owner}/{repo}/git/blobs/{sha}"
-        )
+        response = await self._api.get(f"/repos/{owner}/{repo}/git/blobs/{sha}")
         if response.status_code != 200:
             return
         payload = response.json()
@@ -530,9 +514,7 @@ class GithubAppConnector:
             content_hash=sha,
         )
 
-    async def fetch_repo_tarball(
-        self, owner: str, repo: str
-    ) -> bytes | None:
+    async def fetch_repo_tarball(self, owner: str, repo: str) -> bytes | None:
         """Bulk-pull a small repo as a tarball (single HTTP).
 
         Used opportunistically when a discovery pass determined the
@@ -590,6 +572,7 @@ def _parse_iso(value: str) -> datetime:
 def _glob_match(path: str, pattern: str) -> bool:
     """Minimal fnmatch wrapper exposed as a hook for tests."""
     from fnmatch import fnmatch
+
     return fnmatch(path, pattern)
 
 

--- a/packages/pii-scanner-github/tests/test_api.py
+++ b/packages/pii-scanner-github/tests/test_api.py
@@ -225,6 +225,7 @@ class TestGraphQL:
 
         def handler(request: httpx.Request) -> httpx.Response:
             import json
+
             seen.update(json.loads(request.content))
             return httpx.Response(200, json={"data": {}})
 
@@ -252,9 +253,7 @@ class TestGraphQL:
 
     async def test_graphql_errors_field_raises(self) -> None:
         def handler(_: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                200, json={"errors": [{"message": "bad query"}]}
-            )
+            return httpx.Response(200, json={"errors": [{"message": "bad query"}]})
 
         api = GithubApi(transport=httpx.MockTransport(handler))
         try:
@@ -281,6 +280,7 @@ class TestPost:
 
         def handler(request: httpx.Request) -> httpx.Response:
             import json
+
             seen["body"] = json.loads(request.content)
             return httpx.Response(201, json={"ok": True})
 

--- a/packages/pii-scanner-github/tests/test_app_auth.py
+++ b/packages/pii-scanner-github/tests/test_app_auth.py
@@ -54,9 +54,7 @@ class TestMintAppJwt:
             rsa_pem.encode(), password=None
         ).public_key()
         # No exception => signature valid.
-        public_key.verify(
-            signature, signing_input, padding.PKCS1v15(), hashes.SHA256()
-        )
+        public_key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA256())
 
     def test_uses_default_clock_when_now_omitted(self, rsa_pem: str) -> None:
         # Just smoke — mint_app_jwt(now=None) must not crash.
@@ -64,9 +62,7 @@ class TestMintAppJwt:
         assert token.count(".") == 2
 
     def test_accepts_bytes_pem(self, rsa_pem: str) -> None:
-        token = mint_app_jwt(
-            app_id="1", private_key_pem=rsa_pem.encode(), now=1000.0
-        )
+        token = mint_app_jwt(app_id="1", private_key_pem=rsa_pem.encode(), now=1000.0)
         assert token.count(".") == 2
 
     def test_rejects_non_rsa_key(self) -> None:
@@ -99,9 +95,7 @@ class TestParseExpiry:
         assert ts == 1704067200.0
 
     def test_iso_8601_with_offset(self) -> None:
-        ts = _parse_expiry(
-            {"expires_at": "2024-01-01T00:00:00+00:00"}, now=0.0
-        )
+        ts = _parse_expiry({"expires_at": "2024-01-01T00:00:00+00:00"}, now=0.0)
         assert ts == 1704067200.0
 
     def test_relative_expires_in_fallback(self) -> None:
@@ -238,9 +232,7 @@ class TestAppAuthCache:
         finally:
             await api.aclose()
 
-    async def test_failure_response_raises_permission_error(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_failure_response_raises_permission_error(self, rsa_pem: str) -> None:
         def handler(_: httpx.Request) -> httpx.Response:
             return httpx.Response(404, text="installation not found")
 
@@ -258,9 +250,7 @@ class TestAppAuthCache:
         finally:
             await api.aclose()
 
-    async def test_concurrent_first_call_only_mints_once(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_concurrent_first_call_only_mints_once(self, rsa_pem: str) -> None:
         # Two coroutines race past the unlocked check at the same time.
         # The asyncio.Lock + double-checked re-read of `self._cached`
         # must collapse them onto a single mint. We assert by counting
@@ -300,9 +290,7 @@ class TestAppAuthCache:
         finally:
             await api.aclose()
 
-    async def test_install_token_seam_pre_seeds_cache(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_install_token_seam_pre_seeds_cache(self, rsa_pem: str) -> None:
         # If the cache is pre-populated with a still-valid token, no
         # network call should happen at all.
         def handler(_: httpx.Request) -> httpx.Response:

--- a/packages/pii-scanner-github/tests/test_connector.py
+++ b/packages/pii-scanner-github/tests/test_connector.py
@@ -69,12 +69,14 @@ def make_handler(
     requests cause an explicit AssertionError so we never silently
     return 200 for a path the test forgot to mock.
     """
+
     def handler(request: httpx.Request) -> httpx.Response:
         url = str(request.url)
         for suffix, fn in routes:
             if suffix in url:
                 return fn(request)
         raise AssertionError(f"no route matches {url}")
+
     return handler
 
 
@@ -155,9 +157,7 @@ class TestConstruction:
     def test_credential_missing_keys_rejected(self) -> None:
         cred = Credential(kind="github-app", payload={"app_id": "1"})
         with pytest.raises(ValueError, match="requires keys"):
-            GithubAppConnector(
-                GithubAppConfig(repo="a/b"), credential=cred
-            )
+            GithubAppConnector(GithubAppConfig(repo="a/b"), credential=cred)
 
     def test_credential_non_string_pk_rejected(self, rsa_pem: str) -> None:
         cred = Credential(
@@ -220,10 +220,14 @@ class TestDiscoverSingleRepo:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", access_token),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", access_token),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="acme/widgets"),
             credential=make_credential(rsa_pem),
@@ -256,10 +260,14 @@ class TestDiscoverSingleRepo:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -285,10 +293,14 @@ class TestDiscoverSingleRepo:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -312,10 +324,14 @@ class TestDiscoverSingleRepo:
             await c.close()
 
     async def test_404_repo_yields_nothing(self, rsa_pem: str) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/trees/HEAD", lambda _: httpx.Response(404)),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/trees/HEAD", lambda _: httpx.Response(404)),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -336,48 +352,50 @@ class TestDiscoverSingleRepo:
 class TestDiscoverOrg:
     async def test_paginated_org_repos_yielded(self, rsa_pem: str) -> None:
         # Two GraphQL pages, two repos each, then a tree fetch per repo.
-        graphql_pages = iter([
-            {
-                "data": {
-                    "organization": {
-                        "repositories": {
-                            "pageInfo": {"endCursor": "c1", "hasNextPage": True},
-                            "nodes": [
-                                {
-                                    "name": "r1",
-                                    "owner": {"login": "acme"},
-                                    "isArchived": False,
-                                    "pushedAt": "2024-01-01T00:00:00Z",
-                                },
-                                {
-                                    "name": "r2",
-                                    "owner": {"login": "acme"},
-                                    "isArchived": True,  # filtered out
-                                    "pushedAt": "2024-01-01T00:00:00Z",
-                                },
-                            ],
+        graphql_pages = iter(
+            [
+                {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "pageInfo": {"endCursor": "c1", "hasNextPage": True},
+                                "nodes": [
+                                    {
+                                        "name": "r1",
+                                        "owner": {"login": "acme"},
+                                        "isArchived": False,
+                                        "pushedAt": "2024-01-01T00:00:00Z",
+                                    },
+                                    {
+                                        "name": "r2",
+                                        "owner": {"login": "acme"},
+                                        "isArchived": True,  # filtered out
+                                        "pushedAt": "2024-01-01T00:00:00Z",
+                                    },
+                                ],
+                            }
                         }
                     }
-                }
-            },
-            {
-                "data": {
-                    "organization": {
-                        "repositories": {
-                            "pageInfo": {"endCursor": "c2", "hasNextPage": False},
-                            "nodes": [
-                                {
-                                    "name": "r3",
-                                    "owner": {"login": "acme"},
-                                    "isArchived": False,
-                                    "pushedAt": "2024-01-01T00:00:00Z",
-                                },
-                            ],
+                },
+                {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "pageInfo": {"endCursor": "c2", "hasNextPage": False},
+                                "nodes": [
+                                    {
+                                        "name": "r3",
+                                        "owner": {"login": "acme"},
+                                        "isArchived": False,
+                                        "pushedAt": "2024-01-01T00:00:00Z",
+                                    },
+                                ],
+                            }
                         }
                     }
-                }
-            },
-        ])
+                },
+            ]
+        )
 
         def graphql(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=next(graphql_pages))
@@ -398,11 +416,15 @@ class TestDiscoverOrg:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme", include_archived=False),
             credential=make_credential(rsa_pem),
@@ -418,9 +440,7 @@ class TestDiscoverOrg:
         finally:
             await c.close()
 
-    async def test_include_archived_keeps_archived_repos(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_include_archived_keeps_archived_repos(self, rsa_pem: str) -> None:
         def graphql(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -448,14 +468,19 @@ class TestDiscoverOrg:
 
         def trees(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
-                200, json={"tree": [{"type": "blob", "path": "f", "sha": "s", "size": 1}]}
+                200,
+                json={"tree": [{"type": "blob", "path": "f", "sha": "s", "size": 1}]},
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme", include_archived=True),
             credential=make_credential(rsa_pem),
@@ -509,11 +534,15 @@ class TestDiscoverOrg:
                 json={"tree": [{"type": "blob", "path": "f", "sha": "s", "size": 1}]},
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme"),
             credential=make_credential(rsa_pem),
@@ -541,55 +570,57 @@ class TestDiscoverEnterprise:
     async def test_walks_each_org_in_enterprise(self, rsa_pem: str) -> None:
         # First GraphQL call is enterprise.organizations; subsequent
         # calls are organization.repositories per org.
-        responses = iter([
-            # enterprise.organizations
-            {
-                "data": {
-                    "enterprise": {
-                        "organizations": {
-                            "pageInfo": {"endCursor": None, "hasNextPage": False},
-                            "nodes": [{"login": "acme"}, {"login": "globex"}],
+        responses = iter(
+            [
+                # enterprise.organizations
+                {
+                    "data": {
+                        "enterprise": {
+                            "organizations": {
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "nodes": [{"login": "acme"}, {"login": "globex"}],
+                            }
                         }
                     }
-                }
-            },
-            # organization.repositories (acme)
-            {
-                "data": {
-                    "organization": {
-                        "repositories": {
-                            "pageInfo": {"endCursor": None, "hasNextPage": False},
-                            "nodes": [
-                                {
-                                    "name": "r1",
-                                    "owner": {"login": "acme"},
-                                    "isArchived": False,
-                                    "pushedAt": "2024-01-01T00:00:00Z",
-                                }
-                            ],
+                },
+                # organization.repositories (acme)
+                {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "nodes": [
+                                    {
+                                        "name": "r1",
+                                        "owner": {"login": "acme"},
+                                        "isArchived": False,
+                                        "pushedAt": "2024-01-01T00:00:00Z",
+                                    }
+                                ],
+                            }
                         }
                     }
-                }
-            },
-            # organization.repositories (globex)
-            {
-                "data": {
-                    "organization": {
-                        "repositories": {
-                            "pageInfo": {"endCursor": None, "hasNextPage": False},
-                            "nodes": [
-                                {
-                                    "name": "r2",
-                                    "owner": {"login": "globex"},
-                                    "isArchived": False,
-                                    "pushedAt": "2024-01-01T00:00:00Z",
-                                }
-                            ],
+                },
+                # organization.repositories (globex)
+                {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "nodes": [
+                                    {
+                                        "name": "r2",
+                                        "owner": {"login": "globex"},
+                                        "isArchived": False,
+                                        "pushedAt": "2024-01-01T00:00:00Z",
+                                    }
+                                ],
+                            }
                         }
                     }
-                }
-            },
-        ])
+                },
+            ]
+        )
 
         def graphql(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=next(responses))
@@ -600,11 +631,15 @@ class TestDiscoverEnterprise:
                 json={"tree": [{"type": "blob", "path": "f", "sha": "s", "size": 1}]},
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(enterprise="acme-inc"),
             credential=make_credential(rsa_pem),
@@ -619,56 +654,62 @@ class TestDiscoverEnterprise:
 
     async def test_enterprise_pagination(self, rsa_pem: str) -> None:
         # Two enterprise pages of orgs.
-        responses = iter([
-            {
-                "data": {
-                    "enterprise": {
-                        "organizations": {
-                            "pageInfo": {"endCursor": "p1", "hasNextPage": True},
-                            "nodes": [{"login": "a"}],
+        responses = iter(
+            [
+                {
+                    "data": {
+                        "enterprise": {
+                            "organizations": {
+                                "pageInfo": {"endCursor": "p1", "hasNextPage": True},
+                                "nodes": [{"login": "a"}],
+                            }
                         }
                     }
-                }
-            },
-            {
-                "data": {
-                    "organization": {
-                        "repositories": {
-                            "pageInfo": {"endCursor": None, "hasNextPage": False},
-                            "nodes": [],
+                },
+                {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "nodes": [],
+                            }
                         }
                     }
-                }
-            },
-            {
-                "data": {
-                    "enterprise": {
-                        "organizations": {
-                            "pageInfo": {"endCursor": None, "hasNextPage": False},
-                            "nodes": [{"login": "b"}],
+                },
+                {
+                    "data": {
+                        "enterprise": {
+                            "organizations": {
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "nodes": [{"login": "b"}],
+                            }
                         }
                     }
-                }
-            },
-            {
-                "data": {
-                    "organization": {
-                        "repositories": {
-                            "pageInfo": {"endCursor": None, "hasNextPage": False},
-                            "nodes": [],
+                },
+                {
+                    "data": {
+                        "organization": {
+                            "repositories": {
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "nodes": [],
+                            }
                         }
                     }
-                }
-            },
-        ])
+                },
+            ]
+        )
 
         def graphql(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json=next(responses))
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(enterprise="acme-inc"),
             credential=make_credential(rsa_pem),
@@ -694,10 +735,14 @@ class TestFetch:
                 json={"content": _b64("password=hunter2\n"), "encoding": "base64"},
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/blobs/", blob),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/blobs/", blob),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -718,17 +763,19 @@ class TestFetch:
         finally:
             await c.close()
 
-    async def test_fetch_missing_metadata_returns_empty(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_fetch_missing_metadata_returns_empty(self, rsa_pem: str) -> None:
         # Connector still needs to mint a token (eager refresh) before
         # bailing out; the mock transport must answer that one call.
         def access_token(_: httpx.Request) -> httpx.Response:
             return _access_token_response()
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", access_token),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", access_token),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -746,10 +793,14 @@ class TestFetch:
             await c.close()
 
     async def test_fetch_404_blob_returns_empty(self, rsa_pem: str) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/blobs/", lambda _: httpx.Response(404)),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/blobs/", lambda _: httpx.Response(404)),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -766,16 +817,18 @@ class TestFetch:
         finally:
             await c.close()
 
-    async def test_fetch_undecodable_base64_returns_empty(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_fetch_undecodable_base64_returns_empty(self, rsa_pem: str) -> None:
         def blob(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json={"content": "!!!not_base64!!!"})
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/blobs/", blob),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/blobs/", blob),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -805,10 +858,14 @@ class TestFetchTarball:
         def tarball(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/tarball", tarball),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/tarball", tarball),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -826,10 +883,14 @@ class TestFetchTarball:
         def tarball(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=body)
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/tarball", tarball),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/tarball", tarball),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -841,10 +902,14 @@ class TestFetchTarball:
             await c.close()
 
     async def test_returns_none_on_404(self, rsa_pem: str) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/tarball", lambda _: httpx.Response(404)),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/tarball", lambda _: httpx.Response(404)),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -865,10 +930,17 @@ class TestRateLimitPropagation:
     async def test_secondary_429_during_discover_surfaces_rate_limited(
         self, rsa_pem: str
     ) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/trees/HEAD", lambda _: httpx.Response(429, headers={"Retry-After": "5"})),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    (
+                        "/git/trees/HEAD",
+                        lambda _: httpx.Response(429, headers={"Retry-After": "5"}),
+                    ),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="a/b"),
             credential=make_credential(rsa_pem),
@@ -933,9 +1005,7 @@ class TestSpec:
         assert SPEC.capabilities.incremental is True
         assert SPEC.capabilities.content_hash_delta is True
 
-    def test_factory_builds_connector_with_credential(
-        self, rsa_pem: str
-    ) -> None:
+    def test_factory_builds_connector_with_credential(self, rsa_pem: str) -> None:
         cred = make_credential(rsa_pem)
         c = SPEC.factory(
             {
@@ -984,9 +1054,7 @@ class TestIncrementalSubsources:
         )
         assert isinstance(c, IncrementalSourceConnector)
 
-    async def test_list_subsources_single_repo_uses_rest(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_list_subsources_single_repo_uses_rest(self, rsa_pem: str) -> None:
         def repo_meta(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -996,11 +1064,15 @@ class TestIncrementalSubsources:
         def commit_for_branch(_: httpx.Request) -> httpx.Response:
             return httpx.Response(200, json={"sha": "0" * 40})
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/commits/trunk", commit_for_branch),
-            ("/repos/acme/widgets", repo_meta),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/commits/trunk", commit_for_branch),
+                    ("/repos/acme/widgets", repo_meta),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="acme/widgets"),
             credential=make_credential(rsa_pem),
@@ -1014,9 +1086,7 @@ class TestIncrementalSubsources:
         finally:
             await c.close()
 
-    async def test_list_subsources_org_uses_graphql_oid(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_list_subsources_org_uses_graphql_oid(self, rsa_pem: str) -> None:
         # GraphQL `_ORG_REPOS_QUERY` now includes
         # `defaultBranchRef.target.oid`. We assert the connector
         # extracts it without an extra REST round-trip.
@@ -1057,10 +1127,14 @@ class TestIncrementalSubsources:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme"),
             credential=make_credential(rsa_pem),
@@ -1076,9 +1150,7 @@ class TestIncrementalSubsources:
         finally:
             await c.close()
 
-    async def test_list_subsources_archived_filter(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_list_subsources_archived_filter(self, rsa_pem: str) -> None:
         def graphql(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -1116,10 +1188,14 @@ class TestIncrementalSubsources:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme", include_archived=False),
             credential=make_credential(rsa_pem),
@@ -1163,10 +1239,14 @@ class TestIncrementalSubsources:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme"),
             credential=make_credential(rsa_pem),
@@ -1227,11 +1307,15 @@ class TestIncrementalSubsources:
             tree_calls.append(str(request.url))
             return httpx.Response(200, json={"tree": []})
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/graphql", graphql),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/graphql", graphql),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(org="acme"),
             credential=make_credential(rsa_pem),
@@ -1247,9 +1331,7 @@ class TestIncrementalSubsources:
         finally:
             await c.close()
 
-    async def test_discover_refs_carry_subsource_metadata(
-        self, rsa_pem: str
-    ) -> None:
+    async def test_discover_refs_carry_subsource_metadata(self, rsa_pem: str) -> None:
         def trees(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -1260,10 +1342,14 @@ class TestIncrementalSubsources:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/access_tokens", lambda _: _access_token_response()),
-            ("/git/trees/HEAD", trees),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/access_tokens", lambda _: _access_token_response()),
+                    ("/git/trees/HEAD", trees),
+                ]
+            )
+        )
         c = GithubAppConnector(
             GithubAppConfig(repo="acme/widgets"),
             credential=make_credential(rsa_pem),

--- a/packages/pii-scanner-gitlab/src/pleno_pii_scanner_gitlab/api.py
+++ b/packages/pii-scanner-gitlab/src/pleno_pii_scanner_gitlab/api.py
@@ -76,9 +76,7 @@ class GitlabApi:
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._auth_mode = auth_mode
-        self._auth_header_name, self._auth_header_value = header_for(
-            auth_mode, token
-        )
+        self._auth_header_name, self._auth_header_value = header_for(auth_mode, token)
         kwargs: dict[str, Any] = {"timeout": timeout}
         if transport is not None:
             # MockTransport short-circuits the network entirely; passing
@@ -180,9 +178,7 @@ def _raise_for_rate_limit(response: httpx.Response) -> None:
     status = response.status_code
     if status == 429:
         retry_after = response.headers.get("Retry-After")
-        raise RateLimited(
-            f"gitlab 429; retry_after={retry_after!r}"
-        )
+        raise RateLimited(f"gitlab 429; retry_after={retry_after!r}")
     if status == 403 and (
         response.headers.get("RateLimit-Remaining") == "0"
         or response.headers.get("X-RateLimit-Remaining") == "0"
@@ -190,9 +186,8 @@ def _raise_for_rate_limit(response: httpx.Response) -> None:
         # Quota exhausted, no Retry-After. Surface as RateLimited so the
         # scheduler treats it as transient (refill in <bucket window>)
         # rather than as a permission failure that needs an operator.
-        reset = (
-            response.headers.get("RateLimit-Reset")
-            or response.headers.get("X-RateLimit-Reset")
+        reset = response.headers.get("RateLimit-Reset") or response.headers.get(
+            "X-RateLimit-Reset"
         )
         raise RateLimited(f"gitlab quota exhausted; reset={reset!r}")
 

--- a/packages/pii-scanner-gitlab/src/pleno_pii_scanner_gitlab/connector.py
+++ b/packages/pii-scanner-gitlab/src/pleno_pii_scanner_gitlab/connector.py
@@ -29,7 +29,7 @@ import shutil
 import subprocess
 import tempfile
 import urllib.parse
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -74,9 +74,7 @@ ProjectInfo = Mapping[str, Any]
 CloneFn = Callable[["GitlabConnector", ProjectInfo], Path]
 # Enumeration is async because it walks paginated REST. Tests inject an
 # AsyncIterable to drive the connector without touching the API client.
-EnumerateFn = Callable[
-    ["GitlabConnector"], AsyncIterator[ProjectInfo]
-]
+EnumerateFn = Callable[["GitlabConnector"], AsyncIterator[ProjectInfo]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -201,7 +199,8 @@ class GitlabConnector:
         # changed across GitLab versions; cheaper to re-enumerate.
         del cursor
         projects = (
-            self._enumerate_fn(self) if self._enumerate_fn is not None
+            self._enumerate_fn(self)
+            if self._enumerate_fn is not None
             else self._iter_projects()
         )
         async for project in projects:
@@ -255,9 +254,7 @@ class GitlabConnector:
         url: str = f"/groups/{encoded}/projects"
         first = True
         while True:
-            response = await self._api.get(
-                url, params=params if first else None
-            )
+            response = await self._api.get(url, params=params if first else None)
             if response.status_code != 200:
                 return
             page = response.json()
@@ -309,9 +306,7 @@ class GitlabConnector:
         if not isinstance(path_with_ns, str) or path_with_ns not in self._clones:
             return
         clone_path = self._clones[path_with_ns]
-        inner = DirConnector(
-            DirConfig(root=clone_path, id=f"{KIND}:{path_with_ns}")
-        )
+        inner = DirConnector(DirConfig(root=clone_path, id=f"{KIND}:{path_with_ns}"))
         try:
             inner_ref = self._unwrap_ref(ref)
             async for doc in inner.fetch(inner_ref):
@@ -363,11 +358,12 @@ class GitlabConnector:
             self._tempdirs.append(path)
         return path
 
-    def _wrap_ref(
-        self, inner: DocumentRef, project: ProjectInfo
-    ) -> DocumentRef:
+    def _wrap_ref(self, inner: DocumentRef, project: ProjectInfo) -> DocumentRef:
         path_with_ns = project["path_with_namespace"]
-        web_url = project.get("web_url") or f"{self._config.base_url.rstrip('/')}/{path_with_ns}"
+        web_url = (
+            project.get("web_url")
+            or f"{self._config.base_url.rstrip('/')}/{path_with_ns}"
+        )
         # Surface the project metadata enough that the FindingsStore
         # can render `<group>/<project>:<file>:<line>` without a second
         # API hop.
@@ -533,12 +529,16 @@ def _factory(config: Mapping[str, Any]) -> GitlabConnector:
         )
     return GitlabConnector(
         GitlabConfig(
-            project=str(config["project"]) if config.get("project") is not None else None,
+            project=str(config["project"])
+            if config.get("project") is not None
+            else None,
             group=str(config["group"]) if config.get("group") is not None else None,
             base_url=str(config.get("base_url", DEFAULT_BASE_URL)),
             include_archived=bool(config.get("include_archived", False)),
             visibility=(
-                str(config["visibility"]) if config.get("visibility") is not None else None
+                str(config["visibility"])
+                if config.get("visibility") is not None
+                else None
             ),
             ca_bundle_path=(
                 str(config["ca_bundle_path"])

--- a/packages/pii-scanner-gitlab/tests/test_api.py
+++ b/packages/pii-scanner-gitlab/tests/test_api.py
@@ -126,9 +126,7 @@ class TestProperties:
 
 class TestRateLimited:
     async def test_429_raises(self) -> None:
-        api = _api(
-            lambda _: httpx.Response(429, headers={"Retry-After": "30"})
-        )
+        api = _api(lambda _: httpx.Response(429, headers={"Retry-After": "30"}))
         try:
             with pytest.raises(RateLimited, match="429"):
                 await api.get("/projects")
@@ -173,9 +171,7 @@ class TestRateLimited:
         # A 403 without a rate-limit signal is a permission failure;
         # surfacing it as RateLimited would lock the scheduler in a
         # retry loop against an auth problem that needs a human.
-        api = _api(
-            lambda _: httpx.Response(403, json={"message": "forbidden"})
-        )
+        api = _api(lambda _: httpx.Response(403, json={"message": "forbidden"}))
         try:
             response = await api.get("/projects")
             assert response.status_code == 403
@@ -222,7 +218,7 @@ class TestParseNextLink:
             200,
             headers={
                 "Link": (
-                    'garbage_no_brackets, '
+                    "garbage_no_brackets, "
                     '<https://gitlab.com/api/v4/projects?page=2>; rel="next"'
                 )
             },
@@ -243,9 +239,7 @@ class TestParseNextLink:
         # Only a `rel="prev"` entry — no `next`, return None.
         response = httpx.Response(
             200,
-            headers={
-                "Link": '<https://gitlab.com/api/v4/projects?page=1>; rel="prev"'
-            },
+            headers={"Link": '<https://gitlab.com/api/v4/projects?page=1>; rel="prev"'},
         )
         assert GitlabApi.parse_next_link(response) is None
 
@@ -253,9 +247,7 @@ class TestParseNextLink:
         # A URL without `<>` brackets is not RFC 5988 compliant; bail.
         response = httpx.Response(
             200,
-            headers={
-                "Link": 'https://gitlab.com/api/v4/projects?page=2; rel="next"'
-            },
+            headers={"Link": 'https://gitlab.com/api/v4/projects?page=2; rel="next"'},
         )
         assert GitlabApi.parse_next_link(response) is None
 

--- a/packages/pii-scanner-gitlab/tests/test_connector.py
+++ b/packages/pii-scanner-gitlab/tests/test_connector.py
@@ -41,12 +41,14 @@ def make_handler(
     routes: list[tuple[str, Callable[[httpx.Request], httpx.Response]]],
 ) -> Callable[[httpx.Request], httpx.Response]:
     """Match-by-suffix router; first match wins; unmatched -> AssertionError."""
+
     def handler(request: httpx.Request) -> httpx.Response:
         url = str(request.url)
         for suffix, fn in routes:
             if suffix in url:
                 return fn(request)
         raise AssertionError(f"no route matches {url}")
+
     return handler
 
 
@@ -56,10 +58,12 @@ def stub_clone(
     record: list[tuple[str, str]] | None = None,
 ) -> Callable[[GitlabConnector, Mapping[str, Any]], Path]:
     """Build a clone_fn that returns `return_path` and (optionally) records calls."""
+
     def fn(connector: GitlabConnector, project: Mapping[str, Any]) -> Path:
         if record is not None:
             record.append((connector.token, str(project.get("path_with_namespace"))))
         return return_path
+
     return fn
 
 
@@ -200,9 +204,7 @@ class TestConstruction:
 
 
 class TestDiscoverSingleProject:
-    async def test_single_project_yields_clone_files(
-        self, clone_dir: Path
-    ) -> None:
+    async def test_single_project_yields_clone_files(self, clone_dir: Path) -> None:
         def project(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -215,9 +217,13 @@ class TestDiscoverSingleProject:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/projects/", project),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/projects/", project),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(project="ns/repo"),
             credential=make_credential(),
@@ -244,9 +250,13 @@ class TestDiscoverSingleProject:
             await c.close()
 
     async def test_single_project_404_yields_nothing(self) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/projects/", lambda _: httpx.Response(404)),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/projects/", lambda _: httpx.Response(404)),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(project="ns/missing"),
             credential=make_credential(),
@@ -302,9 +312,13 @@ class TestDiscoverSingleProject:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/projects/", project),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/projects/", project),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(project="ns/old", include_archived=False),
             credential=make_credential(),
@@ -330,9 +344,13 @@ class TestDiscoverSingleProject:
                 },
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/projects/", project),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/projects/", project),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(project="ns/old", include_archived=True),
             credential=make_credential(),
@@ -352,46 +370,46 @@ class TestDiscoverSingleProject:
 
 
 class TestDiscoverGroup:
-    async def test_paginated_group_projects_yielded(
-        self, clone_dir: Path
-    ) -> None:
+    async def test_paginated_group_projects_yielded(self, clone_dir: Path) -> None:
         # Page 1 -> Link points to page 2; page 2 -> no Link header.
         page1_url = "https://gitlab.com/api/v4/groups/acme/projects?page=2"
-        responses = iter([
-            httpx.Response(
-                200,
-                headers={"Link": f'<{page1_url}>; rel="next"'},
-                json=[
-                    {
-                        "id": 1,
-                        "path_with_namespace": "acme/r1",
-                        "default_branch": "main",
-                        "archived": False,
-                    },
-                    {
-                        # Defensive guard: API page entry not a dict — skip.
-                        "not_a_dict": True,
-                    },
-                ],
-            ),
-            httpx.Response(
-                200,
-                json=[
-                    {
-                        "id": 2,
-                        "path_with_namespace": "acme/sub/r2",
-                        "default_branch": "main",
-                        "archived": True,  # filtered out
-                    },
-                    {
-                        "id": 3,
-                        "path_with_namespace": "acme/r3",
-                        "default_branch": "main",
-                        "archived": False,
-                    },
-                ],
-            ),
-        ])
+        responses = iter(
+            [
+                httpx.Response(
+                    200,
+                    headers={"Link": f'<{page1_url}>; rel="next"'},
+                    json=[
+                        {
+                            "id": 1,
+                            "path_with_namespace": "acme/r1",
+                            "default_branch": "main",
+                            "archived": False,
+                        },
+                        {
+                            # Defensive guard: API page entry not a dict — skip.
+                            "not_a_dict": True,
+                        },
+                    ],
+                ),
+                httpx.Response(
+                    200,
+                    json=[
+                        {
+                            "id": 2,
+                            "path_with_namespace": "acme/sub/r2",
+                            "default_branch": "main",
+                            "archived": True,  # filtered out
+                        },
+                        {
+                            "id": 3,
+                            "path_with_namespace": "acme/r3",
+                            "default_branch": "main",
+                            "archived": False,
+                        },
+                    ],
+                ),
+            ]
+        )
         # The list itself contains one non-dict entry to exercise the
         # malformed-page-entry skip.
         responses_list = list(responses)
@@ -405,52 +423,59 @@ class TestDiscoverGroup:
         responses_list[0].json()  # ensure body is decoded
         # Override the middle entry by editing the underlying body in
         # the iterator — easier: mutate via fresh httpx.Response.
-        responses_iter = iter([
-            httpx.Response(
-                200,
-                headers={"Link": f'<{page1_url}>; rel="next"'},
-                json=[
-                    {
-                        "id": 1,
-                        "path_with_namespace": "acme/r1",
-                        "default_branch": "main",
-                        "archived": False,
-                    },
-                    "not-a-dict",
-                ],
-            ),
-            httpx.Response(
-                200,
-                json=[
-                    {
-                        "id": 2,
-                        "path_with_namespace": "acme/sub/r2",
-                        "default_branch": "main",
-                        "archived": True,
-                    },
-                    {
-                        "id": 3,
-                        "path_with_namespace": "acme/r3",
-                        "default_branch": "main",
-                        "archived": False,
-                    },
-                ],
-            ),
-        ])
+        responses_iter = iter(
+            [
+                httpx.Response(
+                    200,
+                    headers={"Link": f'<{page1_url}>; rel="next"'},
+                    json=[
+                        {
+                            "id": 1,
+                            "path_with_namespace": "acme/r1",
+                            "default_branch": "main",
+                            "archived": False,
+                        },
+                        "not-a-dict",
+                    ],
+                ),
+                httpx.Response(
+                    200,
+                    json=[
+                        {
+                            "id": 2,
+                            "path_with_namespace": "acme/sub/r2",
+                            "default_branch": "main",
+                            "archived": True,
+                        },
+                        {
+                            "id": 3,
+                            "path_with_namespace": "acme/r3",
+                            "default_branch": "main",
+                            "archived": False,
+                        },
+                    ],
+                ),
+            ]
+        )
         clones: dict[str, Path] = {}
 
         def clone_fn(_: GitlabConnector, project: Mapping[str, Any]) -> Path:
             # Each project must get its own clone dir to avoid the
             # double-add path. We materialise a unique tmpdir per call.
             import tempfile
+
             d = Path(tempfile.mkdtemp(prefix="pleno-glt-"))
             (d / "f.txt").write_text(f"x={project['path_with_namespace']}\n")
             clones[project["path_with_namespace"]] = d
             return d
 
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", groups),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/groups/", groups),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="acme"),
             credential=make_credential(),
@@ -483,9 +508,13 @@ class TestDiscoverGroup:
                 ],
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", groups),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/groups/", groups),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="acme", visibility="private"),
             credential=make_credential(),
@@ -503,9 +532,13 @@ class TestDiscoverGroup:
             await c.close()
 
     async def test_group_404_yields_nothing(self) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", lambda _: httpx.Response(404)),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/groups/", lambda _: httpx.Response(404)),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="missing"),
             credential=make_credential(),
@@ -519,9 +552,13 @@ class TestDiscoverGroup:
     async def test_group_malformed_response_yields_nothing(self) -> None:
         # GitLab returned a JSON object instead of a list (e.g. a
         # `{"message": "no token"}` 200 from a misconfigured proxy).
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", lambda _: httpx.Response(200, json={"oops": True})),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/groups/", lambda _: httpx.Response(200, json={"oops": True})),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="acme"),
             credential=make_credential(),
@@ -554,9 +591,13 @@ class TestDiscoverGroup:
                 ],
             )
 
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", groups),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/groups/", groups),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="acme"),
             credential=make_credential(),
@@ -604,9 +645,13 @@ class TestCloneFailure:
                 raise subprocess.CalledProcessError(1, ["git", "clone"])
             return clone_dir
 
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", groups),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    ("/groups/", groups),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="acme"),
             credential=make_credential(),
@@ -627,15 +672,15 @@ class TestCloneFailure:
 
 
 class TestEnumerateFn:
-    async def test_enumerate_fn_overrides_api_walk(
-        self, clone_dir: Path
-    ) -> None:
+    async def test_enumerate_fn_overrides_api_walk(self, clone_dir: Path) -> None:
         # The injected enumerator returns one project; the API
         # transport asserts on access — proving we never hit the wire.
         def boom(_: httpx.Request) -> httpx.Response:
             raise AssertionError("API should not be called")
 
-        async def fake_enumerate(_: GitlabConnector) -> AsyncIterator[Mapping[str, Any]]:
+        async def fake_enumerate(
+            _: GitlabConnector,
+        ) -> AsyncIterator[Mapping[str, Any]]:
             yield {
                 "id": 99,
                 "path_with_namespace": "fake/proj",
@@ -659,7 +704,9 @@ class TestEnumerateFn:
 
     async def test_enumerate_fn_skips_malformed_entry(self) -> None:
         # path_with_namespace missing: defensive `continue`.
-        async def fake_enumerate(_: GitlabConnector) -> AsyncIterator[Mapping[str, Any]]:
+        async def fake_enumerate(
+            _: GitlabConnector,
+        ) -> AsyncIterator[Mapping[str, Any]]:
             yield {"id": 1}  # no path_with_namespace
             yield {"path_with_namespace": 123}  # non-string
 
@@ -681,9 +728,7 @@ class TestEnumerateFn:
 
 
 class TestFetch:
-    async def test_returns_decoded_text_from_clone(
-        self, clone_dir: Path
-    ) -> None:
+    async def test_returns_decoded_text_from_clone(self, clone_dir: Path) -> None:
         def project(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -760,9 +805,7 @@ class TestFetch:
 
 
 class TestCloneReuse:
-    async def test_second_call_returns_cached_clone(
-        self, clone_dir: Path
-    ) -> None:
+    async def test_second_call_returns_cached_clone(self, clone_dir: Path) -> None:
         # A project that appears twice in the enumeration must only be
         # cloned once; the second discover() pass returns the cached path.
         calls = {"n": 0}
@@ -771,7 +814,9 @@ class TestCloneReuse:
             calls["n"] += 1
             return clone_dir
 
-        async def fake_enumerate(_: GitlabConnector) -> AsyncIterator[Mapping[str, Any]]:
+        async def fake_enumerate(
+            _: GitlabConnector,
+        ) -> AsyncIterator[Mapping[str, Any]]:
             yield {
                 "id": 1,
                 "path_with_namespace": "ns/dup",
@@ -799,9 +844,7 @@ class TestCloneReuse:
         finally:
             await c.close()
 
-    async def test_concurrent_clone_race_rmtrees_loser(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_concurrent_clone_race_rmtrees_loser(self, tmp_path: Path) -> None:
         # Force the race window: two clones of the same project run
         # concurrently. The loser must rmtree its tempdir.
         import asyncio as _asyncio
@@ -819,6 +862,7 @@ class TestCloneReuse:
             # Block both threads on the gate so they both pass the
             # cache-miss check before either populates the dict.
             import time
+
             for _ in range(100):
                 if gate.is_set():
                     break
@@ -856,9 +900,7 @@ class TestCloneReuse:
 
 
 class TestFetchDefensive:
-    async def test_non_document_yield_skipped(
-        self, clone_dir: Path
-    ) -> None:
+    async def test_non_document_yield_skipped(self, clone_dir: Path) -> None:
         # Patch DirConnector.fetch to yield a DocumentChunk-like object
         # mid-stream; the connector must skip it without crashing.
         import pleno_pii_scanner_gitlab.connector as connector_mod
@@ -869,6 +911,7 @@ class TestFetchDefensive:
             async def fetch(self, ref):  # type: ignore[override]
                 # Yield a non-Document (DocumentChunk) and one Document.
                 from pleno_pii_scanner.sources.base import DocumentChunk
+
                 yield DocumentChunk(
                     ref=ref,
                     byte_range=(0, 1),
@@ -880,6 +923,7 @@ class TestFetchDefensive:
 
         # Inject the fake into the connector module.
         from unittest.mock import patch
+
         def project(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -917,9 +961,16 @@ class TestFetchDefensive:
 
 class TestRateLimitPropagation:
     async def test_429_during_group_walk_surfaces_rate_limited(self) -> None:
-        transport = httpx.MockTransport(make_handler([
-            ("/groups/", lambda _: httpx.Response(429, headers={"Retry-After": "5"})),
-        ]))
+        transport = httpx.MockTransport(
+            make_handler(
+                [
+                    (
+                        "/groups/",
+                        lambda _: httpx.Response(429, headers={"Retry-After": "5"}),
+                    ),
+                ]
+            )
+        )
         c = GitlabConnector(
             GitlabConfig(group="acme"),
             credential=make_credential(),
@@ -942,6 +993,7 @@ class TestClose:
         clone = tmp_path / "clone"
         clone.mkdir()
         (clone / "f.txt").write_text("x")
+
         # Single-project + injected clone_fn returning `clone`.
         def project(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
@@ -1005,6 +1057,7 @@ class TestClose:
         await _drain(c.discover(SourceFilter(), None))
         # Vanish the dir behind the connector's back.
         import shutil
+
         shutil.rmtree(clone)
         # close() must not raise.
         await c.close()
@@ -1044,6 +1097,7 @@ class TestCloneIntoTempdir:
             assert path.exists()
         finally:
             import shutil
+
             shutil.rmtree(path, ignore_errors=True)
             await c.close()
 
@@ -1093,9 +1147,7 @@ class TestCABundle:
         cfg = GitlabConfig(project="ns/p", ca_bundle_path="/etc/ssl/ca.pem")
         assert cfg.ca_bundle_path == "/etc/ssl/ca.pem"
 
-    def test_ca_bundle_path_forwarded_to_api(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_ca_bundle_path_forwarded_to_api(self, tmp_path: Path, monkeypatch) -> None:
         # Wire-test: when the connector is built with `ca_bundle_path`,
         # the GitlabApi constructor must receive `verify=<path>`.
         captured: dict[str, Any] = {}

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/adf.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/adf.py
@@ -111,9 +111,7 @@ def _render_node(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     return f"{marker}\n{inner}".rstrip() if inner else marker
 
 
-def _render_children(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _render_children(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """Render `node['content']` as a sibling sequence."""
     children = node.get("content")
     if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
@@ -121,9 +119,7 @@ def _render_children(
     return _render_sequence(list(children), depth=depth, max_depth=max_depth)
 
 
-def _render_sequence(
-    nodes: list[Any], *, depth: int, max_depth: int
-) -> str:
+def _render_sequence(nodes: list[Any], *, depth: int, max_depth: int) -> str:
     """Render a list of sibling nodes, joining block-level ones with newlines.
 
     Inline runs (`text`, `mention`, `emoji`, inline marks) are
@@ -180,24 +176,18 @@ def _handle_text(node: Mapping[str, Any], **_: Any) -> str:
     return text
 
 
-def _handle_paragraph(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_paragraph(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     return _render_children(node, depth=depth + 1, max_depth=max_depth)
 
 
-def _handle_heading(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_heading(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     # Drop the `# ` prefix Markdown renderers would emit; downstream
     # consumers only care about the body text. The level lives in
     # `attrs.level` if a future renderer wants it.
     return _render_children(node, depth=depth + 1, max_depth=max_depth)
 
 
-def _handle_list(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_list(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """bulletList / orderedList — render each `listItem` on its own line."""
     children = node.get("content")
     if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
@@ -214,18 +204,14 @@ def _handle_list(
     return "\n".join(items)
 
 
-def _handle_list_item(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_list_item(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     inner = _render_children(node, depth=depth + 1, max_depth=max_depth)
     # Strip the trailing newline added by block children inside the
     # item; the outer list joiner re-adds one between items.
     return inner.rstrip("\n")
 
 
-def _handle_code_block(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_code_block(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """codeBlock — flatten to its inner text, dropping the language attr.
 
     Detectors care about the literal code (a `password = "x"` constant
@@ -290,9 +276,7 @@ def _handle_inline_card(node: Mapping[str, Any], **_: Any) -> str:
     return ""
 
 
-def _handle_media_single(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_media_single(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """mediaSingle — wraps a single `media` node; surface its filename/url."""
     return _render_children(node, depth=depth + 1, max_depth=max_depth)
 
@@ -309,9 +293,7 @@ def _handle_media(node: Mapping[str, Any], **_: Any) -> str:
     return " ".join(parts)
 
 
-def _handle_panel(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_panel(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """panel — coloured callout box. Render its content verbatim.
 
     The `attrs.panelType` (info, warning, error, note, success) carries
@@ -320,9 +302,7 @@ def _handle_panel(
     return _render_children(node, depth=depth + 1, max_depth=max_depth)
 
 
-def _handle_blockquote(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_blockquote(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     return _render_children(node, depth=depth + 1, max_depth=max_depth)
 
 
@@ -332,9 +312,7 @@ def _handle_rule(_node: Mapping[str, Any], **_: Any) -> str:
     return "\n"
 
 
-def _handle_table(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_table(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """table — newline-separated rows; each row is tab-separated cells."""
     children = node.get("content")
     if not isinstance(children, Sequence) or isinstance(children, (str, bytes)):
@@ -351,9 +329,7 @@ def _handle_table(
     return "\n".join(rows)
 
 
-def _handle_table_row(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_table_row(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     cells = node.get("content")
     if not isinstance(cells, Sequence) or isinstance(cells, (str, bytes)):
         return ""
@@ -368,16 +344,12 @@ def _handle_table_row(
     return "\t".join(cell_texts)
 
 
-def _handle_doc(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_doc(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """The document root; just descend into `content`."""
     return _render_children(node, depth=depth, max_depth=max_depth)
 
 
-def _handle_expand(
-    node: Mapping[str, Any], *, depth: int, max_depth: int
-) -> str:
+def _handle_expand(node: Mapping[str, Any], *, depth: int, max_depth: int) -> str:
     """expand / nestedExpand — collapsible block. Render the body."""
     return _render_children(node, depth=depth + 1, max_depth=max_depth)
 

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/api.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/api.py
@@ -201,9 +201,7 @@ class JiraApi:
         """
         url = self._absolute(path_or_url)
         clean_params = (
-            {k: v for k, v in params.items() if v is not None}
-            if params
-            else None
+            {k: v for k, v in params.items() if v is not None} if params else None
         )
         for attempt in (1, 2):
             response = await self._client.get(

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/connector.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/connector.py
@@ -150,8 +150,7 @@ class JiraConfig:
             )
         if len(modes) > 1:
             raise ValueError(
-                f"JiraConfig accepts exactly one auth mode; "
-                f"received: {sorted(modes)}"
+                f"JiraConfig accepts exactly one auth mode; received: {sorted(modes)}"
             )
 
     def _present_auth_modes(self) -> set[str]:
@@ -279,9 +278,7 @@ class JiraConnector:
         # operator-supplied `--since` is the authoritative knob (tests
         # also rely on this for deterministic JQL assertions).
         since = (
-            filter.since.isoformat()
-            if filter.since is not None
-            else prior_high_water
+            filter.since.isoformat() if filter.since is not None else prior_high_water
         )
         projects = await self._enumerate_projects(filter)
         for project_key in projects:
@@ -370,9 +367,7 @@ class JiraConnector:
     # internals
     # ------------------------------------------------------------------
 
-    async def _enumerate_projects(
-        self, filter: SourceFilter
-    ) -> list[str]:
+    async def _enumerate_projects(self, filter: SourceFilter) -> list[str]:
         """Return project keys to scan, applying allow-list + filter."""
         if self._config.projects:
             # Operator-supplied allow-list short-circuits enumeration —
@@ -411,9 +406,7 @@ class JiraConnector:
                 return keys
             values = body.get("values") or []
             for project in values:
-                key = (
-                    project.get("key") if isinstance(project, Mapping) else None
-                )
+                key = project.get("key") if isinstance(project, Mapping) else None
                 if isinstance(key, str) and key:
                     keys.append(key)
             if body.get("isLast", True):
@@ -482,9 +475,7 @@ class JiraConnector:
                 return
             start_at = new_start
 
-    async def _fetch_comments(
-        self, issue_key: str
-    ) -> list[Mapping[str, Any]]:
+    async def _fetch_comments(self, issue_key: str) -> list[Mapping[str, Any]]:
         """Paginate `/issue/{key}/comment` and return every comment."""
         out: list[Mapping[str, Any]] = []
         start_at = 0
@@ -589,9 +580,7 @@ class JiraConnector:
             parts.append(f"description={description_text}")
         for comment in comments:
             comment_id = comment.get("id")
-            author = _display_name(
-                comment.get("author") or comment.get("updateAuthor")
-            )
+            author = _display_name(comment.get("author") or comment.get("updateAuthor"))
             body_text = self._convert_body(comment.get("body"))
             if not body_text:
                 continue
@@ -604,13 +593,9 @@ class JiraConnector:
             for attachment in fields.get("attachment") or []:
                 if not isinstance(attachment, Mapping):
                     continue
-                name = (
-                    attachment.get("filename") or attachment.get("name") or ""
-                )
+                name = attachment.get("filename") or attachment.get("name") or ""
                 content_url = (
-                    attachment.get("content")
-                    or attachment.get("contentUrl")
-                    or ""
+                    attachment.get("content") or attachment.get("contentUrl") or ""
                 )
                 if name or content_url:
                     parts.append(f"attachment={name}, url={content_url}")
@@ -745,7 +730,7 @@ def _host_only(base_url: str) -> str:
     s = base_url
     for prefix in ("https://", "http://"):
         if s.startswith(prefix):
-            s = s[len(prefix):]
+            s = s[len(prefix) :]
             break
     if "/" in s:
         s = s.split("/", 1)[0]
@@ -789,9 +774,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
             projects=_string_tuple(config.get("projects")),
             include_comments=bool(config.get("include_comments", True)),
             include_attachments=bool(config.get("include_attachments", True)),
-            request_timeout=float(
-                config.get("request_timeout", DEFAULT_TIMEOUT)
-            ),
+            request_timeout=float(config.get("request_timeout", DEFAULT_TIMEOUT)),
             id=_opt_str(config.get("id")),
         )
     )
@@ -816,9 +799,7 @@ def _string_tuple(value: Any) -> tuple[str, ...]:
             "not a bare string"
         )
     if not isinstance(value, Iterable):
-        raise ValueError(
-            "jira connector list-typed configs must be iterable"
-        )
+        raise ValueError("jira connector list-typed configs must be iterable")
     out: list[str] = []
     for item in value:
         if not isinstance(item, str) or not item:

--- a/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/storage.py
+++ b/packages/pii-scanner-jira/src/pleno_pii_scanner_jira/storage.py
@@ -78,9 +78,7 @@ class _StorageStripper(HTMLParser):
         self._skip_depth = 0
         self._parts: list[str] = []
 
-    def handle_starttag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         del attrs
         if tag in _SKIP_TAGS:
             self._skip_depth += 1
@@ -97,9 +95,7 @@ class _StorageStripper(HTMLParser):
         if tag in _BLOCK_TAGS:
             self._parts.append("\n")
 
-    def handle_startendtag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         # Self-closing tags (`<br/>`, `<hr/>`) — treat as a block break.
         del attrs
         if tag in _BLOCK_TAGS:

--- a/packages/pii-scanner-jira/tests/conftest.py
+++ b/packages/pii-scanner-jira/tests/conftest.py
@@ -89,7 +89,8 @@ def cloud_issue(
             "status": {"name": "Open"},
             "assignee": {"displayName": "Alice"},
             "reporter": {"displayName": "Bob"},
-            "description": description or adf_doc(
+            "description": description
+            or adf_doc(
                 {
                     "type": "paragraph",
                     "content": [adf_text("Hello, world.")],
@@ -117,7 +118,9 @@ def dc_issue(
             "assignee": {"displayName": "Alice", "name": "alice"},
             "reporter": {"displayName": "Bob", "name": "bob"},
             "description": (
-                description if description is not None else "<p>Hello, <b>world</b>.</p>"
+                description
+                if description is not None
+                else "<p>Hello, <b>world</b>.</p>"
             ),
             "attachment": attachments or [],
         },

--- a/packages/pii-scanner-jira/tests/test_adf.py
+++ b/packages/pii-scanner-jira/tests/test_adf.py
@@ -145,9 +145,7 @@ class TestNodeTypes:
         doc = adf_doc(
             {
                 "type": "paragraph",
-                "content": [
-                    {"type": "mention", "attrs": {"id": "557058:abc"}}
-                ],
+                "content": [{"type": "mention", "attrs": {"id": "557058:abc"}}],
             }
         )
         assert "@557058:abc" in adf_to_text(doc)
@@ -165,9 +163,7 @@ class TestNodeTypes:
         doc = adf_doc(
             {
                 "type": "paragraph",
-                "content": [
-                    {"type": "emoji", "attrs": {"shortName": ":+1:"}}
-                ],
+                "content": [{"type": "emoji", "attrs": {"shortName": ":+1:"}}],
             }
         )
         assert ":+1:" in adf_to_text(doc)
@@ -256,9 +252,7 @@ class TestNodeTypes:
             {
                 "type": "panel",
                 "attrs": {"panelType": "warning"},
-                "content": [
-                    {"type": "paragraph", "content": [adf_text("be careful")]}
-                ],
+                "content": [{"type": "paragraph", "content": [adf_text("be careful")]}],
             }
         )
         assert "be careful" in adf_to_text(doc)
@@ -267,9 +261,7 @@ class TestNodeTypes:
         doc = adf_doc(
             {
                 "type": "blockquote",
-                "content": [
-                    {"type": "paragraph", "content": [adf_text("quoted")]}
-                ],
+                "content": [{"type": "paragraph", "content": [adf_text("quoted")]}],
             }
         )
         assert "quoted" in adf_to_text(doc)
@@ -368,9 +360,7 @@ class TestMarks:
                         marks=[
                             {
                                 "type": "link",
-                                "attrs": {
-                                    "href": "https://acme/?token=secret"
-                                },
+                                "attrs": {"href": "https://acme/?token=secret"},
                             }
                         ],
                     )
@@ -412,15 +402,11 @@ class TestMarks:
 
     def test_text_without_marks_field(self) -> None:
         # No marks at all — most common case.
-        assert (
-            adf_to_text({"type": "text", "text": "plain"}) == "plain"
-        )
+        assert adf_to_text({"type": "text", "text": "plain"}) == "plain"
 
     def test_text_with_non_mapping_marks(self) -> None:
         # Defensive: a malformed `marks` field.
-        out = adf_to_text(
-            {"type": "text", "text": "x", "marks": ["not a mapping"]}
-        )
+        out = adf_to_text({"type": "text", "text": "x", "marks": ["not a mapping"]})
         assert out == "x"
 
     def test_text_missing_text_field(self) -> None:
@@ -430,9 +416,7 @@ class TestMarks:
         doc = adf_doc(
             {
                 "type": "paragraph",
-                "content": [
-                    adf_text("click", marks=[{"type": "link"}])
-                ],
+                "content": [adf_text("click", marks=[{"type": "link"}])],
             }
         )
         assert adf_to_text(doc).strip() == "click"
@@ -450,9 +434,7 @@ class TestUnsupported:
         out = adf_to_text(
             {
                 "type": "futureWidget",
-                "content": [
-                    {"type": "paragraph", "content": [adf_text("inside")]}
-                ],
+                "content": [{"type": "paragraph", "content": [adf_text("inside")]}],
             }
         )
         assert "<!-- unsupported: futureWidget -->" in out
@@ -511,18 +493,14 @@ class TestDefensive:
         assert adf_to_text({"type": "bulletList", "content": "oops"}) == ""
 
     def test_bullet_list_skips_non_mapping_children(self) -> None:
-        out = adf_to_text(
-            {"type": "bulletList", "content": ["bad", None, 5]}
-        )
+        out = adf_to_text({"type": "bulletList", "content": ["bad", None, 5]})
         assert out == ""
 
     def test_bullet_list_skips_non_list_item(self) -> None:
         out = adf_to_text(
             {
                 "type": "bulletList",
-                "content": [
-                    {"type": "paragraph", "content": [adf_text("not item")]}
-                ],
+                "content": [{"type": "paragraph", "content": [adf_text("not item")]}],
             }
         )
         assert out == ""
@@ -537,9 +515,7 @@ class TestDefensive:
         out = adf_to_text(
             {
                 "type": "table",
-                "content": [
-                    {"type": "paragraph", "content": [adf_text("not row")]}
-                ],
+                "content": [{"type": "paragraph", "content": [adf_text("not row")]}],
             }
         )
         assert out == ""
@@ -567,9 +543,7 @@ class TestDefensive:
 
     def test_emoji_attrs_with_non_string_shortname(self) -> None:
         # shortName is non-string → skip; falls through to text fallback.
-        out = adf_to_text(
-            {"type": "emoji", "attrs": {"shortName": 5, "text": "ok"}}
-        )
+        out = adf_to_text({"type": "emoji", "attrs": {"shortName": 5, "text": "ok"}})
         assert out == "ok"
 
     def test_emoji_attrs_neither_string(self) -> None:

--- a/packages/pii-scanner-jira/tests/test_api.py
+++ b/packages/pii-scanner-jira/tests/test_api.py
@@ -352,9 +352,7 @@ class TestThrottle:
         def handler(_r: httpx.Request) -> httpx.Response:
             attempts["n"] += 1
             if attempts["n"] == 1:
-                return httpx.Response(
-                    429, headers={"Retry-After": "not-a-number"}
-                )
+                return httpx.Response(429, headers={"Retry-After": "not-a-number"})
             return httpx.Response(200, json={})
 
         api = JiraApi(

--- a/packages/pii-scanner-jira/tests/test_connector.py
+++ b/packages/pii-scanner-jira/tests/test_connector.py
@@ -88,15 +88,11 @@ class TestConfig:
 
     def test_rejects_non_http_base_url(self) -> None:
         with pytest.raises(ValueError, match="http"):
-            JiraConfig(
-                flavor="cloud", base_url="ftp://x", access_token="t"
-            )
+            JiraConfig(flavor="cloud", base_url="ftp://x", access_token="t")
 
     def test_rejects_no_auth(self) -> None:
         with pytest.raises(ValueError, match="one of"):
-            JiraConfig(
-                flavor="cloud", base_url="https://acme.atlassian.net"
-            )
+            JiraConfig(flavor="cloud", base_url="https://acme.atlassian.net")
 
     def test_rejects_two_auth_modes(self) -> None:
         with pytest.raises(ValueError, match="exactly one"):
@@ -203,9 +199,9 @@ class TestCloud:
             _ = [r async for r in c.discover(SourceFilter(), None)]
             assert seen_headers
             assert seen_headers[0].startswith("Basic ")
-            expected = "Basic " + base64.b64encode(
-                b"alice@acme.com:api-token-xyz"
-            ).decode()
+            expected = (
+                "Basic " + base64.b64encode(b"alice@acme.com:api-token-xyz").decode()
+            )
             assert seen_headers[0] == expected
         finally:
             await c.close()
@@ -250,9 +246,7 @@ class TestCloud:
                             "isLast": False,
                         }
                     )
-                return json_response(
-                    {"values": [{"key": "C"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "C"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response({"issues": [], "total": 0})
             return json_response({})
@@ -329,10 +323,7 @@ class TestCloud:
             transport=httpx.MockTransport(handler),
         )
         try:
-            _ = [
-                r
-                async for r in c.discover(SourceFilter(include=("A",)), None)
-            ]
+            _ = [r async for r in c.discover(SourceFilter(include=("A",)), None)]
             assert any('project = "A"' in j for j in seen_jql)
             assert not any('project = "B"' in j for j in seen_jql)
         finally:
@@ -345,10 +336,7 @@ class TestCloud:
             transport=httpx.MockTransport(handler),
         )
         try:
-            _ = [
-                r
-                async for r in c2.discover(SourceFilter(exclude=("A",)), None)
-            ]
+            _ = [r async for r in c2.discover(SourceFilter(exclude=("A",)), None)]
             assert not any('project = "A"' in j for j in seen_jql)
             assert any('project = "B"' in j for j in seen_jql)
         finally:
@@ -360,9 +348,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 start = request.url.params.get("startAt", "0")
                 seen_starts.append(start)
@@ -374,9 +360,7 @@ class TestCloud:
                         )
                         for i in range(100)
                     ]
-                    return json_response(
-                        {"issues": issues, "total": 101, "startAt": 0}
-                    )
+                    return json_response({"issues": issues, "total": 101, "startAt": 0})
                 return json_response(
                     {
                         "issues": [
@@ -411,9 +395,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 start = request.url.params.get("startAt", "0")
                 seen_starts.append(start)
@@ -442,9 +424,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 issue = cloud_issue(
                     description=adf_doc(
@@ -485,13 +465,9 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 start = request.url.params.get("startAt", "0")
                 seen_starts.append(start)
@@ -509,9 +485,7 @@ class TestCloud:
                         }
                         for i in range(100)
                     ]
-                    return json_response(
-                        {"comments": comments, "total": 101}
-                    )
+                    return json_response({"comments": comments, "total": 101})
                 return json_response(
                     {
                         "comments": [
@@ -551,9 +525,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 issue = cloud_issue(
                     attachments=[
@@ -590,13 +562,9 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                issue = cloud_issue(
-                    attachments=[{"filename": "x", "content": "u"}]
-                )
+                issue = cloud_issue(attachments=[{"filename": "x", "content": "u"}])
                 return json_response({"issues": [issue], "total": 1})
             if "/comment" in path:
                 return json_response({"comments": [], "total": 0})
@@ -620,13 +588,9 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 called["comment"] = True
                 return json_response({"comments": [], "total": 0})
@@ -646,9 +610,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 issues = [
                     cloud_issue(
@@ -684,17 +646,13 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 seen_jql.append(request.url.params.get("jql", ""))
                 return json_response({"issues": [], "total": 0})
             return json_response({})
 
-        prior = json.dumps(
-            {"highest_updated": "2026-05-01T00:00:00.000+0000"}
-        )
+        prior = json.dumps({"highest_updated": "2026-05-01T00:00:00.000+0000"})
         c = JiraConnector(
             _cloud_config(),
             transport=httpx.MockTransport(handler),
@@ -702,8 +660,7 @@ class TestCloud:
         try:
             _ = [r async for r in c.discover(SourceFilter(), prior)]
             assert any(
-                'updated >= "2026-05-01T00:00:00.000+0000"' in j
-                for j in seen_jql
+                'updated >= "2026-05-01T00:00:00.000+0000"' in j for j in seen_jql
             )
         finally:
             await c.close()
@@ -714,9 +671,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 seen_jql.append(request.url.params.get("jql", ""))
                 return json_response({"issues": [], "total": 0})
@@ -750,29 +705,20 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 seen_jql.append(request.url.params.get("jql", ""))
                 return json_response({"issues": [], "total": 0})
             return json_response({})
 
-        prior = json.dumps(
-            {"highest_updated": "2026-05-01T00:00:00.000+0000"}
-        )
+        prior = json.dumps({"highest_updated": "2026-05-01T00:00:00.000+0000"})
         c = JiraConnector(
             _cloud_config(),
             transport=httpx.MockTransport(handler),
         )
         try:
             since_dt = datetime(2026, 5, 3, tzinfo=timezone.utc)
-            _ = [
-                r
-                async for r in c.discover(
-                    SourceFilter(since=since_dt), prior
-                )
-            ]
+            _ = [r async for r in c.discover(SourceFilter(since=since_dt), prior)]
             assert any("2026-05-03" in j for j in seen_jql)
             assert not any("2026-05-01" in j for j in seen_jql)
         finally:
@@ -806,9 +752,7 @@ class TestCloud:
             if path.endswith("/project/search"):
                 attempts["n"] += 1
                 if attempts["n"] == 1:
-                    return httpx.Response(
-                        429, headers={"Retry-After": "0.01"}
-                    )
+                    return httpx.Response(429, headers={"Retry-After": "0.01"})
                 return json_response({"values": [], "isLast": True})
             return json_response({})
 
@@ -827,9 +771,7 @@ class TestCloud:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 # Missing `key` — third-party Jira-compatible servers
                 # have been seen to omit it.
@@ -986,9 +928,7 @@ class TestDatacenter:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 issue = dc_issue(
                     description=(
@@ -1019,9 +959,7 @@ class TestDatacenter:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response({"issues": [dc_issue()], "total": 1})
             if "/comment" in path:
@@ -1062,9 +1000,7 @@ class TestDatacenter:
             if path.endswith("/project/search"):
                 attempts["n"] += 1
                 if attempts["n"] == 1:
-                    return httpx.Response(
-                        503, headers={"Retry-After": "0.01"}
-                    )
+                    return httpx.Response(503, headers={"Retry-After": "0.01"})
                 return json_response({"values": [], "isLast": True})
             return json_response({})
 
@@ -1225,9 +1161,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response(
                     {
@@ -1255,9 +1189,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 # Missing summary, status, assignee, reporter.
                 return json_response(
@@ -1266,9 +1198,7 @@ class TestSerialiserEdges:
                             {
                                 "id": "1",
                                 "key": "P-1",
-                                "fields": {
-                                    "updated": "2026-05-04T00:00:00.000+0000"
-                                },
+                                "fields": {"updated": "2026-05-04T00:00:00.000+0000"},
                             }
                         ],
                         "total": 1,
@@ -1294,13 +1224,9 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 return json_response(
                     {
@@ -1337,13 +1263,9 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 return json_response(
                     {
@@ -1378,13 +1300,9 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 return json_response(
                     {
@@ -1414,9 +1332,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 issue = cloud_issue(
                     attachments=["bad", {"filename": "x", "content": "u"}]
@@ -1443,9 +1359,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 # Skip an entry with neither name nor url.
                 issue = cloud_issue(
@@ -1540,13 +1454,9 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 request_count["n"] += 1
                 if request_count["n"] == 1:
@@ -1693,9 +1603,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return httpx.Response(404)
             return json_response({})
@@ -1715,9 +1623,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response(
                     {
@@ -1743,13 +1649,9 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 return httpx.Response(404)
             return json_response({})
@@ -1769,13 +1671,9 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
-                return json_response(
-                    {"issues": [cloud_issue()], "total": 1}
-                )
+                return json_response({"issues": [cloud_issue()], "total": 1})
             if "/comment" in path:
                 return json_response(
                     {
@@ -1813,9 +1711,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": ["bad", {"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": ["bad", {"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response({"issues": [], "total": 0})
             return json_response({})
@@ -1837,9 +1733,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response(
                     {
@@ -1872,9 +1766,7 @@ class TestSerialiserEdges:
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
             if path.endswith("/project/search"):
-                return json_response(
-                    {"values": [{"key": "P"}], "isLast": True}
-                )
+                return json_response({"values": [{"key": "P"}], "isLast": True})
             if path.endswith("/search"):
                 return json_response(
                     {
@@ -1882,9 +1774,7 @@ class TestSerialiserEdges:
                             {
                                 "id": "1",
                                 "key": "P-1",
-                                "fields": {
-                                    "updated": "2026-05-04T00:00:00.000+0000"
-                                },
+                                "fields": {"updated": "2026-05-04T00:00:00.000+0000"},
                             }
                         ],
                         "total": 1,

--- a/packages/pii-scanner-jira/tests/test_storage.py
+++ b/packages/pii-scanner-jira/tests/test_storage.py
@@ -54,9 +54,7 @@ class TestRendering:
         assert "tom&jerry <3" in out
 
     def test_script_content_dropped(self) -> None:
-        out = storage_to_text(
-            "<p>visible</p><script>password = 'leak'</script>"
-        )
+        out = storage_to_text("<p>visible</p><script>password = 'leak'</script>")
         assert "visible" in out
         assert "password" not in out
 
@@ -90,15 +88,11 @@ class TestRendering:
         assert "x" in out
 
     def test_nested_skip_tag(self) -> None:
-        out = storage_to_text(
-            "<style><style>x</style></style><p>visible</p>"
-        )
+        out = storage_to_text("<style><style>x</style></style><p>visible</p>")
         assert "visible" in out
         assert "x" not in out
 
-    def test_parser_exception_falls_back_to_unescape(
-        self, monkeypatch
-    ) -> None:
+    def test_parser_exception_falls_back_to_unescape(self, monkeypatch) -> None:
         # Force the parser to raise on `feed`; the fallback unescape()
         # branch should still surface the raw body.
         from pleno_pii_scanner_jira import storage as storage_mod

--- a/packages/pii-scanner-mongodb/src/pleno_pii_scanner_mongodb/connector.py
+++ b/packages/pii-scanner-mongodb/src/pleno_pii_scanner_mongodb/connector.py
@@ -66,9 +66,7 @@ from pleno_pii_scanner.sources.registry import ConnectorSpec
 _SYSTEM_DATABASES: frozenset[str] = frozenset({"admin", "config", "local"})
 
 
-def reservoir_sample_size(
-    *, confidence: float = 0.95, prevalence: float = 0.01
-) -> int:
+def reservoir_sample_size(*, confidence: float = 0.95, prevalence: float = 0.01) -> int:
     """Minimum sample size for `confidence` PII detection at `prevalence`.
 
     Reproduces ADR §16: P(no PII in n rows) = (1-p)^n; we want this ≤ α.
@@ -111,9 +109,7 @@ class MongoConfig:
     collections: tuple[str, ...] = ()
     excluded_collections: tuple[str, ...] = ()
     sample_rows: int = field(
-        default_factory=lambda: reservoir_sample_size(
-            confidence=0.95, prevalence=0.01
-        )
+        default_factory=lambda: reservoir_sample_size(confidence=0.95, prevalence=0.01)
     )
     max_time_ms: int = 30_000
     max_pool_size: int = 2
@@ -132,8 +128,7 @@ class MongoConfig:
         # use based on the scheme suffix.
         if scheme not in {"mongodb", "mongodb+srv"}:
             raise ValueError(
-                "uri must be mongodb:// or mongodb+srv:// "
-                f"(got {scheme!r})"
+                f"uri must be mongodb:// or mongodb+srv:// (got {scheme!r})"
             )
         if self.sample_rows <= 0:
             raise ValueError("sample_rows must be > 0")
@@ -222,16 +217,11 @@ class MongoConnector:
             collections = await self._list_collections(db_name)
             for coll_name in collections:
                 full = f"{db_name}.{coll_name}"
-                if (
-                    self._config.collections
-                    and full not in self._config.collections
-                ):
+                if self._config.collections and full not in self._config.collections:
                     continue
                 if full in self._config.excluded_collections:
                     continue
-                if filter.include and not _matches_any(
-                    full, filter.include
-                ):
+                if filter.include and not _matches_any(full, filter.include):
                     continue
                 if filter.exclude and _matches_any(full, filter.exclude):
                     continue
@@ -318,10 +308,7 @@ class MongoConnector:
                 self._config.databases and name in self._config.databases
             ):
                 continue
-            if (
-                self._config.databases
-                and name not in self._config.databases
-            ):
+            if self._config.databases and name not in self._config.databases:
                 continue
             if name in self._config.excluded_databases:
                 continue
@@ -342,9 +329,7 @@ class MongoConnector:
         meta: _CollectionMeta,
     ) -> AsyncIterator[Document]:
         pipeline = [{"$sample": {"size": self._config.sample_rows}}]
-        cursor = coll.aggregate(
-            pipeline, maxTimeMS=self._config.max_time_ms
-        )
+        cursor = coll.aggregate(pipeline, maxTimeMS=self._config.max_time_ms)
         i = 0
         async for doc in cursor:
             text = json_util.dumps(doc)
@@ -354,8 +339,7 @@ class MongoConnector:
                     source_kind=ref.source_kind,
                     path=f"{meta.full}#doc-{i}",
                     content_type="application/json",
-                    metadata=dict(ref.metadata)
-                    | {"document_index": str(i)},
+                    metadata=dict(ref.metadata) | {"document_index": str(i)},
                 ),
                 text=text,
                 fetched_at=datetime.now(UTC),
@@ -411,9 +395,7 @@ class MongoConnector:
         finally:
             # Motor's change stream supports both `close()` and
             # `aclose()` across versions; prefer the modern spelling.
-            close = getattr(stream, "aclose", None) or getattr(
-                stream, "close", None
-            )
+            close = getattr(stream, "aclose", None) or getattr(stream, "close", None)
             if close is not None:
                 result = close()
                 if hasattr(result, "__await__"):
@@ -459,32 +441,22 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
             databases=tuple(config.get("databases") or ()),
             excluded_databases=tuple(config.get("excluded_databases") or ()),
             collections=tuple(config.get("collections") or ()),
-            excluded_collections=tuple(
-                config.get("excluded_collections") or ()
-            ),
+            excluded_collections=tuple(config.get("excluded_collections") or ()),
             sample_rows=int(
                 config.get(
                     "sample_rows",
-                    reservoir_sample_size(
-                        confidence=0.95, prevalence=0.01
-                    ),
+                    reservoir_sample_size(confidence=0.95, prevalence=0.01),
                 )
             ),
             max_time_ms=int(config.get("max_time_ms", 30_000)),
             max_pool_size=int(config.get("max_pool_size", 2)),
-            require_secondary=bool(
-                config.get("require_secondary", True)
-            ),
+            require_secondary=bool(config.get("require_secondary", True)),
             incremental=bool(config.get("incremental", False)),
             username=(
-                str(config["username"])
-                if config.get("username") is not None
-                else None
+                str(config["username"]) if config.get("username") is not None else None
             ),
             password=(
-                str(config["password"])
-                if config.get("password") is not None
-                else None
+                str(config["password"]) if config.get("password") is not None else None
             ),
             id=str(config["id"]) if config.get("id") is not None else None,
         )

--- a/packages/pii-scanner-mongodb/tests/test_connector.py
+++ b/packages/pii-scanner-mongodb/tests/test_connector.py
@@ -173,8 +173,7 @@ class _FakeMotor:
         change_events: dict[str, list[dict[str, Any]]] | None = None,
     ) -> None:
         self._databases: dict[str, _FakeDatabase] = {
-            name: _FakeDatabase(name, colls)
-            for name, colls in databases.items()
+            name: _FakeDatabase(name, colls) for name, colls in databases.items()
         }
         self.admin = _FakeAdmin({"secondary": secondary})
         self.closed = False
@@ -196,9 +195,7 @@ class _FakeMotor:
         self.closed = True
 
 
-def _make_connector(
-    fake: _FakeMotor, **overrides: Any
-) -> MongoConnector:
+def _make_connector(fake: _FakeMotor, **overrides: Any) -> MongoConnector:
     kwargs = {"uri": "mongodb://h", "require_secondary": True} | overrides
     return MongoConnector(MongoConfig(**kwargs), client=fake)
 
@@ -253,9 +250,7 @@ class TestConfig:
         assert cfg.resolved_id() == "my-id"
 
     def test_default_id_strips_credentials(self) -> None:
-        cfg = MongoConfig(
-            uri="mongodb://user:secret@mongo.example:27017/db?w=majority"
-        )
+        cfg = MongoConfig(uri="mongodb://user:secret@mongo.example:27017/db?w=majority")
         rid = cfg.resolved_id()
         assert "secret" not in rid
         assert "user" not in rid
@@ -420,9 +415,7 @@ class TestDiscover:
             await c.close()
 
     async def test_database_include_filter(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": []}, "billing": {"invoices": []}}
-        )
+        fake = _FakeMotor({"app": {"users": []}, "billing": {"invoices": []}})
         c = _make_connector(fake, databases=("app",))
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -431,9 +424,7 @@ class TestDiscover:
             await c.close()
 
     async def test_database_exclude_filter(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": []}, "billing": {"invoices": []}}
-        )
+        fake = _FakeMotor({"app": {"users": []}, "billing": {"invoices": []}})
         c = _make_connector(fake, excluded_databases=("billing",))
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -442,9 +433,7 @@ class TestDiscover:
             await c.close()
 
     async def test_collection_include_filter(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": [], "logs": []}}
-        )
+        fake = _FakeMotor({"app": {"users": [], "logs": []}})
         c = _make_connector(fake, collections=("app.users",))
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -453,9 +442,7 @@ class TestDiscover:
             await c.close()
 
     async def test_collection_exclude_filter(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": [], "logs": []}}
-        )
+        fake = _FakeMotor({"app": {"users": [], "logs": []}})
         c = _make_connector(fake, excluded_collections=("app.logs",))
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -464,32 +451,22 @@ class TestDiscover:
             await c.close()
 
     async def test_source_filter_include_glob(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": []}, "billing": {"invoices": []}}
-        )
+        fake = _FakeMotor({"app": {"users": []}, "billing": {"invoices": []}})
         c = _make_connector(fake)
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(include=("billing.*",)), None
-                )
+                r async for r in c.discover(SourceFilter(include=("billing.*",)), None)
             ]
             assert {r.path for r in refs} == {"billing.invoices"}
         finally:
             await c.close()
 
     async def test_source_filter_exclude_glob(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": [], "logs": []}}
-        )
+        fake = _FakeMotor({"app": {"users": [], "logs": []}})
         c = _make_connector(fake)
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(exclude=("*.logs",)), None
-                )
+                r async for r in c.discover(SourceFilter(exclude=("*.logs",)), None)
             ]
             assert {r.path for r in refs} == {"app.users"}
         finally:
@@ -500,10 +477,7 @@ class TestDiscover:
         fake = _FakeMotor({"app": {"users": []}})
         c = _make_connector(fake, incremental=True)
         try:
-            refs = [
-                r
-                async for r in c.discover(SourceFilter(), "resume-token-X")
-            ]
+            refs = [r async for r in c.discover(SourceFilter(), "resume-token-X")]
             assert refs[0].metadata["_cursor"] == "resume-token-X"
         finally:
             await c.close()
@@ -526,9 +500,7 @@ class TestSample:
             assert len(collected) == 10
             # Pipeline must contain $sample with the configured size.
             coll = fake["app"]["users"]
-            assert coll.last_aggregate_pipeline == [
-                {"$sample": {"size": 10}}
-            ]
+            assert coll.last_aggregate_pipeline == [{"$sample": {"size": 10}}]
         finally:
             await c.close()
 
@@ -543,9 +515,7 @@ class TestSample:
             await c.close()
 
     async def test_document_index_attached(self) -> None:
-        fake = _FakeMotor(
-            {"app": {"users": [{"_id": 1}, {"_id": 2}]}}
-        )
+        fake = _FakeMotor({"app": {"users": [{"_id": 1}, {"_id": 2}]}})
         c = _make_connector(fake, sample_rows=2)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -757,24 +727,17 @@ class TestChangeStream:
 
 class TestRedactUri:
     def test_strips_userinfo(self) -> None:
-        assert (
-            _redact_uri("mongodb://u:p@h:27017/d")
-            == "mongodb://h:27017/d"
-        )
+        assert _redact_uri("mongodb://u:p@h:27017/d") == "mongodb://h:27017/d"
 
     def test_strips_query(self) -> None:
         # Query string can carry password= in some setups.
-        assert "password" not in _redact_uri(
-            "mongodb://h/?password=p&authSource=admin"
-        )
+        assert "password" not in _redact_uri("mongodb://h/?password=p&authSource=admin")
 
     def test_passes_through_when_no_userinfo(self) -> None:
         assert _redact_uri("mongodb://h:27017/d") == "mongodb://h:27017/d"
 
     def test_handles_srv(self) -> None:
-        out = _redact_uri(
-            "mongodb+srv://scanner:hunter2@cluster.example/?w=majority"
-        )
+        out = _redact_uri("mongodb+srv://scanner:hunter2@cluster.example/?w=majority")
         assert "hunter2" not in out
         assert "scanner" not in out
         assert "cluster.example" in out
@@ -875,11 +838,7 @@ class TestLifecycle:
         from pleno_pii_scanner_mongodb import connector as mod
 
         monkeypatch.setattr(mod, "AsyncIOMotorClient", _Spy)
-        MongoConnector(
-            MongoConfig(
-                uri="mongodb://h", username="u", password="p"
-            )
-        )
+        MongoConnector(MongoConfig(uri="mongodb://h", username="u", password="p"))
         assert captured["username"] == "u"
         assert captured["password"] == "p"
         assert captured["maxPoolSize"] == 2

--- a/packages/pii-scanner-msteams/src/pleno_pii_scanner_msteams/connector.py
+++ b/packages/pii-scanner-msteams/src/pleno_pii_scanner_msteams/connector.py
@@ -188,9 +188,7 @@ class MsTeamsConnector:
                     yield self._ref_for(msg, full, team_id, channel_id)
                     if not self._config.include_replies:
                         continue
-                    replies = await self._list_replies(
-                        team_id, channel_id, msg_id
-                    )
+                    replies = await self._list_replies(team_id, channel_id, msg_id)
                     for reply in replies:
                         reply_id = reply.get("id")
                         if not reply_id:
@@ -200,9 +198,7 @@ class MsTeamsConnector:
                             full_reply, filter.include
                         ):
                             continue
-                        if filter.exclude and _matches_any(
-                            full_reply, filter.exclude
-                        ):
+                        if filter.exclude and _matches_any(full_reply, filter.exclude):
                             continue
                         self._messages[full_reply] = reply
                         yield self._ref_for(
@@ -270,9 +266,7 @@ class MsTeamsConnector:
             return access_token
 
     async def _acquire_token(self) -> tuple[str, float]:
-        url = (
-            f"{_LOGIN_BASE}/{self._config.tenant_id}/oauth2/v2.0/token"
-        )
+        url = f"{_LOGIN_BASE}/{self._config.tenant_id}/oauth2/v2.0/token"
         data: dict[str, str] = {
             "client_id": self._config.client_id,
             "scope": _GRAPH_SCOPE,
@@ -335,9 +329,7 @@ class MsTeamsConnector:
             url = resume_link
             absolute = True
         else:
-            url = (
-                f"/v1.0/teams/{team_id}/channels/{channel_id}/messages/delta"
-            )
+            url = f"/v1.0/teams/{team_id}/channels/{channel_id}/messages/delta"
             absolute = False
         collected: list[dict[str, Any]] = []
         delta_link: str | None = None
@@ -359,8 +351,7 @@ class MsTeamsConnector:
         self, team_id: str, channel_id: str, message_id: str
     ) -> list[dict[str, Any]]:
         url = (
-            f"/v1.0/teams/{team_id}/channels/{channel_id}"
-            f"/messages/{message_id}/replies"
+            f"/v1.0/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies"
         )
         absolute = False
         out: list[dict[str, Any]] = []

--- a/packages/pii-scanner-msteams/tests/test_connector.py
+++ b/packages/pii-scanner-msteams/tests/test_connector.py
@@ -92,9 +92,7 @@ class TestConfig:
             )
 
     def test_explicit_id(self) -> None:
-        cfg = MsTeamsConfig(
-            tenant_id="t", client_id="c", client_secret="s", id="x"
-        )
+        cfg = MsTeamsConfig(tenant_id="t", client_id="c", client_secret="s", id="x")
         assert cfg.resolved_id() == "x"
 
     def test_default_id_no_secret_leak(self) -> None:
@@ -151,8 +149,7 @@ class TestToken:
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.host == "login.microsoftonline.com":
                 form = dict(
-                    item.split("=", 1)
-                    for item in request.content.decode().split("&")
+                    item.split("=", 1) for item in request.content.decode().split("&")
                 )
                 seen.append(form)
                 return _token_response()
@@ -162,9 +159,7 @@ class TestToken:
 
         async with _client(handler) as client:
             c = MsTeamsConnector(
-                MsTeamsConfig(
-                    tenant_id="tid", client_id="cid", client_secret="csec"
-                ),
+                MsTeamsConfig(tenant_id="tid", client_id="cid", client_secret="csec"),
                 client=client,
             )
             try:
@@ -183,8 +178,7 @@ class TestToken:
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.host == "login.microsoftonline.com":
                 form = dict(
-                    item.split("=", 1)
-                    for item in request.content.decode().split("&")
+                    item.split("=", 1) for item in request.content.decode().split("&")
                 )
                 seen.append(form)
                 return _token_response()
@@ -224,9 +218,7 @@ class TestToken:
 
         async with _client(handler) as client:
             c = MsTeamsConnector(
-                MsTeamsConfig(
-                    tenant_id="tid", client_id="cid", client_secret="csec"
-                ),
+                MsTeamsConfig(tenant_id="tid", client_id="cid", client_secret="csec"),
                 client=client,
             )
             try:
@@ -253,9 +245,9 @@ def _make_handler(
     """Build a Graph mock. `delta_pages[channel_id]` is a flat list of
     messages returned in one shot (single page with deltaLink)."""
     teams = teams if teams is not None else [{"id": "T1", "displayName": "team"}]
-    channels = channels if channels is not None else [
-        {"id": "C1", "displayName": "general"}
-    ]
+    channels = (
+        channels if channels is not None else [{"id": "C1", "displayName": "general"}]
+    )
     delta_pages = delta_pages or {}
     replies = replies or {}
     seen: dict[str, list[str]] = {"paths": []}
@@ -276,10 +268,7 @@ def _make_handler(
                 200,
                 json={"value": msgs, "@odata.deltaLink": deltalink},
             )
-        if (
-            resume_link_match is not None
-            and resume_link_match in str(request.url)
-        ):
+        if resume_link_match is not None and resume_link_match in str(request.url):
             chan = "C1"
             return httpx.Response(
                 200,
@@ -290,9 +279,7 @@ def _make_handler(
             )
         if path.endswith("/replies"):
             msg_id = path.split("/messages/")[1].split("/")[0]
-            return httpx.Response(
-                200, json={"value": replies.get(msg_id, [])}
-            )
+            return httpx.Response(200, json={"value": replies.get(msg_id, [])})
         return httpx.Response(404, content=str(request.url).encode())
 
     return handler, seen
@@ -343,9 +330,7 @@ class TestDelta:
             if path.endswith("/channels") and "/teams/" in path:
                 return httpx.Response(
                     200,
-                    json={
-                        "value": [{"id": "C1", "displayName": "general"}]
-                    },
+                    json={"value": [{"id": "C1", "displayName": "general"}]},
                 )
             if str(request.url) == resume_url:
                 return httpx.Response(
@@ -535,9 +520,7 @@ class TestReplies:
                 await c.close()
 
     async def test_replies_paginate(self) -> None:
-        next_url = (
-            "https://graph.microsoft.com/v1.0/replies-page-2"
-        )
+        next_url = "https://graph.microsoft.com/v1.0/replies-page-2"
 
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.host == "login.microsoftonline.com":
@@ -561,9 +544,7 @@ class TestReplies:
                     },
                 )
             if str(request.url) == next_url:
-                return httpx.Response(
-                    200, json={"value": [_msg("r2")]}
-                )
+                return httpx.Response(200, json={"value": [_msg("r2")]})
             if path.endswith("/replies"):
                 return httpx.Response(
                     200,
@@ -576,9 +557,7 @@ class TestReplies:
 
         async with _client(handler) as client:
             c = MsTeamsConnector(
-                MsTeamsConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                MsTeamsConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -627,11 +606,7 @@ class TestAllowlist:
 
 class TestFilter:
     async def test_include_exclude_filters_message_paths(self) -> None:
-        handler, _ = _make_handler(
-            delta_pages={
-                "C1": [_msg("keep"), _msg("drop")]
-            }
-        )
+        handler, _ = _make_handler(delta_pages={"C1": [_msg("keep"), _msg("drop")]})
         async with _client(handler) as client:
             c = MsTeamsConnector(
                 MsTeamsConfig(
@@ -644,10 +619,7 @@ class TestFilter:
             )
             try:
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("*/keep",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("*/keep",)), None)
                 ]
                 assert {r.metadata["message_id"] for r in refs} == {"keep"}
             finally:
@@ -665,9 +637,7 @@ class TestFilter:
             try:
                 refs = [
                     r
-                    async for r in c2.discover(
-                        SourceFilter(exclude=("*/drop",)), None
-                    )
+                    async for r in c2.discover(SourceFilter(exclude=("*/drop",)), None)
                 ]
                 assert {r.metadata["message_id"] for r in refs} == {"keep"}
             finally:
@@ -690,10 +660,7 @@ class TestFilter:
             try:
                 # Include matches m1 but not the reply path.
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("*/m1",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("*/m1",)), None)
                 ]
                 ids = {r.metadata["message_id"] for r in refs}
                 assert ids == {"m1"}
@@ -766,9 +733,7 @@ class TestRender:
 
         async with _client(lambda _r: httpx.Response(404)) as client:
             c = MsTeamsConnector(
-                MsTeamsConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                MsTeamsConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -877,9 +842,7 @@ class TestMalformed:
         )
         async with _client(handler) as client:
             c = MsTeamsConnector(
-                MsTeamsConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                MsTeamsConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -911,9 +874,7 @@ class TestCursor:
 
         async with _client(handler2) as client:
             c = MsTeamsConnector(
-                MsTeamsConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                MsTeamsConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -938,9 +899,7 @@ class TestCursor:
             )
             try:
                 # Not JSON → decoder returns {} → fresh delta walk.
-                refs = [
-                    r async for r in c.discover(SourceFilter(), "not-json{")
-                ]
+                refs = [r async for r in c.discover(SourceFilter(), "not-json{")]
                 assert refs
             finally:
                 await c.close()
@@ -958,9 +917,7 @@ class TestCursor:
                 client=client,
             )
             try:
-                refs = [
-                    r async for r in c.discover(SourceFilter(), '["a","b"]')
-                ]
+                refs = [r async for r in c.discover(SourceFilter(), '["a","b"]')]
                 assert refs
             finally:
                 await c.close()

--- a/packages/pii-scanner-mysql/src/pleno_pii_scanner_mysql/connector.py
+++ b/packages/pii-scanner-mysql/src/pleno_pii_scanner_mysql/connector.py
@@ -50,7 +50,6 @@ from pleno_pii_scanner.sources.base import (
 )
 from pleno_pii_scanner.sources.registry import ConnectorSpec
 from pleno_pii_scanner_mysql.sampling import (
-    SamplingPlan,
     plan_sample,
     reservoir_sample_size,
 )
@@ -98,9 +97,7 @@ class MysqlConfig:
     tables: tuple[str, ...] = ()
     excluded_tables: tuple[str, ...] = ()
     sample_rows: int = field(
-        default_factory=lambda: reservoir_sample_size(
-            confidence=0.95, prevalence=0.01
-        )
+        default_factory=lambda: reservoir_sample_size(confidence=0.95, prevalence=0.01)
     )
     statement_timeout_ms: int = 30_000
     pool_size: int = 2
@@ -111,9 +108,7 @@ class MysqlConfig:
         if not self.dsn:
             raise ValueError("dsn must be non-empty")
         if not self.dsn.startswith(("mysql://", "mysql+aiomysql://")):
-            raise ValueError(
-                "dsn must start with mysql:// or mysql+aiomysql://"
-            )
+            raise ValueError("dsn must start with mysql:// or mysql+aiomysql://")
         if self.sample_rows <= 0:
             raise ValueError("sample_rows must be > 0")
         if self.pool_size < 1:
@@ -287,9 +282,7 @@ class MysqlConnector:
         #      must return ≥1 row → this server is replicating from
         #      another. Belt-and-braces: a `read_only` primary that
         #      isn't actually replicating should also be refused.
-        ro = await self._fetch_all(
-            "SHOW VARIABLES LIKE 'read_only'", ()
-        )
+        ro = await self._fetch_all("SHOW VARIABLES LIKE 'read_only'", ())
         if not ro or _row_value(ro[0]).lower() not in {"on", "1"}:
             raise PrimaryConnectionRefused(
                 "refusing to scan: read_only is OFF (set "
@@ -324,9 +317,7 @@ class MysqlConnector:
             schema, table = full.split(".", 1)
         except ValueError:
             return None
-        rows = await self._fetch_all(
-            _RELOAD_SQL, (schema, table, list(_TEXTUAL_TYPES))
-        )
+        rows = await self._fetch_all(_RELOAD_SQL, (schema, table, list(_TEXTUAL_TYPES)))
         if not rows:
             return None
         return _TableMeta(
@@ -347,9 +338,7 @@ class MysqlConnector:
                     await cur.execute(sql)
                 return await cur.fetchall()
 
-    async def _fetch_all_one_of(
-        self, sqls: tuple[str, ...]
-    ) -> list[dict[str, Any]]:
+    async def _fetch_all_one_of(self, sqls: tuple[str, ...]) -> list[dict[str, Any]]:
         # Tries each statement until one runs without ProgrammingError.
         # Both `SHOW REPLICA STATUS` (≥8.0.22) and `SHOW SLAVE STATUS`
         # are valid on different MySQL versions; we try the modern
@@ -484,9 +473,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
                     reservoir_sample_size(confidence=0.95, prevalence=0.01),
                 )
             ),
-            statement_timeout_ms=int(
-                config.get("statement_timeout_ms", 30_000)
-            ),
+            statement_timeout_ms=int(config.get("statement_timeout_ms", 30_000)),
             pool_size=int(config.get("pool_size", 2)),
             require_replica=bool(config.get("require_replica", True)),
             id=str(config["id"]) if config.get("id") is not None else None,

--- a/packages/pii-scanner-mysql/src/pleno_pii_scanner_mysql/sampling.py
+++ b/packages/pii-scanner-mysql/src/pleno_pii_scanner_mysql/sampling.py
@@ -57,10 +57,7 @@ class SamplingPlan:
                 f"WHERE CRC32(CAST(`id` AS CHAR)) % {self.bucket_modulus} = 0 "
                 f"LIMIT {self.sample_rows}"
             )
-        return (
-            f"SELECT {cols} FROM {ident} "
-            f"ORDER BY RAND() LIMIT {self.sample_rows}"
-        )
+        return f"SELECT {cols} FROM {ident} ORDER BY RAND() LIMIT {self.sample_rows}"
 
 
 def plan_sample(
@@ -105,9 +102,7 @@ def _quote_ident(name: str) -> str:
     injection via crafted catalog rows.
     """
     if "`" in name:
-        raise ValueError(
-            f"refusing to quote identifier containing backtick: {name!r}"
-        )
+        raise ValueError(f"refusing to quote identifier containing backtick: {name!r}")
     if not name:
         raise ValueError("identifier must be non-empty")
     return f"`{name}`"

--- a/packages/pii-scanner-mysql/tests/test_connector.py
+++ b/packages/pii-scanner-mysql/tests/test_connector.py
@@ -89,7 +89,9 @@ class _FakePool:
         self.closed = False
         self.waited_close = False
         self._replica_status = (
-            replica_status if replica_status is not None else [{"Source_Host": "primary"}]
+            replica_status
+            if replica_status is not None
+            else [{"Source_Host": "primary"}]
         )
         self._read_only_value = read_only_value
         self._replica_command_supported = replica_command_supported
@@ -107,9 +109,7 @@ class _FakePool:
         # canned routing for replica check
         upper = sql.strip().upper()
         if "SHOW VARIABLES LIKE 'READ_ONLY'" in upper:
-            return [
-                {"Variable_name": "read_only", "Value": self._read_only_value}
-            ]
+            return [{"Variable_name": "read_only", "Value": self._read_only_value}]
         if "SHOW REPLICA STATUS" in upper:
             if not self._replica_command_supported:
                 raise _FakeProgrammingError("SHOW REPLICA STATUS not supported")
@@ -132,7 +132,6 @@ class _FakePool:
 @pytest.fixture(autouse=True)
 def _patch_aiomysql_programmingerror(monkeypatch: pytest.MonkeyPatch):
     # Connector catches aiomysql.ProgrammingError; route to our fake.
-    import pleno_pii_scanner_mysql.connector as conn_mod
     import aiomysql
 
     monkeypatch.setattr(aiomysql, "ProgrammingError", _FakeProgrammingError)
@@ -165,9 +164,7 @@ class TestConfig:
         assert cfg.resolved_schemas() == ("app",)
 
     def test_explicit_schemas_override_dsn_db(self) -> None:
-        cfg = MysqlConfig(
-            dsn="mysql://u:p@h:3306/app", schemas=("billing", "app")
-        )
+        cfg = MysqlConfig(dsn="mysql://u:p@h:3306/app", schemas=("billing", "app"))
         assert cfg.resolved_schemas() == ("billing", "app")
 
     def test_rejects_bad_sample_rows(self) -> None:
@@ -199,15 +196,11 @@ class TestConfig:
 
 class TestProtocol:
     def test_runtime_isinstance(self) -> None:
-        c = MysqlConnector(
-            MysqlConfig(dsn="mysql://u@h/db"), pool=_FakePool()
-        )
+        c = MysqlConnector(MysqlConfig(dsn="mysql://u@h/db"), pool=_FakePool())
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
-        c = MysqlConnector(
-            MysqlConfig(dsn="mysql://u@h/db"), pool=_FakePool()
-        )
+        c = MysqlConnector(MysqlConfig(dsn="mysql://u@h/db"), pool=_FakePool())
         assert c.capabilities() == Capabilities(
             incremental=False,
             binary=True,
@@ -222,9 +215,7 @@ class TestProtocol:
 
 class TestReplicaEnforcement:
     async def test_replica_passes(self) -> None:
-        c = MysqlConnector(
-            MysqlConfig(dsn="mysql://u@h/db"), pool=_FakePool()
-        )
+        c = MysqlConnector(MysqlConfig(dsn="mysql://u@h/db"), pool=_FakePool())
         try:
             await c._enforce_replica()
         finally:
@@ -423,10 +414,7 @@ class TestDiscover:
         )
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(include=("app.users",)), None
-                )
+                r async for r in c.discover(SourceFilter(include=("app.users",)), None)
             ]
             assert {r.path for r in refs} == {"app.users"}
         finally:
@@ -546,9 +534,7 @@ class TestFetch:
             MysqlConfig(dsn="mysql://u@h/db", schemas=("app",)), pool=pool
         )
         try:
-            ref = DocumentRef(
-                source_id=c.id, source_kind=c.kind, path="ghost.gone"
-            )
+            ref = DocumentRef(source_id=c.id, source_kind=c.kind, path="ghost.gone")
             docs = [d async for d in c.fetch(ref)]
             assert docs == []
         finally:

--- a/packages/pii-scanner-mysql/tests/test_sampling.py
+++ b/packages/pii-scanner-mysql/tests/test_sampling.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 
 from pleno_pii_scanner_mysql.sampling import (
-    SamplingPlan,
     plan_sample,
     reservoir_sample_size,
 )

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/api.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/api.py
@@ -151,9 +151,7 @@ def _raise_for_rate_limit(response: httpx.Response) -> None:
     """
     if response.status_code == 429:
         retry_after = response.headers.get("Retry-After")
-        raise RateLimited(
-            f"notion 429; retry_after={retry_after!r}"
-        )
+        raise RateLimited(f"notion 429; retry_after={retry_after!r}")
 
 
 __all__ = [

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/connector.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/connector.py
@@ -21,15 +21,14 @@ published cap is ~3 RPS averaged and 429 ramps up quickly past it.
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from collections.abc import AsyncIterator, Iterable, Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
 import httpx
 
-from pleno_pii_scanner.scheduler.rate_limit import BucketKey, RateLimited
+from pleno_pii_scanner.scheduler.rate_limit import BucketKey
 from pleno_pii_scanner.sources.base import (
     Capabilities,
     Cursor,
@@ -41,7 +40,7 @@ from pleno_pii_scanner.sources.base import (
 )
 from pleno_pii_scanner.sources.registry import ConnectorSpec
 
-from .api import DEFAULT_BASE_URL, NOTION_VERSION, PAGE_SIZE, NotionApi, NotionApiError
+from .api import DEFAULT_BASE_URL, NOTION_VERSION, PAGE_SIZE, NotionApi
 from .markdown import MAX_DEPTH, render_blocks, render_database_row
 
 
@@ -175,9 +174,7 @@ class NotionConnector:
             body: dict[str, Any] = {"page_size": PAGE_SIZE}
             if cursor:
                 body["start_cursor"] = cursor
-            payload = await self._api.post(
-                f"/databases/{database_id}/query", json=body
-            )
+            payload = await self._api.post(f"/databases/{database_id}/query", json=body)
             for row in payload.get("results", []):
                 ref = self._page_to_ref(row, parent_database_id=database_id)
                 if ref is not None:
@@ -231,9 +228,7 @@ class NotionConnector:
         # `notion://page/<id>` or `notion://database-row/<id>` — the
         # parent_database_id qualifier disambiguates rows from standalone
         # pages.
-        path_kind = (
-            "database-row" if parent_database_id else object_type
-        )
+        path_kind = "database-row" if parent_database_id else object_type
         path = f"notion://{path_kind}/{object_id}"
         parent_chain: tuple[str, ...] = ()
         if parent_database_id:
@@ -370,9 +365,7 @@ class NotionConnector:
             include_archived=self._config.include_archived,
         )
 
-    async def _list_block_children(
-        self, block_id: str
-    ) -> list[Mapping[str, Any]]:
+    async def _list_block_children(self, block_id: str) -> list[Mapping[str, Any]]:
         """Page through `/blocks/{id}/children` and return every child block."""
         out: list[Mapping[str, Any]] = []
         cursor: str | None = None
@@ -380,9 +373,7 @@ class NotionConnector:
             params: dict[str, Any] = {"page_size": PAGE_SIZE}
             if cursor:
                 params["start_cursor"] = cursor
-            payload = await self._api.get(
-                f"/blocks/{block_id}/children", params=params
-            )
+            payload = await self._api.get(f"/blocks/{block_id}/children", params=params)
             for block in payload.get("results", []):
                 if not isinstance(block, Mapping):
                     continue
@@ -474,15 +465,12 @@ def _string_tuple(value: Any) -> tuple[str, ...]:
             "must be a list, not a bare string"
         )
     if not isinstance(value, Iterable):
-        raise ValueError(
-            "notion connector list-typed configs must be iterable"
-        )
+        raise ValueError("notion connector list-typed configs must be iterable")
     out: list[str] = []
     for item in value:
         if not isinstance(item, str) or not item:
             raise ValueError(
-                "notion connector list-typed configs must contain "
-                "non-empty strings"
+                "notion connector list-typed configs must contain non-empty strings"
             )
         out.append(item)
     return tuple(out)

--- a/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/markdown.py
+++ b/packages/pii-scanner-notion/src/pleno_pii_scanner_notion/markdown.py
@@ -20,7 +20,7 @@ Notion API change must never crash a scan.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 
@@ -82,9 +82,7 @@ def _render_rich_text_element(element: Mapping[str, Any]) -> str:
         # raw text see the LaTeX source verbatim.
         equation = element.get("equation")
         expression = (
-            equation.get("expression", "")
-            if isinstance(equation, Mapping)
-            else ""
+            equation.get("expression", "") if isinstance(equation, Mapping) else ""
         )
         return f"${expression}$" if expression else _plain(element)
     # Unknown rich-text type: fall back to the `plain_text` field that
@@ -119,13 +117,25 @@ def _render_mention_element(element: Mapping[str, Any]) -> str:
     if not href:
         if mention_type == "user":
             user = mention.get("user") or {}
-            href = f"notion://user/{user.get('id', 'unknown')}" if isinstance(user, Mapping) else None
+            href = (
+                f"notion://user/{user.get('id', 'unknown')}"
+                if isinstance(user, Mapping)
+                else None
+            )
         elif mention_type == "page":
             page = mention.get("page") or {}
-            href = f"notion://page/{page.get('id', 'unknown')}" if isinstance(page, Mapping) else None
+            href = (
+                f"notion://page/{page.get('id', 'unknown')}"
+                if isinstance(page, Mapping)
+                else None
+            )
         elif mention_type == "database":
             db = mention.get("database") or {}
-            href = f"notion://database/{db.get('id', 'unknown')}" if isinstance(db, Mapping) else None
+            href = (
+                f"notion://database/{db.get('id', 'unknown')}"
+                if isinstance(db, Mapping)
+                else None
+            )
         elif mention_type == "date":
             date = mention.get("date") or {}
             start = date.get("start", "") if isinstance(date, Mapping) else ""
@@ -289,7 +299,9 @@ def _render_bulleted(payload: Mapping[str, Any], **_: Any) -> str:
     return f"- {render_rich_text(payload.get('rich_text'))}"
 
 
-def _render_numbered(payload: Mapping[str, Any], *, numbered_index: int = 1, **_: Any) -> str:
+def _render_numbered(
+    payload: Mapping[str, Any], *, numbered_index: int = 1, **_: Any
+) -> str:
     return f"{numbered_index}. {render_rich_text(payload.get('rich_text'))}"
 
 
@@ -336,7 +348,9 @@ def _render_table_placeholder(_: Mapping[str, Any], **__: Any) -> str:
 
 def _render_table_row(payload: Mapping[str, Any], **_: Any) -> str:
     cells = payload.get("cells") or []
-    rendered_cells = [render_rich_text(cell) for cell in cells if isinstance(cell, Sequence)]
+    rendered_cells = [
+        render_rich_text(cell) for cell in cells if isinstance(cell, Sequence)
+    ]
     return "| " + " | ".join(rendered_cells) + " |"
 
 
@@ -390,11 +404,23 @@ def _render_table(payload: Mapping[str, Any], rows: Sequence[Mapping[str, Any]])
     if not rows:
         return ""
     table_width = int(payload.get("table_width") or 0) or _row_width(rows[0])
-    header_row, *body_rows = rows if payload.get("has_column_header") else (
-        [{"type": "table_row", "table_row": {"cells": [[] for _ in range(table_width)]}}]
-        + list(rows)
+    header_row, *body_rows = (
+        rows
+        if payload.get("has_column_header")
+        else (
+            [
+                {
+                    "type": "table_row",
+                    "table_row": {"cells": [[] for _ in range(table_width)]},
+                }
+            ]
+            + list(rows)
+        )
     )
-    parts = [_render_one_row(header_row), "| " + " | ".join(["---"] * table_width) + " |"]
+    parts = [
+        _render_one_row(header_row),
+        "| " + " | ".join(["---"] * table_width) + " |",
+    ]
     for r in body_rows:
         parts.append(_render_one_row(r))
     return "\n".join(parts)
@@ -511,11 +537,7 @@ def _prop_select(prop: Mapping[str, Any]) -> str:
 
 def _prop_multi_select(prop: Mapping[str, Any]) -> str:
     items = prop.get("multi_select") or []
-    names = [
-        str(item.get("name", ""))
-        for item in items
-        if isinstance(item, Mapping)
-    ]
+    names = [str(item.get("name", "")) for item in items if isinstance(item, Mapping)]
     return ", ".join(n for n in names if n)
 
 
@@ -555,11 +577,7 @@ def _prop_people(prop: Mapping[str, Any]) -> str:
             continue
         name = person.get("name")
         person_obj = person.get("person")
-        email = (
-            person_obj.get("email")
-            if isinstance(person_obj, Mapping)
-            else None
-        )
+        email = person_obj.get("email") if isinstance(person_obj, Mapping) else None
         if name and email:
             rendered.append(f"{name} <{email}>")
         elif name:
@@ -623,7 +641,11 @@ def _prop_rollup(prop: Mapping[str, Any]) -> str:
         return ""
     if r_type == "array" and isinstance(value, list):
         # Each array element is itself a typed property; recurse.
-        rendered = [_render_property(item, item.get("type")) for item in value if isinstance(item, Mapping)]
+        rendered = [
+            _render_property(item, item.get("type"))
+            for item in value
+            if isinstance(item, Mapping)
+        ]
         return ", ".join(r for r in rendered if r)
     if isinstance(value, Mapping) and "start" in value:
         return _prop_date({"date": value})

--- a/packages/pii-scanner-notion/tests/conftest.py
+++ b/packages/pii-scanner-notion/tests/conftest.py
@@ -13,7 +13,6 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 import httpx
-import pytest
 
 
 # Public re-export so tests can `from conftest import ...` if needed.

--- a/packages/pii-scanner-notion/tests/test_api.py
+++ b/packages/pii-scanner-notion/tests/test_api.py
@@ -13,7 +13,7 @@ from pleno_pii_scanner_notion.api import (
     NotionApiError,
 )
 
-from .conftest import json_response, make_handler
+from .conftest import json_response
 
 
 class TestConstruction:
@@ -86,7 +86,9 @@ class TestStatusHandling:
     async def test_404_returns_empty_dict(self) -> None:
         api = NotionApi(
             token="x",
-            transport=httpx.MockTransport(lambda _: httpx.Response(404, text="not found")),
+            transport=httpx.MockTransport(
+                lambda _: httpx.Response(404, text="not found")
+            ),
         )
         try:
             assert await api.get("/pages/missing") == {}

--- a/packages/pii-scanner-notion/tests/test_connector.py
+++ b/packages/pii-scanner-notion/tests/test_connector.py
@@ -60,12 +60,23 @@ def database_object(database_id: str) -> dict[str, Any]:
     }
 
 
-def block_payload(text: str, *, block_type: str = "paragraph", block_id: str = "b") -> dict[str, Any]:
+def block_payload(
+    text: str, *, block_type: str = "paragraph", block_id: str = "b"
+) -> dict[str, Any]:
     return {
         "id": block_id,
         "object": "block",
         "type": block_type,
-        block_type: {"rich_text": [{"type": "text", "text": {"content": text, "link": None}, "annotations": {}, "plain_text": text}]},
+        block_type: {
+            "rich_text": [
+                {
+                    "type": "text",
+                    "text": {"content": text, "link": None},
+                    "annotations": {},
+                    "plain_text": text,
+                }
+            ]
+        },
         "archived": False,
         "has_children": False,
     }
@@ -116,7 +127,9 @@ class TestConstruction:
 
     def test_bucket_key_falls_back_to_id(self) -> None:
         c = NotionConnector(NotionConfig(token="t"))
-        assert c.bucket_key() == BucketKey(connector_kind="notion", tenant_id="notion:default")
+        assert c.bucket_key() == BucketKey(
+            connector_kind="notion", tenant_id="notion:default"
+        )
 
 
 # ---------------------------------------------------------------------
@@ -288,10 +301,18 @@ class TestDiscoverSearch:
             return json_response(
                 {
                     "results": [
-                        page_object("p1", parent={"type": "page_id", "page_id": "parent-1"}),
-                        page_object("p2", parent={"type": "database_id", "database_id": "db-1"}),
-                        page_object("p3", parent={"type": "block_id", "block_id": "b-1"}),
-                        page_object("p4", parent={"type": "workspace", "workspace": True}),
+                        page_object(
+                            "p1", parent={"type": "page_id", "page_id": "parent-1"}
+                        ),
+                        page_object(
+                            "p2", parent={"type": "database_id", "database_id": "db-1"}
+                        ),
+                        page_object(
+                            "p3", parent={"type": "block_id", "block_id": "b-1"}
+                        ),
+                        page_object(
+                            "p4", parent={"type": "workspace", "workspace": True}
+                        ),
                         page_object("p5", parent={"type": "unknown_kind"}),
                     ],
                     "has_more": False,
@@ -302,7 +323,10 @@ class TestDiscoverSearch:
         transport = httpx.MockTransport(make_handler([("/search", search)]))
         c = NotionConnector(NotionConfig(token="t"), transport=transport)
         try:
-            refs = {r.metadata["object_id"]: r for r in await drain(c.discover(SourceFilter(), None))}
+            refs = {
+                r.metadata["object_id"]: r
+                for r in await drain(c.discover(SourceFilter(), None))
+            }
             assert refs["p1"].parent_chain == ("notion://page/parent-1",)
             assert refs["p2"].parent_chain == ("notion://database/db-1",)
             assert refs["p3"].parent_chain == ("notion://block/b-1",)
@@ -352,8 +376,12 @@ class TestDiscoverExplicitPages:
             await c.close()
 
     async def test_404_page_yields_nothing(self) -> None:
-        transport = httpx.MockTransport(make_handler([("/pages/", lambda _: httpx.Response(404))]))
-        c = NotionConnector(NotionConfig(token="t", pages=("missing",)), transport=transport)
+        transport = httpx.MockTransport(
+            make_handler([("/pages/", lambda _: httpx.Response(404))])
+        )
+        c = NotionConnector(
+            NotionConfig(token="t", pages=("missing",)), transport=transport
+        )
         try:
             assert await drain(c.discover(SourceFilter(), None)) == []
         finally:
@@ -411,7 +439,9 @@ class TestDiscoverDatabase:
                 {"results": [page_object("r1")], "has_more": True, "next_cursor": None}
             )
 
-        transport = httpx.MockTransport(make_handler([("/databases/db-1/query", query)]))
+        transport = httpx.MockTransport(
+            make_handler([("/databases/db-1/query", query)])
+        )
         c = NotionConnector(
             NotionConfig(token="t", databases=("db-1",)), transport=transport
         )
@@ -435,7 +465,11 @@ class TestDiscoverCombined:
 
         def query(_: httpx.Request) -> httpx.Response:
             return json_response(
-                {"results": [page_object("row1")], "has_more": False, "next_cursor": None}
+                {
+                    "results": [page_object("row1")],
+                    "has_more": False,
+                    "next_cursor": None,
+                }
             )
 
         transport = httpx.MockTransport(
@@ -463,7 +497,9 @@ class TestDiscoverCombined:
 # ---------------------------------------------------------------------
 
 
-def _children_route(children_by_block: dict[str, list[dict[str, Any]]]) -> Callable[[httpx.Request], httpx.Response]:
+def _children_route(
+    children_by_block: dict[str, list[dict[str, Any]]],
+) -> Callable[[httpx.Request], httpx.Response]:
     def handler(request: httpx.Request) -> httpx.Response:
         # URL: /v1/blocks/<id>/children
         path = request.url.path
@@ -516,7 +552,12 @@ class TestFetch:
             "Name": {
                 "type": "title",
                 "title": [
-                    {"type": "text", "text": {"content": "alice", "link": None}, "annotations": {}, "plain_text": "alice"}
+                    {
+                        "type": "text",
+                        "text": {"content": "alice", "link": None},
+                        "annotations": {},
+                        "plain_text": "alice",
+                    }
                 ],
             },
             "Email": {"type": "email", "email": "alice@x.test"},
@@ -537,7 +578,11 @@ class TestFetch:
                 source_id=c.id,
                 source_kind=c.kind,
                 path="notion://database-row/row1",
-                metadata={"object_id": "row1", "object_type": "page", "database_id": "db1"},
+                metadata={
+                    "object_id": "row1",
+                    "object_type": "page",
+                    "database_id": "db1",
+                },
             )
             docs = [d async for d in c.fetch(ref)]
             assert len(docs) == 1
@@ -576,7 +621,9 @@ class TestFetch:
         transport = httpx.MockTransport(make_handler([]))
         c = NotionConnector(NotionConfig(token="t"), transport=transport)
         try:
-            ghost = DocumentRef(source_id=c.id, source_kind=c.kind, path="notion://page/x")
+            ghost = DocumentRef(
+                source_id=c.id, source_kind=c.kind, path="notion://page/x"
+            )
             assert [d async for d in c.fetch(ghost)] == []
         finally:
             await c.close()
@@ -713,7 +760,9 @@ class TestFetch:
         finally:
             await c.close()
 
-    async def test_block_children_pagination_stops_when_next_cursor_missing(self) -> None:
+    async def test_block_children_pagination_stops_when_next_cursor_missing(
+        self,
+    ) -> None:
         # has_more=True without next_cursor must terminate (defense in depth).
         def children(_: httpx.Request) -> httpx.Response:
             return json_response(
@@ -824,7 +873,12 @@ class TestRateLimit:
     async def test_429_during_search_surfaces_rate_limited(self) -> None:
         transport = httpx.MockTransport(
             make_handler(
-                [("/search", lambda _: httpx.Response(429, headers={"Retry-After": "1"}))]
+                [
+                    (
+                        "/search",
+                        lambda _: httpx.Response(429, headers={"Retry-After": "1"}),
+                    )
+                ]
             )
         )
         c = NotionConnector(NotionConfig(token="t"), transport=transport)
@@ -839,7 +893,10 @@ class TestRateLimit:
             make_handler(
                 [
                     ("/pages/p1", lambda _: json_response(page_object("p1"))),
-                    ("/blocks/", lambda _: httpx.Response(429, headers={"Retry-After": "2"})),
+                    (
+                        "/blocks/",
+                        lambda _: httpx.Response(429, headers={"Retry-After": "2"}),
+                    ),
                 ]
             )
         )

--- a/packages/pii-scanner-notion/tests/test_markdown.py
+++ b/packages/pii-scanner-notion/tests/test_markdown.py
@@ -13,7 +13,9 @@ from pleno_pii_scanner_notion.markdown import (
 )
 
 
-def text_element(content: str, *, link: str | None = None, **annotations: bool) -> dict[str, Any]:
+def text_element(
+    content: str, *, link: str | None = None, **annotations: bool
+) -> dict[str, Any]:
     obj: dict[str, Any] = {
         "type": "text",
         "text": {"content": content, "link": {"url": link} if link else None},
@@ -23,7 +25,14 @@ def text_element(content: str, *, link: str | None = None, **annotations: bool) 
     return obj
 
 
-def block(block_type: str, payload: dict[str, Any], *, archived: bool = False, has_children: bool = False, block_id: str = "b") -> dict[str, Any]:
+def block(
+    block_type: str,
+    payload: dict[str, Any],
+    *,
+    archived: bool = False,
+    has_children: bool = False,
+    block_id: str = "b",
+) -> dict[str, Any]:
     return {
         "id": block_id,
         "object": "block",
@@ -166,11 +175,21 @@ class TestRichText:
 
     def test_annotations_on_empty_text_passthrough(self) -> None:
         # Empty text → no wrapping (avoid `**`` etc on empty).
-        element = {"type": "text", "text": {"content": ""}, "annotations": {"bold": True}, "plain_text": ""}
+        element = {
+            "type": "text",
+            "text": {"content": ""},
+            "annotations": {"bold": True},
+            "plain_text": "",
+        }
         assert render_rich_text([element]) == ""
 
     def test_annotations_non_mapping_returns_text_unchanged(self) -> None:
-        element = {"type": "text", "text": {"content": "x"}, "annotations": "nope", "plain_text": "x"}
+        element = {
+            "type": "text",
+            "text": {"content": "x"},
+            "annotations": "nope",
+            "plain_text": "x",
+        }
         # `_render_text_element` reads annotations as `or {}` so non-mapping
         # becomes empty mapping and text passes through.
         assert render_rich_text([element]) == "x"
@@ -235,7 +254,11 @@ class TestBlocks:
 
     def test_code_with_language_fence(self) -> None:
         out = render_blocks(
-            [block("code", {"rich_text": [text_element("x = 1")], "language": "python"})]
+            [
+                block(
+                    "code", {"rich_text": [text_element("x = 1")], "language": "python"}
+                )
+            ]
         )
         assert out == "```python\nx = 1\n```"
 
@@ -250,7 +273,10 @@ class TestBlocks:
                 block("quote", {"rich_text": [text_element("wisdom")]}),
                 block(
                     "callout",
-                    {"rich_text": [text_element("info")], "icon": {"type": "emoji", "emoji": "💡"}},
+                    {
+                        "rich_text": [text_element("info")],
+                        "icon": {"type": "emoji", "emoji": "💡"},
+                    },
                 ),
             ]
         )
@@ -262,7 +288,9 @@ class TestBlocks:
         assert out == ">"
 
     def test_callout_without_emoji(self) -> None:
-        out = render_blocks([block("callout", {"rich_text": [text_element("hi")], "icon": None})])
+        out = render_blocks(
+            [block("callout", {"rich_text": [text_element("hi")], "icon": None})]
+        )
         assert out == "> hi"
 
     def test_divider(self) -> None:
@@ -293,7 +321,9 @@ class TestBlocks:
         assert out == ""
 
     def test_bookmark_without_caption_falls_back_to_url(self) -> None:
-        out = render_blocks([block("bookmark", {"url": "https://b.test/y", "caption": []})])
+        out = render_blocks(
+            [block("bookmark", {"url": "https://b.test/y", "caption": []})]
+        )
         assert out == "[https://b.test/y](https://b.test/y)"
 
     def test_bookmark_without_url_emits_nothing(self) -> None:
@@ -301,7 +331,9 @@ class TestBlocks:
         assert out == ""
 
     def test_link_to_page(self) -> None:
-        out = render_blocks([block("link_to_page", {"type": "page_id", "page_id": "pid-1"})])
+        out = render_blocks(
+            [block("link_to_page", {"type": "page_id", "page_id": "pid-1"})]
+        )
         assert out == "[link](notion://page_id/pid-1)"
 
     def test_link_to_page_with_unknown_target_returns_empty(self) -> None:
@@ -333,7 +365,9 @@ class TestBlocks:
         out = render_blocks(
             [
                 block("paragraph", {"rich_text": [text_element("kept")]}),
-                block("paragraph", {"rich_text": [text_element("dropped")]}, archived=True),
+                block(
+                    "paragraph", {"rich_text": [text_element("dropped")]}, archived=True
+                ),
             ]
         )
         assert "kept" in out
@@ -342,14 +376,18 @@ class TestBlocks:
     def test_archived_block_kept_with_flag(self) -> None:
         out = render_blocks(
             [
-                block("paragraph", {"rich_text": [text_element("kept")]}, archived=True),
+                block(
+                    "paragraph", {"rich_text": [text_element("kept")]}, archived=True
+                ),
             ],
             include_archived=True,
         )
         assert "kept" in out
 
     def test_non_mapping_block_skipped(self) -> None:
-        out = render_blocks(["broken", block("paragraph", {"rich_text": [text_element("x")]})])
+        out = render_blocks(
+            ["broken", block("paragraph", {"rich_text": [text_element("x")]})]
+        )
         assert out == "x"
 
     def test_block_with_non_mapping_payload_renders_via_empty_payload(self) -> None:
@@ -391,15 +429,29 @@ class TestNestedBlocks:
         # with `has_children=True`. The cap should kick in before stack
         # overflow.
         def lookup(_: Any) -> list[Any]:
-            return [block("paragraph", {"rich_text": [text_element("deep")]}, has_children=True, block_id="recurse")]
+            return [
+                block(
+                    "paragraph",
+                    {"rich_text": [text_element("deep")]},
+                    has_children=True,
+                    block_id="recurse",
+                )
+            ]
 
-        parent = block("paragraph", {"rich_text": [text_element("root")]}, has_children=True, block_id="recurse")
+        parent = block(
+            "paragraph",
+            {"rich_text": [text_element("root")]},
+            has_children=True,
+            block_id="recurse",
+        )
         # Call the renderer at MAX_DEPTH — must short-circuit.
         out = render_blocks([parent], children_for=lookup, depth=MAX_DEPTH)
         assert out == DEPTH_TRUNCATED_MARKER
 
     def test_children_skipped_when_no_lookup(self) -> None:
-        parent = block("paragraph", {"rich_text": [text_element("root")]}, has_children=True)
+        parent = block(
+            "paragraph", {"rich_text": [text_element("root")]}, has_children=True
+        )
         # No `children_for` callback → just render the parent body.
         assert render_blocks([parent]) == "root"
 
@@ -422,8 +474,16 @@ class TestNestedBlocks:
 class TestTable:
     def test_table_with_header_and_rows(self) -> None:
         rows = [
-            block("table_row", {"cells": [[text_element("name")], [text_element("email")]]}, block_id="r0"),
-            block("table_row", {"cells": [[text_element("alice")], [text_element("a@b.test")]]}, block_id="r1"),
+            block(
+                "table_row",
+                {"cells": [[text_element("name")], [text_element("email")]]},
+                block_id="r0",
+            ),
+            block(
+                "table_row",
+                {"cells": [[text_element("alice")], [text_element("a@b.test")]]},
+                block_id="r1",
+            ),
         ]
         children = {"t1": rows}
 
@@ -443,7 +503,11 @@ class TestTable:
 
     def test_table_without_column_header_synthesizes_blank(self) -> None:
         rows = [
-            block("table_row", {"cells": [[text_element("alice")], [text_element("bob")]]}, block_id="r0"),
+            block(
+                "table_row",
+                {"cells": [[text_element("alice")], [text_element("bob")]]},
+                block_id="r0",
+            ),
         ]
         children = {"t2": rows}
 
@@ -479,13 +543,26 @@ class TestTable:
 
     def test_render_one_row_with_non_mapping_payload(self) -> None:
         # Defensive guard inside `_render_one_row`.
-        rows = [{"id": "r", "type": "table_row", "table_row": "broken", "archived": False, "has_children": False}]
+        rows = [
+            {
+                "id": "r",
+                "type": "table_row",
+                "table_row": "broken",
+                "archived": False,
+                "has_children": False,
+            }
+        ]
         children = {"t": rows}
 
         def lookup(bid: Any) -> list[Any]:
             return children.get(bid, [])
 
-        table = block("table", {"table_width": 0, "has_column_header": True}, has_children=True, block_id="t")
+        table = block(
+            "table",
+            {"table_width": 0, "has_column_header": True},
+            has_children=True,
+            block_id="t",
+        )
         # `_row_width` returns 0 → no separator columns; renderer copes.
         out = render_blocks([table], children_for=lookup)
         # The table renderer still emits the (empty) header & separator rows;
@@ -519,7 +596,10 @@ class TestDatabaseRow:
     def test_skips_low_signal_metadata(self) -> None:
         props = {
             "Created": {"type": "created_time", "created_time": "2020-01-01T00:00:00Z"},
-            "Edited": {"type": "last_edited_time", "last_edited_time": "2020-01-01T00:00:00Z"},
+            "Edited": {
+                "type": "last_edited_time",
+                "last_edited_time": "2020-01-01T00:00:00Z",
+            },
             "By": {"type": "created_by", "created_by": {"id": "u"}},
             "EditBy": {"type": "last_edited_by", "last_edited_by": {"id": "u"}},
             "Name": {"type": "title", "title": [text_element("alice")]},
@@ -534,7 +614,10 @@ class TestDatabaseRow:
         out = render_database_row(
             {
                 "Title": {"type": "title", "title": [text_element("Hello")]},
-                "Body": {"type": "rich_text", "rich_text": [text_element("World", bold=True)]},
+                "Body": {
+                    "type": "rich_text",
+                    "rich_text": [text_element("World", bold=True)],
+                },
             }
         )
         assert "Title: Hello" in out
@@ -554,7 +637,10 @@ class TestDatabaseRow:
         out = render_database_row(
             {
                 "Sel": {"type": "select", "select": {"name": "Open"}},
-                "Tags": {"type": "multi_select", "multi_select": [{"name": "a"}, {"name": "b"}]},
+                "Tags": {
+                    "type": "multi_select",
+                    "multi_select": [{"name": "a"}, {"name": "b"}],
+                },
                 "St": {"type": "status", "status": {"name": "InProgress"}},
             }
         )
@@ -574,7 +660,10 @@ class TestDatabaseRow:
         out = render_database_row(
             {
                 "Day": {"type": "date", "date": {"start": "2026-05-04"}},
-                "Range": {"type": "date", "date": {"start": "2026-05-04", "end": "2026-05-10"}},
+                "Range": {
+                    "type": "date",
+                    "date": {"start": "2026-05-04", "end": "2026-05-10"},
+                },
                 "Empty": {"type": "date", "date": None},
             }
         )
@@ -612,7 +701,11 @@ class TestDatabaseRow:
                 "Owners": {
                     "type": "people",
                     "people": [
-                        {"id": "u1", "name": "Alice", "person": {"email": "alice@x.test"}},
+                        {
+                            "id": "u1",
+                            "name": "Alice",
+                            "person": {"email": "alice@x.test"},
+                        },
                         {"id": "u2", "name": "Bob"},
                         {"id": "u3", "person": {"email": "anon@x.test"}},
                         {"id": "u4"},
@@ -624,7 +717,12 @@ class TestDatabaseRow:
 
     def test_people_skips_non_mapping_entries(self) -> None:
         out = render_database_row(
-            {"Owners": {"type": "people", "people": ["broken", {"id": "u1", "name": "Alice"}]}}
+            {
+                "Owners": {
+                    "type": "people",
+                    "people": ["broken", {"id": "u1", "name": "Alice"}],
+                }
+            }
         )
         assert out == "Owners: Alice"
 
@@ -634,8 +732,16 @@ class TestDatabaseRow:
                 "Files": {
                     "type": "files",
                     "files": [
-                        {"name": "a.png", "type": "file", "file": {"url": "https://x.test/a"}},
-                        {"name": "b.png", "type": "external", "external": {"url": "https://x.test/b"}},
+                        {
+                            "name": "a.png",
+                            "type": "file",
+                            "file": {"url": "https://x.test/a"},
+                        },
+                        {
+                            "name": "b.png",
+                            "type": "external",
+                            "external": {"url": "https://x.test/b"},
+                        },
                         {"name": "c"},
                     ],
                 }
@@ -661,7 +767,12 @@ class TestDatabaseRow:
 
     def test_relation(self) -> None:
         out = render_database_row(
-            {"Rel": {"type": "relation", "relation": [{"id": "p1"}, {"id": "p2"}, "broken", {}]}}
+            {
+                "Rel": {
+                    "type": "relation",
+                    "relation": [{"id": "p1"}, {"id": "p2"}, "broken", {}],
+                }
+            }
         )
         assert out == "Rel: p1, p2"
 
@@ -680,10 +791,14 @@ class TestDatabaseRow:
     def test_formula_invalid(self) -> None:
         out = render_database_row({"F": {"type": "formula", "formula": None}})
         assert out == "F: "
-        out2 = render_database_row({"F": {"type": "formula", "formula": {"type": "string", "string": None}}})
+        out2 = render_database_row(
+            {"F": {"type": "formula", "formula": {"type": "string", "string": None}}}
+        )
         assert out2 == "F: "
         # Mapping value that isn't a date object renders empty.
-        out3 = render_database_row({"F": {"type": "formula", "formula": {"type": "weird", "weird": {"k": 1}}}})
+        out3 = render_database_row(
+            {"F": {"type": "formula", "formula": {"type": "weird", "weird": {"k": 1}}}}
+        )
         assert out3 == "F: "
 
     def test_rollup_array_and_scalar(self) -> None:
@@ -723,7 +838,9 @@ class TestDatabaseRow:
     def test_rollup_invalid(self) -> None:
         out = render_database_row({"R": {"type": "rollup", "rollup": None}})
         assert out == "R: "
-        out2 = render_database_row({"R": {"type": "rollup", "rollup": {"type": "number", "number": None}}})
+        out2 = render_database_row(
+            {"R": {"type": "rollup", "rollup": {"type": "number", "number": None}}}
+        )
         assert out2 == "R: "
 
     def test_unknown_property_type_emits_marker(self) -> None:
@@ -733,5 +850,10 @@ class TestDatabaseRow:
         assert "Mystery: <!-- unsupported property: future_kind -->" in out
 
     def test_non_mapping_property_skipped(self) -> None:
-        out = render_database_row({"Bad": "not a mapping", "Title": {"type": "title", "title": [text_element("ok")]}})
+        out = render_database_row(
+            {
+                "Bad": "not a mapping",
+                "Title": {"type": "title", "title": [text_element("ok")]},
+            }
+        )
         assert out == "Title: ok"

--- a/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/auth.py
+++ b/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/auth.py
@@ -21,7 +21,6 @@ tokens skip realm negotiation entirely via `StaticAuth`.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -68,8 +67,7 @@ class BasicAuth:
         token = body.get("token") or body.get("access_token")
         if not token:
             raise ValueError(
-                "registry token-realm response had neither 'token' nor "
-                "'access_token'"
+                "registry token-realm response had neither 'token' nor 'access_token'"
             )
         return token
 
@@ -88,8 +86,7 @@ class AnonymousAuth:
         token = body.get("token") or body.get("access_token")
         if not token:
             raise ValueError(
-                "anonymous token request returned neither 'token' nor "
-                "'access_token'"
+                "anonymous token request returned neither 'token' nor 'access_token'"
             )
         return token
 
@@ -102,10 +99,8 @@ def parse_challenge(www_authenticate: str) -> dict[str, str]:
     surfaces with a clear error rather than an empty params dict.
     """
     if not www_authenticate.lower().startswith("bearer "):
-        raise ValueError(
-            f"only Bearer challenges supported, got: {www_authenticate!r}"
-        )
-    rest = www_authenticate[len("Bearer "):]
+        raise ValueError(f"only Bearer challenges supported, got: {www_authenticate!r}")
+    rest = www_authenticate[len("Bearer ") :]
     out: dict[str, str] = {}
     for pair in _split_header(rest):
         if "=" not in pair:

--- a/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/connector.py
+++ b/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/connector.py
@@ -282,9 +282,7 @@ class OciConnector:
 
     # --- internals -------------------------------------------------
 
-    async def _resolve_manifest(
-        self, ref: ImageReference
-    ) -> "_ResolvedManifest":
+    async def _resolve_manifest(self, ref: ImageReference) -> "_ResolvedManifest":
         manifest_url = ref.manifest_url()
         body, media_type = await self._get_json(
             manifest_url, scope=f"repository:{ref.repository}:pull", ref=ref
@@ -331,9 +329,7 @@ class OciConnector:
         media_type = resp.headers.get("Content-Type", "").split(";", 1)[0].strip()
         return resp.json(), media_type
 
-    async def _fetch_blob(
-        self, ref: ImageReference, digest: str
-    ) -> bytes:
+    async def _fetch_blob(self, ref: ImageReference, digest: str) -> bytes:
         url = ref.blob_url(digest)
         scope = f"repository:{ref.repository}:pull"
         headers = await self._auth_headers(ref.registry, scope, ref=ref)
@@ -341,9 +337,7 @@ class OciConnector:
         if resp.status_code == 401:
             await self._negotiate_token(resp, ref.registry, scope)
             headers = await self._auth_headers(ref.registry, scope, ref=ref)
-            resp = await self._client.get(
-                url, headers=headers, follow_redirects=True
-            )
+            resp = await self._client.get(url, headers=headers, follow_redirects=True)
         resp.raise_for_status()
         return resp.content
 
@@ -371,9 +365,7 @@ class OciConnector:
         # `scope` so subsequent `_auth_headers` lookups hit.
         token_scope = params.get("scope", scope)
         if not realm:
-            raise ValueError(
-                "challenge from registry has no realm parameter"
-            )
+            raise ValueError("challenge from registry has no realm parameter")
         auth: BasicAuth | AnonymousAuth
         if self._config.username is not None and self._config.password is not None:
             auth = BasicAuth(self._config.username, self._config.password)
@@ -409,14 +401,10 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
                 else None
             ),
             username=(
-                str(config["username"])
-                if config.get("username") is not None
-                else None
+                str(config["username"]) if config.get("username") is not None else None
             ),
             password=(
-                str(config["password"])
-                if config.get("password") is not None
-                else None
+                str(config["password"]) if config.get("password") is not None else None
             ),
             id=str(config["id"]) if config.get("id") is not None else None,
         )

--- a/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/layers.py
+++ b/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/layers.py
@@ -67,10 +67,7 @@ def iter_layer_members(
         for entry in tar:
             if not entry.isfile():
                 continue
-            if (
-                max_member_bytes is not None
-                and entry.size > max_member_bytes
-            ):
+            if max_member_bytes is not None and entry.size > max_member_bytes:
                 continue
             extracted = tar.extractfile(entry)
             if extracted is None:
@@ -99,9 +96,7 @@ def _open_decompressed(media_type: str, raw: bytes):
         import io
 
         return io.BytesIO(raw)
-    raise ValueError(
-        f"unsupported layer media-type: {media_type!r}"
-    )
+    raise ValueError(f"unsupported layer media-type: {media_type!r}")
 
 
 __all__ = [

--- a/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/manifest.py
+++ b/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/manifest.py
@@ -79,14 +79,10 @@ def parse_manifest(media_type: str, body: dict[str, Any]) -> ImageManifest:
         )
         for layer in body.get("layers", [])
     )
-    return ImageManifest(
-        media_type=media_type, config=config, layers=layers
-    )
+    return ImageManifest(media_type=media_type, config=config, layers=layers)
 
 
-def select_platform(
-    body: dict[str, Any], *, default_platform: str
-) -> Descriptor:
+def select_platform(body: dict[str, Any], *, default_platform: str) -> Descriptor:
     """Pick a single-platform descriptor from an Image Index body.
 
     `default_platform` is `os/arch[/variant]` (e.g. `linux/amd64`).

--- a/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/reference.py
+++ b/packages/pii-scanner-oci/src/pleno_pii_scanner_oci/reference.py
@@ -38,8 +38,7 @@ class ImageReference:
 
     def manifest_url(self) -> str:
         return (
-            f"https://{self.registry}/v2/{self.repository}/manifests/"
-            f"{self.reference}"
+            f"https://{self.registry}/v2/{self.repository}/manifests/{self.reference}"
         )
 
     def blob_url(self, digest: str) -> str:

--- a/packages/pii-scanner-oci/tests/test_auth.py
+++ b/packages/pii-scanner-oci/tests/test_auth.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 
 import httpx
 import pytest
@@ -35,15 +34,11 @@ class TestParseChallenge:
             parse_challenge("Basic realm=foo")
 
     def test_quoted_value_with_comma(self) -> None:
-        params = parse_challenge(
-            'Bearer realm="https://auth/token",scope="a,b,c"'
-        )
+        params = parse_challenge('Bearer realm="https://auth/token",scope="a,b,c"')
         assert params["scope"] == "a,b,c"
 
     def test_ignores_malformed_pair(self) -> None:
-        params = parse_challenge(
-            'Bearer realm="https://auth/token",noequalshere'
-        )
+        params = parse_challenge('Bearer realm="https://auth/token",noequalshere')
         assert "realm" in params
         assert "noequalshere" not in params
 
@@ -55,9 +50,7 @@ class TestBasicAuth:
         def handler(request: httpx.Request) -> httpx.Response:
             seen_request["url"] = str(request.url)
             seen_request["auth"] = request.headers.get("Authorization", "")
-            return httpx.Response(
-                200, json={"token": "token-from-realm"}
-            )
+            return httpx.Response(200, json={"token": "token-from-realm"})
 
         transport = httpx.MockTransport(handler)
         async with httpx.AsyncClient(transport=transport) as client:
@@ -67,7 +60,10 @@ class TestBasicAuth:
             )
         assert token == "token-from-realm"
         assert "service=r.example" in seen_request["url"]
-        assert "scope=repo%3Afoo%3Apull" in seen_request["url"] or "scope=repo:foo:pull" in seen_request["url"]
+        assert (
+            "scope=repo%3Afoo%3Apull" in seen_request["url"]
+            or "scope=repo:foo:pull" in seen_request["url"]
+        )
         assert seen_request["auth"].startswith("Basic ")
 
     async def test_accepts_access_token_field(self) -> None:
@@ -112,6 +108,4 @@ class TestAnonymousAuth:
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             with pytest.raises(ValueError, match="neither 'token'"):
-                await AnonymousAuth().fetch_token(
-                    client, "https://x/token", "s", "v"
-                )
+                await AnonymousAuth().fetch_token(client, "https://x/token", "s", "v")

--- a/packages/pii-scanner-oci/tests/test_connector.py
+++ b/packages/pii-scanner-oci/tests/test_connector.py
@@ -7,7 +7,6 @@ import io
 import json
 import tarfile
 from collections.abc import Callable
-from typing import Any
 
 import httpx
 import pytest
@@ -329,7 +328,6 @@ class TestLayerDedup:
             )
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
-                kinds = [r.metadata.get("kind") for r in refs]
                 # 2 configs + 1 dedup'd layer (the layer for the second
                 # image is only emitted after fetch() of the first marks
                 # the digest as scanned)
@@ -376,9 +374,7 @@ class TestStaleFetch:
         async with httpx.AsyncClient(
             transport=httpx.MockTransport(lambda _r: httpx.Response(404))
         ) as client:
-            c = OciConnector(
-                OciConfig(references=("alpine",)), client=client
-            )
+            c = OciConnector(OciConfig(references=("alpine",)), client=client)
             try:
                 ref = DocumentRef(
                     source_id=c.id,
@@ -452,9 +448,7 @@ class TestTokenNegotiation:
                 return httpx.Response(200, content=config_bytes)
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = OciConnector(OciConfig(references=("alpine:v1",)), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -504,9 +498,7 @@ class TestTokenNegotiation:
                 )
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = OciConnector(
                 OciConfig(
                     references=("alpine:v1",),
@@ -551,9 +543,7 @@ class TestTokenNegotiation:
                 )
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = OciConnector(
                 OciConfig(
                     references=("alpine:v1",),
@@ -633,9 +623,7 @@ class TestErrorPaths:
                 headers={"Content-Type": "application/x-bogus"},
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = OciConnector(OciConfig(references=("alpine",)), client=client)
             try:
                 with pytest.raises(ValueError, match="unexpected manifest media-type"):
@@ -682,9 +670,7 @@ class TestErrorPaths:
                 return httpx.Response(200, content=config_bytes)
             return httpx.Response(404)
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = OciConnector(OciConfig(references=("alpine:v1",)), client=client)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -702,9 +688,7 @@ class TestErrorPaths:
                 headers={"WWW-Authenticate": 'Bearer service="r.example"'},
             )
 
-        async with httpx.AsyncClient(
-            transport=httpx.MockTransport(handler)
-        ) as client:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             c = OciConnector(OciConfig(references=("alpine",)), client=client)
             try:
                 with pytest.raises(ValueError, match="no realm parameter"):

--- a/packages/pii-scanner-oci/tests/test_layers.py
+++ b/packages/pii-scanner-oci/tests/test_layers.py
@@ -59,9 +59,7 @@ class TestGzipLayer:
         tar_bytes = _build_dir_tarball()
         gz = gzip.compress(tar_bytes)
         members = list(
-            iter_layer_members(
-                "application/vnd.oci.image.layer.v1.tar+gzip", gz
-            )
+            iter_layer_members("application/vnd.oci.image.layer.v1.tar+gzip", gz)
         )
         # Only the regular file, not the directory.
         assert [m.path for m in members] == ["etc/passwd"]

--- a/packages/pii-scanner-oci/tests/test_reference.py
+++ b/packages/pii-scanner-oci/tests/test_reference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from pleno_pii_scanner_oci.reference import ImageReference, parse_reference
+from pleno_pii_scanner_oci.reference import parse_reference
 
 
 class TestParseReference:
@@ -68,18 +68,12 @@ class TestParseReference:
 
     def test_manifest_url(self) -> None:
         ref = parse_reference("ghcr.io/acme/api:v1")
-        assert (
-            ref.manifest_url()
-            == "https://ghcr.io/v2/acme/api/manifests/v1"
-        )
+        assert ref.manifest_url() == "https://ghcr.io/v2/acme/api/manifests/v1"
 
     def test_blob_url(self) -> None:
         ref = parse_reference("ghcr.io/acme/api:v1")
         digest = "sha256:" + "d" * 64
-        assert (
-            ref.blob_url(digest)
-            == f"https://ghcr.io/v2/acme/api/blobs/{digest}"
-        )
+        assert ref.blob_url(digest) == f"https://ghcr.io/v2/acme/api/blobs/{digest}"
 
     def test_blob_url_invalid_digest(self) -> None:
         ref = parse_reference("ghcr.io/acme/api:v1")

--- a/packages/pii-scanner-postgres/src/pleno_pii_scanner_postgres/connector.py
+++ b/packages/pii-scanner-postgres/src/pleno_pii_scanner_postgres/connector.py
@@ -85,9 +85,7 @@ class PostgresConfig:
     tables: tuple[str, ...] = ()
     excluded_tables: tuple[str, ...] = ()
     sample_rows: int = field(
-        default_factory=lambda: reservoir_sample_size(
-            confidence=0.95, prevalence=0.01
-        )
+        default_factory=lambda: reservoir_sample_size(confidence=0.95, prevalence=0.01)
     )
     statement_timeout: str = "30s"
     pool_size: int = 2
@@ -279,9 +277,7 @@ class PostgresConnector:
         except ValueError:
             return None
         async with self._pool.acquire() as conn:  # type: ignore[union-attr]
-            rows = await conn.fetch(
-                _RELOAD_SQL, schema, table, list(_TEXTUAL_TYPES)
-            )
+            rows = await conn.fetch(_RELOAD_SQL, schema, table, list(_TEXTUAL_TYPES))
         if not rows:
             return None
         return _TableMeta(

--- a/packages/pii-scanner-postgres/src/pleno_pii_scanner_postgres/sampling.py
+++ b/packages/pii-scanner-postgres/src/pleno_pii_scanner_postgres/sampling.py
@@ -59,10 +59,7 @@ class SamplingPlan:
         # O(N log N) so we cap with `LIMIT` upfront — the planner can
         # use index-only scans here on small tables but the strategy is
         # only ever picked when estimated_rows ≤ 100k.
-        return (
-            f"SELECT {cols} FROM {ident} "
-            f"ORDER BY random() LIMIT {self.sample_rows}"
-        )
+        return f"SELECT {cols} FROM {ident} ORDER BY random() LIMIT {self.sample_rows}"
 
 
 def plan_sample(

--- a/packages/pii-scanner-postgres/tests/test_connector.py
+++ b/packages/pii-scanner-postgres/tests/test_connector.py
@@ -66,9 +66,7 @@ class _FakeConn:
 
 
 class _FakePool:
-    def __init__(
-        self, fetch_responses: list[Any], in_recovery: bool = True
-    ) -> None:
+    def __init__(self, fetch_responses: list[Any], in_recovery: bool = True) -> None:
         self._conn = _FakeConn(fetch_responses, in_recovery)
         self.closed = False
 
@@ -144,17 +142,13 @@ class TestConfig:
 
 class TestHelpers:
     def test_redact_dsn_strips_password(self) -> None:
-        assert (
-            _redact_dsn("postgresql://u:p@h/d") == "postgresql://u@h/d"
-        )
+        assert _redact_dsn("postgresql://u:p@h/d") == "postgresql://u@h/d"
 
     def test_redact_dsn_no_auth(self) -> None:
         assert _redact_dsn("postgresql://h/d") == "postgresql://h/d"
 
     def test_redact_dsn_user_only(self) -> None:
-        assert (
-            _redact_dsn("postgresql://u@h/d") == "postgresql://u@h/d"
-        )
+        assert _redact_dsn("postgresql://u@h/d") == "postgresql://u@h/d"
 
     def test_redact_dsn_keyvalue_form_passthrough(self) -> None:
         # libpq key=value: too many corner cases to safely strip, so
@@ -250,9 +244,7 @@ class TestDiscover:
         ]
         patch_pool([rows])
         c = PostgresConnector(
-            PostgresConfig(
-                dsn="postgresql://u@h/d", tables=("public.users",)
-            )
+            PostgresConfig(dsn="postgresql://u@h/d", tables=("public.users",))
         )
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -324,10 +316,7 @@ class TestDiscover:
         )
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(include=("billing.*",)), None
-                )
+                r async for r in c.discover(SourceFilter(include=("billing.*",)), None)
             ]
             assert {r.path for r in refs} == {"billing.invoices"}
         finally:
@@ -358,10 +347,7 @@ class TestDiscover:
         c = PostgresConnector(PostgresConfig(dsn="postgresql://u@h/d"))
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(exclude=("*.logs",)), None
-                )
+                r async for r in c.discover(SourceFilter(exclude=("*.logs",)), None)
             ]
             assert {r.path for r in refs} == {"public.users"}
         finally:
@@ -396,9 +382,7 @@ class TestReplicaEnforcement:
         ]
         patch_pool([rows], in_recovery=False)
         c = PostgresConnector(
-            PostgresConfig(
-                dsn="postgresql://u@h/d", require_replica=False
-            )
+            PostgresConfig(dsn="postgresql://u@h/d", require_replica=False)
         )
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -565,9 +549,7 @@ class TestSpec:
 
     def test_factory_empty_schemas_uses_default(self) -> None:
         register(SPEC)
-        c = create(
-            "postgres", {"dsn": "postgresql://u@h/d", "schemas": []}
-        )
+        c = create("postgres", {"dsn": "postgresql://u@h/d", "schemas": []})
         assert c._config.schemas == ("public",)
 
 

--- a/packages/pii-scanner-postgres/tests/test_sampling.py
+++ b/packages/pii-scanner-postgres/tests/test_sampling.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import math
 
 import pytest
 
 from pleno_pii_scanner_postgres.sampling import (
-    SamplingPlan,
     _quote_ident,
     plan_sample,
     reservoir_sample_size,
@@ -79,15 +77,11 @@ class TestPlanSample:
 
     def test_rejects_zero_estimated_rows(self) -> None:
         with pytest.raises(ValueError, match="estimated_rows"):
-            plan_sample(
-                schema="s", table="t", estimated_rows=0, sample_rows=10
-            )
+            plan_sample(schema="s", table="t", estimated_rows=0, sample_rows=10)
 
     def test_rejects_zero_sample_rows(self) -> None:
         with pytest.raises(ValueError, match="sample_rows"):
-            plan_sample(
-                schema="s", table="t", estimated_rows=100, sample_rows=0
-            )
+            plan_sample(schema="s", table="t", estimated_rows=100, sample_rows=0)
 
     def test_query_quotes_identifiers(self) -> None:
         p = plan_sample(

--- a/packages/pii-scanner-postman/src/pleno_pii_scanner_postman/connector.py
+++ b/packages/pii-scanner-postman/src/pleno_pii_scanner_postman/connector.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -94,18 +94,14 @@ class PostmanConnector:
         self._config = config
         self.id = config.resolved_id()
         if client is None:
-            self._client = httpx.AsyncClient(
-                base_url=_API_BASE, timeout=30.0
-            )
+            self._client = httpx.AsyncClient(base_url=_API_BASE, timeout=30.0)
             self._owns_client = True
         else:
             self._client = client
             self._owns_client = False
         self._headers = {"X-Api-Key": config.api_key}
         # Pre-compiled patterns so we don't re-build per finding.
-        self._interlock = [
-            re.compile(p) for p in config.interlock_patterns
-        ]
+        self._interlock = [re.compile(p) for p in config.interlock_patterns]
         # Cache for fetch(): map of ref.path → pre-rendered text.
         self._documents: dict[str, str] = {}
 
@@ -159,9 +155,7 @@ class PostmanConnector:
                     env_obj = env.get("environment", {})
                     env_name = env_obj.get("name", env_id)
                     full = f"{ws_name}/__env__/{env_name}"
-                    if filter.include and not _matches_any(
-                        full, filter.include
-                    ):
+                    if filter.include and not _matches_any(full, filter.include):
                         continue
                     if filter.exclude and _matches_any(full, filter.exclude):
                         continue
@@ -380,9 +374,7 @@ def _serialise_request(
         if isinstance(exec_lines, str):
             exec_lines = [exec_lines]
         for line in exec_lines:
-            parts.append(
-                f"script.{listen}={_resolve_vars(str(line), variables)}"
-            )
+            parts.append(f"script.{listen}={_resolve_vars(str(line), variables)}")
     for resp in responses:
         if not isinstance(resp, Mapping):
             continue
@@ -395,9 +387,7 @@ def _serialise_request(
     return "\n".join(parts)
 
 
-def _serialise_url(
-    url: Any, variables: Mapping[str, str]
-) -> str:
+def _serialise_url(url: Any, variables: Mapping[str, str]) -> str:
     if isinstance(url, str):
         return _resolve_vars(url, variables)
     if not isinstance(url, Mapping):
@@ -441,9 +431,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
         PostmanConfig(
             api_key=str(config["api_key"]),
             workspaces=tuple(str(w) for w in config.get("workspaces", ())),
-            include_environments=bool(
-                config.get("include_environments", True)
-            ),
+            include_environments=bool(config.get("include_environments", True)),
             include_examples=bool(config.get("include_examples", True)),
             interlock_patterns=tuple(
                 str(p) for p in config.get("interlock_patterns", ())

--- a/packages/pii-scanner-postman/tests/test_connector.py
+++ b/packages/pii-scanner-postman/tests/test_connector.py
@@ -151,9 +151,7 @@ def _collection_basic() -> dict:
                             "script": {"exec": ["console.log('{{api_key}}')"]},
                         }
                     ],
-                    "response": [
-                        {"name": "200-ok", "body": "Bearer real-{{api_key}}"}
-                    ],
+                    "response": [{"name": "200-ok", "body": "Bearer real-{{api_key}}"}],
                 }
             ],
         }
@@ -283,7 +281,9 @@ class TestEndToEnd:
             if path.endswith("/environments/e1"):
                 return httpx.Response(200, json=_env())
             if path.endswith("/collections/c1"):
-                return httpx.Response(200, json={"collection": {"info": {"name": "C"}, "item": []}})
+                return httpx.Response(
+                    200, json={"collection": {"info": {"name": "C"}, "item": []}}
+                )
             return httpx.Response(404)
 
         async with _client(handler) as client:
@@ -364,9 +364,7 @@ class TestEdgeCases:
         coll = {
             "collection": {
                 "info": {"name": "C"},
-                "item": [
-                    {"name": "r1", "request": "https://example.com/{{path}}"}
-                ],
+                "item": [{"name": "r1", "request": "https://example.com/{{path}}"}],
             }
         }
 
@@ -666,9 +664,7 @@ class TestFilter:
             try:
                 refs = [
                     r
-                    async for r in c.discover(
-                        SourceFilter(include=("*/users",)), None
-                    )
+                    async for r in c.discover(SourceFilter(include=("*/users",)), None)
                 ]
                 assert all(r.metadata["request_name"] == "users" for r in refs)
             finally:
@@ -698,7 +694,9 @@ class TestFilter:
             if path.endswith("/environments/e1"):
                 return httpx.Response(200, json=_env())
             if path.endswith("/collections/c1"):
-                return httpx.Response(200, json={"collection": {"info": {"name": "C"}, "item": []}})
+                return httpx.Response(
+                    200, json={"collection": {"info": {"name": "C"}, "item": []}}
+                )
             return httpx.Response(404)
 
         async with _client(handler) as client:
@@ -756,9 +754,7 @@ class TestInterlock:
 
         async with _client(handler) as client:
             c = PostmanConnector(
-                PostmanConfig(
-                    api_key="k", interlock_patterns=("AKIA[A-Z0-9]+",)
-                ),
+                PostmanConfig(api_key="k", interlock_patterns=("AKIA[A-Z0-9]+",)),
                 client=client,
             )
             try:
@@ -781,9 +777,7 @@ class TestDepthDefense:
         for i in range(105):
             node = {"name": f"f{i}", "item": [node]}
 
-        coll = {
-            "collection": {"info": {"name": "C"}, "item": [node]}
-        }
+        coll = {"collection": {"info": {"name": "C"}, "item": [node]}}
 
         def handler(request: httpx.Request) -> httpx.Response:
             path = request.url.path
@@ -1021,10 +1015,7 @@ class TestEnvIncludeFilter:
             try:
                 # Include pattern that does NOT match → env dropped
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("nope/*",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("nope/*",)), None)
                 ]
                 assert refs == []
             finally:

--- a/packages/pii-scanner-redis/src/pleno_pii_scanner_redis/connector.py
+++ b/packages/pii-scanner-redis/src/pleno_pii_scanner_redis/connector.py
@@ -52,9 +52,7 @@ from pleno_pii_scanner.sources.registry import ConnectorSpec
 
 # Redis "categories" that the scanner is allowed to use. Anything
 # beyond these is a sign the credential is over-scoped — refuse.
-_ALLOWED_CATEGORIES: frozenset[str] = frozenset(
-    {"@read", "@connection", "@keyspace"}
-)
+_ALLOWED_CATEGORIES: frozenset[str] = frozenset({"@read", "@connection", "@keyspace"})
 # Categories that, if granted, indicate an over-privileged role.
 _FORBIDDEN_CATEGORIES: frozenset[str] = frozenset(
     {"@write", "@admin", "@dangerous", "@scripting", "@all"}
@@ -244,14 +242,10 @@ class RedisConnector:
             return b"\n".join(members)
         if value_type == "hash":
             data = await self._client.hgetall(key)
-            return b"\n".join(
-                _b(f) + b"=" + _b(v) for f, v in data.items()
-            )
+            return b"\n".join(_b(f) + b"=" + _b(v) for f, v in data.items())
         if value_type == "zset":
             entries = await self._client.zrange(key, 0, -1, withscores=True)
-            return b"\n".join(
-                _b(m) + b"=" + str(s).encode() for m, s in entries
-            )
+            return b"\n".join(_b(m) + b"=" + str(s).encode() for m, s in entries)
         if value_type == "stream":
             entries = await self._client.xrange(
                 key, count=self._config.stream_max_entries
@@ -291,18 +285,13 @@ def _normalise_acl(info: Any) -> dict[str, Any]:
         return {_to_str(k): v for k, v in info.items()}
     if isinstance(info, list):
         # Redis returns flat alternating list in RESP2. Pair them.
-        return {
-            _to_str(info[i]): info[i + 1]
-            for i in range(0, len(info) - 1, 2)
-        }
+        return {_to_str(info[i]): info[i + 1] for i in range(0, len(info) - 1, 2)}
     return {}
 
 
 def _format_stream_entry(entry: tuple[Any, dict[Any, Any]]) -> bytes:
     msg_id, fields = entry
-    body = b" ".join(
-        _b(f) + b"=" + _b(v) for f, v in fields.items()
-    )
+    body = b" ".join(_b(f) + b"=" + _b(v) for f, v in fields.items())
     return _b(msg_id) + b"  " + body
 
 

--- a/packages/pii-scanner-redis/tests/test_connector.py
+++ b/packages/pii-scanner-redis/tests/test_connector.py
@@ -70,14 +70,10 @@ class _FakeRedis:
                 return self._acl_user
         raise AssertionError(f"unexpected command: {args}")
 
-    def scan_iter(
-        self, *, match: str = "*", count: int = 100
-    ) -> AsyncIterator[bytes]:
+    def scan_iter(self, *, match: str = "*", count: int = 100) -> AsyncIterator[bytes]:
         import fnmatch
 
-        keys = [
-            k for k in self._keys.keys() if fnmatch.fnmatch(k.decode(), match)
-        ]
+        keys = [k for k in self._keys.keys() if fnmatch.fnmatch(k.decode(), match)]
 
         async def _gen() -> AsyncIterator[bytes]:
             for k in keys:
@@ -181,15 +177,11 @@ class TestConfig:
 
 class TestProtocol:
     def test_runtime_isinstance(self) -> None:
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=_FakeRedis()
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=_FakeRedis())
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=_FakeRedis()
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=_FakeRedis())
         assert c.capabilities() == Capabilities(
             incremental=False,
             binary=True,
@@ -204,24 +196,16 @@ class TestProtocol:
 
 class TestAclEnforcement:
     async def test_readonly_user_passes(self) -> None:
-        client = _FakeRedis(
-            acl_user={"commands": "+@read +@connection -@write"}
-        )
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        client = _FakeRedis(acl_user={"commands": "+@read +@connection -@write"})
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             await c._enforce_acl()
         finally:
             await c.close()
 
     async def test_user_with_write_rejected(self) -> None:
-        client = _FakeRedis(
-            acl_user={"commands": "+@read +@write +@connection"}
-        )
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        client = _FakeRedis(acl_user={"commands": "+@read +@write +@connection"})
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             with pytest.raises(AclEnforcementError, match="@write"):
                 await c._enforce_acl()
@@ -229,12 +213,8 @@ class TestAclEnforcement:
             await c.close()
 
     async def test_user_with_admin_rejected(self) -> None:
-        client = _FakeRedis(
-            acl_user={"commands": "+@read +@admin"}
-        )
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        client = _FakeRedis(acl_user={"commands": "+@read +@admin"})
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             with pytest.raises(AclEnforcementError, match="@admin"):
                 await c._enforce_acl()
@@ -245,13 +225,13 @@ class TestAclEnforcement:
         # Pre-Redis 7.2 returns ACL GETUSER as a flat alternating list.
         client = _FakeRedis(
             acl_user=[
-                b"flags", [b"on"],
-                b"commands", b"+@read +@connection -@write",
+                b"flags",
+                [b"on"],
+                b"commands",
+                b"+@read +@connection -@write",
             ]
         )
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             await c._enforce_acl()
         finally:
@@ -259,9 +239,7 @@ class TestAclEnforcement:
 
     async def test_disabled_enforcement_skips_check(self) -> None:
         # Even an over-privileged user passes when enforcement is off.
-        client = _FakeRedis(
-            acl_user={"commands": "+@all"}
-        )
+        client = _FakeRedis(acl_user={"commands": "+@all"})
         c = RedisConnector(
             RedisConfig(url="redis://h", enforce_readonly=False),
             client=client,
@@ -281,9 +259,7 @@ class TestAclEnforcement:
                 return await super().execute_command(*args)
 
         client = _Counting()
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             await c._enforce_acl()
             await c._enforce_acl()
@@ -296,9 +272,7 @@ class TestAclEnforcement:
         # Defensive path — neither dict nor list. Connector should
         # not crash but also not granting privileges.
         client = _FakeRedis(acl_user="some-string")
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             # No forbidden category present in empty dict → passes.
             await c._enforce_acl()
@@ -311,13 +285,13 @@ class TestAclEnforcement:
 
 class TestDiscover:
     async def test_yields_one_ref_per_key(self) -> None:
-        client = _FakeRedis(keys={
-            b"user:1": ("string", b"alice@example.com"),
-            b"user:2": ("string", b"bob@example.com"),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"user:1": ("string", b"alice@example.com"),
+                b"user:2": ("string", b"bob@example.com"),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             paths = sorted(r.path for r in refs)
@@ -327,13 +301,13 @@ class TestDiscover:
             await c.close()
 
     async def test_match_glob_filters_keys(self) -> None:
-        client = _FakeRedis(keys={
-            b"user:1": ("string", b"x"),
-            b"session:1": ("string", b"y"),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h", match="user:*"), client=client
+        client = _FakeRedis(
+            keys={
+                b"user:1": ("string", b"x"),
+                b"session:1": ("string", b"y"),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h", match="user:*"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             assert {r.path for r in refs} == {"user:1"}
@@ -341,38 +315,32 @@ class TestDiscover:
             await c.close()
 
     async def test_source_filter_include_applied(self) -> None:
-        client = _FakeRedis(keys={
-            b"user:1": ("string", b"x"),
-            b"session:1": ("string", b"y"),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"user:1": ("string", b"x"),
+                b"session:1": ("string", b"y"),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(include=("user:*",)), None
-                )
+                r async for r in c.discover(SourceFilter(include=("user:*",)), None)
             ]
             assert {r.path for r in refs} == {"user:1"}
         finally:
             await c.close()
 
     async def test_source_filter_exclude_applied(self) -> None:
-        client = _FakeRedis(keys={
-            b"user:1": ("string", b"x"),
-            b"session:1": ("string", b"y"),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"user:1": ("string", b"x"),
+                b"session:1": ("string", b"y"),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [
-                r
-                async for r in c.discover(
-                    SourceFilter(exclude=("session:*",)), None
-                )
+                r async for r in c.discover(SourceFilter(exclude=("session:*",)), None)
             ]
             assert {r.path for r in refs} == {"user:1"}
         finally:
@@ -385,9 +353,7 @@ class TestDiscover:
                 return b"none"
 
         client = _Racing(keys={b"k": ("string", b"v")})
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             assert refs == []
@@ -401,9 +367,7 @@ class TestDiscover:
 class TestFetchString:
     async def test_returns_text(self) -> None:
         client = _FakeRedis(keys={b"k": ("string", b"hello@example.com")})
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             docs = [d async for d in c.fetch(refs[0])]
@@ -416,12 +380,12 @@ class TestFetchString:
 
 class TestFetchList:
     async def test_joins_entries_newline(self) -> None:
-        client = _FakeRedis(keys={
-            b"q": ("list", [b"first", b"second", b"third"]),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"q": ("list", [b"first", b"second", b"third"]),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             docs = [d async for d in c.fetch(refs[0])]
@@ -432,12 +396,12 @@ class TestFetchList:
 
 class TestFetchSet:
     async def test_sorted_join(self) -> None:
-        client = _FakeRedis(keys={
-            b"s": ("set", {b"banana", b"apple", b"cherry"}),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"s": ("set", {b"banana", b"apple", b"cherry"}),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             docs = [d async for d in c.fetch(refs[0])]
@@ -449,12 +413,12 @@ class TestFetchSet:
 
 class TestFetchHash:
     async def test_field_value_lines(self) -> None:
-        client = _FakeRedis(keys={
-            b"h": ("hash", {b"email": b"x@y.z", b"name": b"alice"}),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"h": ("hash", {b"email": b"x@y.z", b"name": b"alice"}),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             docs = [d async for d in c.fetch(refs[0])]
@@ -466,12 +430,12 @@ class TestFetchHash:
 
 class TestFetchZset:
     async def test_member_score(self) -> None:
-        client = _FakeRedis(keys={
-            b"z": ("zset", [(b"alice", 1.0), (b"bob", 2.5)]),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"z": ("zset", [(b"alice", 1.0), (b"bob", 2.5)]),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             docs = [d async for d in c.fetch(refs[0])]
@@ -483,15 +447,15 @@ class TestFetchZset:
 
 class TestFetchStream:
     async def test_id_and_fields(self) -> None:
-        client = _FakeRedis(keys={
-            b"x": (
-                "stream",
-                [(b"1700000000000-0", {b"event": b"login", b"user": b"alice"})],
-            ),
-        })
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
+        client = _FakeRedis(
+            keys={
+                b"x": (
+                    "stream",
+                    [(b"1700000000000-0", {b"event": b"login", b"user": b"alice"})],
+                ),
+            }
         )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             docs = [d async for d in c.fetch(refs[0])]
@@ -505,9 +469,7 @@ class TestFetchStream:
 class TestFetchEdge:
     async def test_unknown_type_returns_no_documents(self) -> None:
         client = _FakeRedis(keys={b"k": ("hyperloglog", b"\x00")})
-        c = RedisConnector(
-            RedisConfig(url="redis://h"), client=client
-        )
+        c = RedisConnector(RedisConfig(url="redis://h"), client=client)
         try:
             refs = [r async for r in c.discover(SourceFilter(), None)]
             # discover still yields the ref; fetch is the type filter.

--- a/packages/pii-scanner-salesforce/src/pleno_pii_scanner_salesforce/connector.py
+++ b/packages/pii-scanner-salesforce/src/pleno_pii_scanner_salesforce/connector.py
@@ -292,8 +292,7 @@ class SalesforceConnector:
 
     async def _describe_fields(self, sobject: str) -> tuple[str, ...]:
         body = await self._get_json(
-            f"/services/data/{self._config.api_version}"
-            f"/sobjects/{sobject}/describe"
+            f"/services/data/{self._config.api_version}/sobjects/{sobject}/describe"
         )
         out: list[str] = []
         for entry in body.get("fields", []) or []:
@@ -328,9 +327,7 @@ class SalesforceConnector:
             resp = await self._client.post(
                 f"{_LOGIN_HOST}{_TOKEN_PATH}",
                 data={
-                    "grant_type": (
-                        "urn:ietf:params:oauth:grant-type:jwt-bearer"
-                    ),
+                    "grant_type": ("urn:ietf:params:oauth:grant-type:jwt-bearer"),
                     "assertion": assertion,
                 },
             )
@@ -338,9 +335,7 @@ class SalesforceConnector:
             body = resp.json()
             access = body.get("access_token")
             if not isinstance(access, str) or not access:
-                raise ValueError(
-                    "Salesforce token endpoint returned no access_token"
-                )
+                raise ValueError("Salesforce token endpoint returned no access_token")
             # Salesforce does not return `expires_in` on the JWT bearer
             # response; tokens default to the org's session timeout
             # (typically 2 h). Cache for 1 h to bound staleness.
@@ -480,9 +475,7 @@ def _parse_iso(value: Any) -> datetime | None:
 def _factory(config: Mapping[str, Any]) -> SourceConnector:
     for required in ("instance_url", "client_id", "username", "private_key_pem"):
         if required not in config:
-            raise ValueError(
-                f"salesforce connector config requires {required!r}"
-            )
+            raise ValueError(f"salesforce connector config requires {required!r}")
     sobjects_raw = config.get("sobjects", _DEFAULT_SOBJECTS)
     sobjects = tuple(str(s) for s in sobjects_raw)
     return SalesforceConnector(

--- a/packages/pii-scanner-salesforce/tests/test_connector.py
+++ b/packages/pii-scanner-salesforce/tests/test_connector.py
@@ -73,9 +73,7 @@ def _stub_token(c: SalesforceConnector) -> None:
 
 
 def _describe_response(*field_names: str) -> dict[str, object]:
-    return {
-        "fields": [{"name": n, "type": "string"} for n in field_names]
-    }
+    return {"fields": [{"name": n, "type": "string"} for n in field_names]}
 
 
 # --- config --------------------------------------------------------
@@ -159,16 +157,12 @@ def _sobject_handler(
             seen_authorisations.append(request.headers.get("Authorization", ""))
         path_with_query = request.url.path
         if request.url.query:
-            path_with_query = (
-                f"{request.url.path}?{request.url.query.decode()}"
-            )
+            path_with_query = f"{request.url.path}?{request.url.query.decode()}"
         if seen_paths is not None:
             seen_paths.append(path_with_query)
         # describe
         for sobject, fields in fields_by_sobject.items():
-            if request.url.path.endswith(
-                f"/sobjects/{sobject}/describe"
-            ):
+            if request.url.path.endswith(f"/sobjects/{sobject}/describe"):
                 return httpx.Response(200, json=_describe_response(*fields))
         # initial query — match by sobject name in the q= param
         if request.url.path.endswith("/query"):
@@ -222,9 +216,7 @@ class TestDiscover:
             },
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -244,15 +236,11 @@ class TestDiscover:
         seen: list[str] = []
         handler = _sobject_handler(
             fields_by_sobject={"Case": ("Subject",)},
-            pages_by_sobject={
-                "Case": [{"done": True, "totalSize": 0, "records": []}]
-            },
+            pages_by_sobject={"Case": [{"done": True, "totalSize": 0, "records": []}]},
             seen_authorisations=seen,
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 _ = [r async for r in c.discover(SourceFilter(), None)]
@@ -267,15 +255,11 @@ class TestDiscover:
             fields_by_sobject={
                 "Case": ("Subject", "Description", "OwnerId"),
             },
-            pages_by_sobject={
-                "Case": [{"done": True, "totalSize": 0, "records": []}]
-            },
+            pages_by_sobject={"Case": [{"done": True, "totalSize": 0, "records": []}]},
             seen_paths=seen_paths,
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 _ = [r async for r in c.discover(SourceFilter(), None)]
@@ -322,9 +306,7 @@ class TestDiscover:
             pages_by_sobject={"Case": [page_one, page_two]},
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -357,9 +339,7 @@ class TestDiscover:
             pages_by_sobject={"Case": [page_one, {"done": True, "records": []}]},
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 gen = c.discover(SourceFilter(), None)
@@ -397,9 +377,7 @@ class TestDiscover:
             )
 
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             cursor = json.dumps({"Case": resume_path}, sort_keys=True)
             try:
@@ -430,9 +408,7 @@ class TestDiscover:
             },
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -469,9 +445,7 @@ class TestDiscover:
             },
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 refs = [r async for r in c.discover(SourceFilter(), None)]
@@ -490,9 +464,6 @@ class TestMultiSObject:
         def handler(request: httpx.Request) -> httpx.Response:
             if "/describe" in request.url.path:
                 described.append(request.url.path)
-                # Extract sobject name between /sobjects/ and /describe
-                segs = request.url.path.split("/sobjects/")
-                sobj = segs[1].split("/", 1)[0]
                 return httpx.Response(200, json=_describe_response("Id"))
             if request.url.path.endswith("/query"):
                 return httpx.Response(
@@ -525,15 +496,11 @@ class TestFilter:
         handler = _sobject_handler(
             fields_by_sobject={"Case": ("Subject",)},
             pages_by_sobject={
-                "Case": [
-                    {"done": True, "totalSize": 2, "records": records}
-                ]
+                "Case": [{"done": True, "totalSize": 2, "records": records}]
             },
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 refs = [
@@ -554,15 +521,11 @@ class TestFilter:
         handler = _sobject_handler(
             fields_by_sobject={"Case": ("Subject",)},
             pages_by_sobject={
-                "Case": [
-                    {"done": True, "totalSize": 2, "records": records}
-                ]
+                "Case": [{"done": True, "totalSize": 2, "records": records}]
             },
         )
         async with _client(handler) as client:
-            c = SalesforceConnector(
-                _make_config(sobjects=("Case",)), client=client
-            )
+            c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
             _stub_token(c)
             try:
                 refs = [
@@ -620,7 +583,9 @@ class TestJwtBearerFlow:
                 await c.close()
         body = captured["body"]
         assert isinstance(body, str)
-        assert "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer" in body
+        assert (
+            "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer" in body
+        )
         assert "assertion=" in body
         assertion = body.split("assertion=", 1)[1].split("&", 1)[0]
         # Three parts: header.payload.signature
@@ -687,9 +652,7 @@ def _b64url_decode(s: str) -> bytes:
 
 class TestSoql:
     def test_id_always_first_and_deduplicated(self) -> None:
-        sql = _connector_mod._build_soql(
-            "Case", ("Id", "Subject", "id", "Description")
-        )
+        sql = _connector_mod._build_soql("Case", ("Id", "Subject", "id", "Description"))
         # Id appears once, first, regardless of describe casing.
         assert sql.startswith("SELECT Id, ")
         # 'id' duplicate suppressed; other fields preserved in order.
@@ -746,8 +709,6 @@ class TestHelpers:
     def test_describe_skips_non_mapping_field_entries(self) -> None:
         # Defensive: malformed describe payload must not crash.
         async def run() -> tuple[str, ...]:
-            seen: list[str] = []
-
             def handler(request: httpx.Request) -> httpx.Response:
                 if "/describe" in request.url.path:
                     return httpx.Response(
@@ -764,9 +725,7 @@ class TestHelpers:
                 return httpx.Response(404)
 
             async with _client(handler) as client:
-                c = SalesforceConnector(
-                    _make_config(sobjects=("Case",)), client=client
-                )
+                c = SalesforceConnector(_make_config(sobjects=("Case",)), client=client)
                 _stub_token(c)
                 try:
                     return await c._describe_fields("Case")
@@ -889,9 +848,7 @@ class TestRsaSigning:
         ).decode("utf-8")
         sig = _connector_mod._rs256_sign(pem, b"hello")
         # Verify with the matching public key.
-        private.public_key().verify(
-            sig, b"hello", padding.PKCS1v15(), hashes.SHA256()
-        )
+        private.public_key().verify(sig, b"hello", padding.PKCS1v15(), hashes.SHA256())
 
     def test_assertion_layout(self) -> None:
         from cryptography.hazmat.primitives import serialization
@@ -919,8 +876,4 @@ class TestRsaSigning:
         assert payload["aud"] == "https://login.salesforce.com"
         # `exp` exactly 180 s after `iat` (Salesforce 5-min cap, our 3-min
         # safety margin).
-        assert (
-            payload["exp"]
-            == int(datetime(2026, 1, 1, tzinfo=UTC).timestamp())
-            + 180
-        )
+        assert payload["exp"] == int(datetime(2026, 1, 1, tzinfo=UTC).timestamp()) + 180

--- a/packages/pii-scanner-sharepoint/src/pleno_pii_scanner_sharepoint/connector.py
+++ b/packages/pii-scanner-sharepoint/src/pleno_pii_scanner_sharepoint/connector.py
@@ -33,11 +33,10 @@ operators to pin `sites=` to the granted set; falling back to
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import time
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -66,9 +65,7 @@ _TOKEN_URL = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
 
 # JWT-bearer client_assertion grant per RFC 7521/7523. Required when
 # we substitute a federated OIDC JWT for a client_secret.
-_CLIENT_ASSERTION_TYPE = (
-    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-)
+_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 # Default Graph scope for application credentials. `/.default` requests
 # the union of pre-consented application permissions registered on the
@@ -153,9 +150,7 @@ class SharePointConnector:
         self._config = config
         self.id = config.resolved_id()
         if client is None:
-            self._client = httpx.AsyncClient(
-                base_url=_GRAPH_BASE, timeout=30.0
-            )
+            self._client = httpx.AsyncClient(base_url=_GRAPH_BASE, timeout=30.0)
             self._owns_client = True
         else:
             self._client = client
@@ -243,10 +238,7 @@ class SharePointConnector:
 
     async def _bearer(self) -> str:
         cached = self._cached
-        if (
-            cached is not None
-            and cached.expires_at - _TOKEN_SKEW_SECONDS > self._now()
-        ):
+        if cached is not None and cached.expires_at - _TOKEN_SKEW_SECONDS > self._now():
             return cached.token
         async with self._token_lock:
             cached = self._cached
@@ -282,9 +274,7 @@ class SharePointConnector:
         payload = resp.json()
         token = payload["access_token"]
         expires_in = payload.get("expires_in", 3600)
-        return _CachedBearer(
-            token=token, expires_at=self._now() + float(expires_in)
-        )
+        return _CachedBearer(token=token, expires_at=self._now() + float(expires_in))
 
     async def _auth_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {await self._bearer()}"}
@@ -331,8 +321,7 @@ class SharePointConnector:
         # Initial run hits the bare delta endpoint; resume re-uses the
         # absolute deltaLink the service handed back last time.
         next_url: str | None = (
-            resume_link
-            or f"/v1.0/sites/{site_id}/drives/{drive_id}/root/delta"
+            resume_link or f"/v1.0/sites/{site_id}/drives/{drive_id}/root/delta"
         )
         while next_url is not None:
             payload = await self._get_json(next_url)
@@ -382,15 +371,11 @@ class SharePointConnector:
                 # bookkeeping prefix so the rendered path is clean.
                 _, _, parent_path = raw.partition("root:")
                 parent_path = parent_path.lstrip("/")
-        full_path = "/".join(
-            p for p in (site_name, drive_name, parent_path, name) if p
-        )
+        full_path = "/".join(p for p in (site_name, drive_name, parent_path, name) if p)
         size = item.get("size")
         file_facet = item.get("file") or {}
         mime = (
-            file_facet.get("mimeType")
-            if isinstance(file_facet, Mapping)
-            else None
+            file_facet.get("mimeType") if isinstance(file_facet, Mapping) else None
         ) or "application/octet-stream"
         etag = item.get("eTag") or item.get("cTag")
         last_modified_str = item.get("lastModifiedDateTime")
@@ -455,10 +440,7 @@ class SharePointConnector:
     async def _fetch_file(
         self, ref: DocumentRef
     ) -> AsyncIterator[Document | DocumentChunk]:
-        if (
-            ref.size is not None
-            and ref.size > self._config.max_file_size_bytes
-        ):
+        if ref.size is not None and ref.size > self._config.max_file_size_bytes:
             # Surface the skip via empty fetch — the discover ref still
             # exists for auditing.
             return

--- a/packages/pii-scanner-sharepoint/tests/test_connector.py
+++ b/packages/pii-scanner-sharepoint/tests/test_connector.py
@@ -40,9 +40,7 @@ def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.AsyncCl
 
 
 def _ok_token(_request: httpx.Request) -> httpx.Response:
-    return httpx.Response(
-        200, json={"access_token": "AAA", "expires_in": 3600}
-    )
+    return httpx.Response(200, json={"access_token": "AAA", "expires_in": 3600})
 
 
 def _make_handler(
@@ -73,19 +71,13 @@ def _make_handler(
                 from urllib.parse import parse_qs
 
                 body = request.content.decode("utf-8")
-                token_calls.append(
-                    {k: v[0] for k, v in parse_qs(body).items()}
-                )
-            return httpx.Response(
-                200, json={"access_token": "AAA", "expires_in": 3600}
-            )
+                token_calls.append({k: v[0] for k, v in parse_qs(body).items()})
+            return httpx.Response(200, json={"access_token": "AAA", "expires_in": 3600})
         if path == "/v1.0/sites" and request.url.params.get("search") == "*":
             return httpx.Response(200, json={"value": sites})
         if path.startswith("/v1.0/sites/") and path.endswith("/drives"):
             site_id = path.split("/")[3]
-            return httpx.Response(
-                200, json={"value": drives_by_site.get(site_id, [])}
-            )
+            return httpx.Response(200, json={"value": drives_by_site.get(site_id, [])})
         if "/root/delta" in path or url in delta_pages:
             # Resume URLs are absolute; initial path is relative.
             page_key = url if url in delta_pages else path
@@ -96,23 +88,15 @@ def _make_handler(
             return httpx.Response(200, json={"value": []})
         if path.startswith("/v1.0/sites/") and path.endswith("/lists"):
             site_id = path.split("/")[3]
-            return httpx.Response(
-                200, json={"value": lists_by_site.get(site_id, [])}
-            )
+            return httpx.Response(200, json={"value": lists_by_site.get(site_id, [])})
         if (
             path.startswith("/v1.0/sites/")
             and "/lists/" in path
             and path.endswith("/items")
         ):
             list_id = path.split("/")[5]
-            return httpx.Response(
-                200, json={"value": list_items.get(list_id, [])}
-            )
-        if (
-            path.startswith("/v1.0/sites/")
-            and "/lists/" in path
-            and "/items/" in path
-        ):
+            return httpx.Response(200, json={"value": list_items.get(list_id, [])})
+        if path.startswith("/v1.0/sites/") and "/lists/" in path and "/items/" in path:
             item_id = path.split("/items/")[1]
             return httpx.Response(
                 200, json=list_item_detail.get(item_id, {"fields": {}})
@@ -123,9 +107,7 @@ def _make_handler(
             return httpx.Response(200, content=blob)
         if path.startswith("/v1.0/sites/") and path.count("/") == 3:
             # /v1.0/sites/{path-form} resolved site lookup.
-            return httpx.Response(
-                200, json={"id": "resolved-site", "name": "resolved"}
-            )
+            return httpx.Response(200, json={"id": "resolved-site", "name": "resolved"})
         return httpx.Response(404, content=str(request.url).encode())
 
     return handler
@@ -137,15 +119,11 @@ def _make_handler(
 class TestConfig:
     def test_rejects_empty_tenant_id(self) -> None:
         with pytest.raises(ValueError, match="tenant_id"):
-            SharePointConfig(
-                tenant_id="", client_id="c", client_secret="s"
-            )
+            SharePointConfig(tenant_id="", client_id="c", client_secret="s")
 
     def test_rejects_empty_client_id(self) -> None:
         with pytest.raises(ValueError, match="client_id"):
-            SharePointConfig(
-                tenant_id="t", client_id="", client_secret="s"
-            )
+            SharePointConfig(tenant_id="t", client_id="", client_secret="s")
 
     def test_rejects_neither_credential(self) -> None:
         with pytest.raises(ValueError, match="exactly one"):
@@ -176,9 +154,7 @@ class TestConfig:
         assert cfg.resolved_id() == "custom"
 
     def test_default_id_includes_tenant_and_client(self) -> None:
-        cfg = SharePointConfig(
-            tenant_id="t", client_id="c", client_secret="s"
-        )
+        cfg = SharePointConfig(tenant_id="t", client_id="c", client_secret="s")
         rid = cfg.resolved_id()
         assert "t" in rid and "c" in rid
 
@@ -198,17 +174,13 @@ class TestConfig:
 class TestProtocol:
     def test_runtime_isinstance(self) -> None:
         c = SharePointConnector(
-            SharePointConfig(
-                tenant_id="t", client_id="c", client_secret="s"
-            )
+            SharePointConfig(tenant_id="t", client_id="c", client_secret="s")
         )
         assert isinstance(c, SourceConnector)
 
     def test_capabilities(self) -> None:
         c = SharePointConnector(
-            SharePointConfig(
-                tenant_id="t", client_id="c", client_secret="s"
-            )
+            SharePointConfig(tenant_id="t", client_id="c", client_secret="s")
         )
         assert c.capabilities() == Capabilities(
             incremental=True,
@@ -348,9 +320,7 @@ class TestDelta:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -385,9 +355,7 @@ class TestDelta:
         prior = json.dumps({"s1/d1": "https://graph.microsoft.com/delta-resume"})
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -418,9 +386,7 @@ class TestDelta:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -444,9 +410,7 @@ class TestDelta:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -463,9 +427,7 @@ class TestDelta:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -543,9 +505,7 @@ class TestLists:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -575,9 +535,7 @@ class TestFetch:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -609,9 +567,7 @@ class TestFetch:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -640,9 +596,7 @@ class TestFetch:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -691,9 +645,7 @@ class TestFetch:
 
         async with _client(_make_handler()) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -708,9 +660,7 @@ class TestFetch:
 
         async with _client(_make_handler()) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -730,9 +680,7 @@ class TestFetch:
 
         async with _client(_make_handler()) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -817,9 +765,7 @@ class TestSitesAllowlist:
             if "login.microsoftonline" in url:
                 return _ok_token(request)
             if path == "/v1.0/sites/contoso.sharepoint.com:/sites/team":
-                return httpx.Response(
-                    200, json={"id": "resolved-1", "name": "team"}
-                )
+                return httpx.Response(200, json={"id": "resolved-1", "name": "team"})
             if path.startswith("/v1.0/sites/resolved-1/drives"):
                 return httpx.Response(200, json={"value": []})
             return httpx.Response(404)
@@ -863,17 +809,12 @@ class TestFilter:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
                 refs = [
-                    r
-                    async for r in c.discover(
-                        SourceFilter(include=("*keep*",)), None
-                    )
+                    r async for r in c.discover(SourceFilter(include=("*keep*",)), None)
                 ]
                 assert {r.metadata["name"] for r in refs} == {"keep.txt"}
             finally:
@@ -899,17 +840,13 @@ class TestFilter:
                 transport=httpx.MockTransport(handler2),
             )
             c2 = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client2,
             )
             try:
                 refs = [
                     r
-                    async for r in c2.discover(
-                        SourceFilter(exclude=("*drop*",)), None
-                    )
+                    async for r in c2.discover(SourceFilter(exclude=("*drop*",)), None)
                 ]
                 assert {r.metadata["name"] for r in refs} == {"keep.txt"}
             finally:
@@ -967,9 +904,7 @@ class TestRefEdges:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -996,9 +931,7 @@ class TestRefEdges:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -1026,9 +959,7 @@ class TestRefEdges:
         )
         async with _client(handler) as client:
             c = SharePointConnector(
-                SharePointConfig(
-                    tenant_id="t", client_id="c", client_secret="s"
-                ),
+                SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
                 client=client,
             )
             try:
@@ -1094,18 +1025,14 @@ class TestSpec:
 class TestClose:
     async def test_close_owns_client(self) -> None:
         c = SharePointConnector(
-            SharePointConfig(
-                tenant_id="t", client_id="c", client_secret="s"
-            )
+            SharePointConfig(tenant_id="t", client_id="c", client_secret="s")
         )
         await c.close()
 
     async def test_close_external_client_not_closed(self) -> None:
         client = httpx.AsyncClient()
         c = SharePointConnector(
-            SharePointConfig(
-                tenant_id="t", client_id="c", client_secret="s"
-            ),
+            SharePointConfig(tenant_id="t", client_id="c", client_secret="s"),
             client=client,
         )
         await c.close()

--- a/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/_files.py
+++ b/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/_files.py
@@ -29,12 +29,56 @@ import httpx
 # path at the connector boundary.
 _TEXT_LIKE_EXTENSIONS: frozenset[str] = frozenset(
     {
-        "py", "pyi", "js", "ts", "tsx", "jsx", "rb", "go", "rs", "java",
-        "kt", "swift", "c", "cc", "cpp", "h", "hpp", "cs", "php", "scala",
-        "sh", "bash", "zsh", "ps1", "lua", "r", "sql", "yaml", "yml",
-        "toml", "ini", "cfg", "conf", "json", "ndjson", "jsonl", "xml",
-        "html", "htm", "css", "scss", "less", "md", "rst", "tex", "csv",
-        "tsv", "log", "env", "dockerfile",
+        "py",
+        "pyi",
+        "js",
+        "ts",
+        "tsx",
+        "jsx",
+        "rb",
+        "go",
+        "rs",
+        "java",
+        "kt",
+        "swift",
+        "c",
+        "cc",
+        "cpp",
+        "h",
+        "hpp",
+        "cs",
+        "php",
+        "scala",
+        "sh",
+        "bash",
+        "zsh",
+        "ps1",
+        "lua",
+        "r",
+        "sql",
+        "yaml",
+        "yml",
+        "toml",
+        "ini",
+        "cfg",
+        "conf",
+        "json",
+        "ndjson",
+        "jsonl",
+        "xml",
+        "html",
+        "htm",
+        "css",
+        "scss",
+        "less",
+        "md",
+        "rst",
+        "tex",
+        "csv",
+        "tsv",
+        "log",
+        "env",
+        "dockerfile",
     }
 )
 
@@ -49,9 +93,7 @@ class FileBody:
 
     def __post_init__(self) -> None:
         if (self.text is None) == (self.binary is None):
-            raise ValueError(
-                "FileBody must populate exactly one of text or binary"
-            )
+            raise ValueError("FileBody must populate exactly one of text or binary")
 
 
 def is_text_like(mimetype: str | None, name: str | None) -> bool:
@@ -110,8 +152,8 @@ async def download_file(
         follow_redirects=True,
     )
     response.raise_for_status()
-    content_type = (
-        response.headers.get("Content-Type", mimetype or "application/octet-stream")
+    content_type = response.headers.get(
+        "Content-Type", mimetype or "application/octet-stream"
     )
     raw = response.content
     if is_text_like(mimetype, name) or content_type.lower().startswith("text/"):

--- a/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/_rate.py
+++ b/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/_rate.py
@@ -65,9 +65,7 @@ def raise_from_slack_api_error(exc: SlackApiError) -> None:
     if status == 429 or error_str == "ratelimited":
         headers = getattr(response, "headers", {}) or {}
         retry_after = _retry_after_seconds(headers)
-        raise RateLimited(
-            _format_message("slack rate limited", retry_after)
-        ) from exc
+        raise RateLimited(_format_message("slack rate limited", retry_after)) from exc
 
 
 @contextlib.asynccontextmanager

--- a/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/connector.py
+++ b/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/connector.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -297,9 +297,7 @@ class SlackConnector:
             )
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 429:
-                raise RateLimited(
-                    "slack file download rate limited"
-                ) from exc
+                raise RateLimited("slack file download rate limited") from exc
             raise
         principal = await self._principal_for(client, file_obj.get("user"))
         yield Document(
@@ -342,7 +340,11 @@ class SlackConnector:
             display_name = (
                 user_obj.get("real_name")
                 or user_obj.get("name")
-                or (profile.get("display_name") if isinstance(profile, Mapping) else None)
+                or (
+                    profile.get("display_name")
+                    if isinstance(profile, Mapping)
+                    else None
+                )
             )
             email = profile.get("email") if isinstance(profile, Mapping) else None
             principal = Principal(
@@ -402,7 +404,9 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
         SlackConfig(
             token=token,
             id=str(config["id"]) if config.get("id") is not None else None,
-            team_id=str(config["team_id"]) if config.get("team_id") is not None else None,
+            team_id=str(config["team_id"])
+            if config.get("team_id") is not None
+            else None,
             enterprise_id=(
                 str(config["enterprise_id"])
                 if config.get("enterprise_id") is not None

--- a/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/conversations.py
+++ b/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/conversations.py
@@ -64,7 +64,7 @@ async def _paginate(
         # .get(); the test doubles below mirror that surface.
         yield dict(page.data) if hasattr(page, "data") else dict(page)
         next_cursor = ""
-        meta = (page.get("response_metadata") if hasattr(page, "get") else None)
+        meta = page.get("response_metadata") if hasattr(page, "get") else None
         if meta:
             next_cursor = meta.get("next_cursor", "") or ""
         if not next_cursor:
@@ -256,9 +256,7 @@ async def _yield_thread_replies(
         "ts": thread_ts,
         "limit": _HISTORY_PAGE,
     }
-    async for page in _paginate(
-        method=client.conversations_replies, base_kwargs=base
-    ):
+    async for page in _paginate(method=client.conversations_replies, base_kwargs=base):
         messages = page.get("messages", [])
         for message in sorted(messages, key=lambda m: float(m.get("ts", 0))):
             ts = str(message["ts"])

--- a/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/discovery.py
+++ b/packages/pii-scanner-slack/src/pleno_pii_scanner_slack/discovery.py
@@ -53,7 +53,7 @@ async def _paginate(
             page = await method(**kwargs)
         yield dict(page.data) if hasattr(page, "data") else dict(page)
         next_cursor = ""
-        meta = (page.get("response_metadata") if hasattr(page, "get") else None)
+        meta = page.get("response_metadata") if hasattr(page, "get") else None
         if meta:
             next_cursor = meta.get("next_cursor", "") or ""
         if not next_cursor:
@@ -197,10 +197,7 @@ async def discover_via_discovery(
                     )
                     if include_files:
                         for file_obj in message.get("files") or ():
-                            if (
-                                isinstance(file_obj, Mapping)
-                                and file_obj.get("id")
-                            ):
+                            if isinstance(file_obj, Mapping) and file_obj.get("id"):
                                 yield _build_discovery_file_ref(
                                     source_id=source_id,
                                     team_id=team_id,

--- a/packages/pii-scanner-slack/tests/test_connector.py
+++ b/packages/pii-scanner-slack/tests/test_connector.py
@@ -65,9 +65,7 @@ class TestProtocol:
         assert c.id == "slack:bot:T1"
 
     def test_resolved_id_org(self) -> None:
-        c = SlackConnector(
-            SlackConfig(token="xoxa-1", enterprise_id="E1")
-        )
+        c = SlackConnector(SlackConfig(token="xoxa-1", enterprise_id="E1"))
         assert c.id == "slack:org:E1"
 
     def test_resolved_id_unknown_scope(self) -> None:
@@ -101,7 +99,10 @@ class TestDiscoverConversations:
         fake = FakeAsyncWebClient()
         fake.script("auth_test", FakeResponse({"team_id": "T9", "ok": True}))
         fake.script("conversations_list", _list_resp([{"id": "C1"}]))
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U", "text": "x"}]))
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U", "text": "x"}]),
+        )
         c = SlackConnector(
             SlackConfig(token="xoxb-test"),
             client_factory=make_client_factory(fake),
@@ -116,7 +117,10 @@ class TestDiscoverConversations:
         fake = FakeAsyncWebClient()
         # No auth_test scripted — would AssertionError if called.
         fake.script("conversations_list", _list_resp([{"id": "C1"}]))
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U", "text": "x"}]))
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U", "text": "x"}]),
+        )
         c = SlackConnector(
             SlackConfig(token="xoxb-test", team_id="T1"),
             client_factory=make_client_factory(fake),
@@ -141,7 +145,9 @@ class TestDiscoverConversations:
         finally:
             await c.close()
         # The history call must have been made with oldest=500.0.
-        history_call = next(call for call in fake.calls if call[0] == "conversations_history")
+        history_call = next(
+            call for call in fake.calls if call[0] == "conversations_history"
+        )
         assert history_call[1]["oldest"] == "500.0"
         assert refs == []
 
@@ -240,8 +246,14 @@ class TestFetchMessage:
 
     async def test_principal_cache_hits_once(self) -> None:
         fake = FakeAsyncWebClient()
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U1", "text": "a"}]))
-        fake.script("conversations_history", _hist_resp([{"ts": "2.0", "user": "U1", "text": "b"}]))
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U1", "text": "a"}]),
+        )
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "2.0", "user": "U1", "text": "b"}]),
+        )
         fake.script(
             "users_info",
             FakeResponse({"user": {"id": "U1", "real_name": "Alice"}}),
@@ -274,11 +286,12 @@ class TestFetchMessage:
 
     async def test_principal_disabled(self) -> None:
         fake = FakeAsyncWebClient()
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U1", "text": "a"}]))
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U1", "text": "a"}]),
+        )
         c = SlackConnector(
-            SlackConfig(
-                token="xoxb-x", team_id="T1", fetch_user_principal=False
-            ),
+            SlackConfig(token="xoxb-x", team_id="T1", fetch_user_principal=False),
             client_factory=make_client_factory(fake),
         )
         try:
@@ -296,8 +309,13 @@ class TestFetchMessage:
 
     async def test_principal_fallback_when_user_not_found(self) -> None:
         fake = FakeAsyncWebClient()
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U1", "text": "x"}]))
-        err_resp = FakeResponse({"ok": False, "error": "user_not_found"}, status_code=200)
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U1", "text": "x"}]),
+        )
+        err_resp = FakeResponse(
+            {"ok": False, "error": "user_not_found"}, status_code=200
+        )
         fake.script("users_info", SlackApiError("nope", err_resp))
         c = SlackConnector(
             SlackConfig(token="xoxb-x", team_id="T1"),
@@ -319,8 +337,13 @@ class TestFetchMessage:
 
     async def test_principal_users_info_unexpected_error_raises(self) -> None:
         fake = FakeAsyncWebClient()
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U1", "text": "x"}]))
-        err_resp = FakeResponse({"ok": False, "error": "internal_error"}, status_code=500)
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U1", "text": "x"}]),
+        )
+        err_resp = FakeResponse(
+            {"ok": False, "error": "internal_error"}, status_code=500
+        )
         fake.script("users_info", SlackApiError("boom", err_resp))
         c = SlackConnector(
             SlackConfig(token="xoxb-x", team_id="T1"),
@@ -361,7 +384,10 @@ class TestFetchMessage:
 
     async def test_principal_minimal_when_user_payload_missing(self) -> None:
         fake = FakeAsyncWebClient()
-        fake.script("conversations_history", _hist_resp([{"ts": "1.0", "user": "U2", "text": "x"}]))
+        fake.script(
+            "conversations_history",
+            _hist_resp([{"ts": "1.0", "user": "U2", "text": "x"}]),
+        )
         # users.info returns ok=true but with no user object — strange,
         # but Slack has been observed to return this on permission denial.
         fake.script("users_info", FakeResponse({"ok": True}))
@@ -384,7 +410,9 @@ class TestFetchMessage:
 
     async def test_message_not_in_channel_returns_empty(self) -> None:
         fake = FakeAsyncWebClient()
-        err_resp = FakeResponse({"ok": False, "error": "not_in_channel"}, status_code=200)
+        err_resp = FakeResponse(
+            {"ok": False, "error": "not_in_channel"}, status_code=200
+        )
         fake.script("conversations_history", SlackApiError("nope", err_resp))
         c = SlackConnector(
             SlackConfig(token="xoxb-x", team_id="T1"),
@@ -592,7 +620,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             docs = [d async for d in c.fetch(ref)]
         finally:
@@ -617,7 +651,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             with pytest.raises(RateLimited):
                 [d async for d in c.fetch(ref)]
@@ -638,7 +678,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             with pytest.raises(SlackApiError):
                 [d async for d in c.fetch(ref)]
@@ -663,7 +709,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             docs = [d async for d in c.fetch(ref)]
         finally:
@@ -683,7 +735,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             docs = [d async for d in c.fetch(ref)]
         finally:
@@ -709,7 +767,9 @@ class TestFetchFile:
 
         def handler(request: httpx.Request) -> httpx.Response:
             called["url"] = str(request.url)
-            return httpx.Response(200, content=b"ok", headers={"Content-Type": "text/plain"})
+            return httpx.Response(
+                200, content=b"ok", headers={"Content-Type": "text/plain"}
+            )
 
         c = SlackConnector(
             SlackConfig(token="xoxb-x", team_id="T1"),
@@ -721,7 +781,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             docs = [d async for d in c.fetch(ref)]
         finally:
@@ -757,7 +823,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             with pytest.raises(RateLimited):
                 [d async for d in c.fetch(ref)]
@@ -792,7 +864,13 @@ class TestFetchFile:
                 source_id=c.id,
                 source_kind="slack",
                 path="slack://T1/C1/1.0/files/F1",
-                metadata={"channel_id": "C1", "team_id": "T1", "ts": "1.0", "file_id": "F1", "parent_ts": "1.0"},
+                metadata={
+                    "channel_id": "C1",
+                    "team_id": "T1",
+                    "ts": "1.0",
+                    "file_id": "F1",
+                    "parent_ts": "1.0",
+                },
             )
             with pytest.raises(httpx.HTTPStatusError):
                 [d async for d in c.fetch(ref)]

--- a/packages/pii-scanner-slack/tests/test_conversations.py
+++ b/packages/pii-scanner-slack/tests/test_conversations.py
@@ -100,8 +100,12 @@ class TestPagination:
         client = FakeAsyncWebClient()
         client.script("conversations_list", _channels("C01", "more"))
         client.script("conversations_list", _channels("C02", ""))
-        client.script("conversations_history", _history([{"ts": "1.0", "user": "U", "text": "a"}]))
-        client.script("conversations_history", _history([{"ts": "2.0", "user": "U", "text": "b"}]))
+        client.script(
+            "conversations_history", _history([{"ts": "1.0", "user": "U", "text": "a"}])
+        )
+        client.script(
+            "conversations_history", _history([{"ts": "2.0", "user": "U", "text": "b"}])
+        )
         cursor_state: dict[str, str] = {}
         refs = [
             r
@@ -202,9 +206,10 @@ class TestThreadReplies:
             )
         ]
         assert len(refs) == 1
-        assert ("conversations_replies", {"channel": "C01", "ts": "1.0", "limit": 200}) not in [
-            (m, k) for m, k in client.calls
-        ]
+        assert (
+            "conversations_replies",
+            {"channel": "C01", "ts": "1.0", "limit": 200},
+        ) not in [(m, k) for m, k in client.calls]
 
     async def test_replies_disabled_via_flag(self) -> None:
         client = FakeAsyncWebClient()

--- a/packages/pii-scanner-slack/tests/test_discovery.py
+++ b/packages/pii-scanner-slack/tests/test_discovery.py
@@ -373,7 +373,10 @@ class TestDiscoveryDiscover:
                 cursor_state=cursor_state,
             )
         ]
-        assert refs[1].metadata["url_private_download"] == "https://files.slack.com/fallback"
+        assert (
+            refs[1].metadata["url_private_download"]
+            == "https://files.slack.com/fallback"
+        )
 
     async def test_file_with_no_url_omits_metadata(self) -> None:
         # Neither url_private_download nor url_private — both branches
@@ -465,8 +468,6 @@ class TestDiscoveryDiscover:
             status_code=429,
             headers={"Retry-After": "5"},
         )
-        client.script(
-            "discovery_enterprise_info", SlackApiError("rate", response)
-        )
+        client.script("discovery_enterprise_info", SlackApiError("rate", response))
         with pytest.raises(RateLimited):
             await fetch_enterprise_id(client)

--- a/packages/pii-scanner-slack/tests/test_rate.py
+++ b/packages/pii-scanner-slack/tests/test_rate.py
@@ -13,7 +13,9 @@ from .conftest import FakeResponse
 
 def _make_429(retry_after: str | None = "12") -> SlackApiError:
     headers = {"Retry-After": retry_after} if retry_after is not None else {}
-    response = FakeResponse({"ok": False, "error": "ratelimited"}, status_code=429, headers=headers)
+    response = FakeResponse(
+        {"ok": False, "error": "ratelimited"}, status_code=429, headers=headers
+    )
     return SlackApiError("rate", response)
 
 
@@ -25,9 +27,7 @@ class TestRaiseFromSlackApiError:
     def test_translates_ratelimited_string(self) -> None:
         # Older Slack APIs return 200 + body error="ratelimited" instead
         # of 429. Both must surface as RateLimited.
-        response = FakeResponse(
-            {"ok": False, "error": "ratelimited"}, status_code=200
-        )
+        response = FakeResponse({"ok": False, "error": "ratelimited"}, status_code=200)
         exc = SlackApiError("rate", response)
         with pytest.raises(RateLimited):
             _rate.raise_from_slack_api_error(exc)

--- a/packages/pii-scanner-snowflake/src/pleno_pii_scanner_snowflake/connector.py
+++ b/packages/pii-scanner-snowflake/src/pleno_pii_scanner_snowflake/connector.py
@@ -160,13 +160,9 @@ class SnowflakeConnector:
                     rows, columns = await self._sample_table(db, schema, table)
                     for i, row in enumerate(rows):
                         path = f"{db}/{schema}/{table}/{i}"
-                        if filter.include and not _matches_any(
-                            path, filter.include
-                        ):
+                        if filter.include and not _matches_any(path, filter.include):
                             continue
-                        if filter.exclude and _matches_any(
-                            path, filter.exclude
-                        ):
+                        if filter.exclude and _matches_any(path, filter.exclude):
                             continue
                         # JSON-encode the projected row dict so the
                         # row payload travels as the DocumentRef
@@ -222,12 +218,9 @@ class SnowflakeConnector:
         )
         return [_pick(columns, row, "name") for row in rows]
 
-    async def _resolve_tables(
-        self, database: str, schema: str
-    ) -> list[str]:
+    async def _resolve_tables(self, database: str, schema: str) -> list[str]:
         rows, columns = await self._run(
-            f"SHOW TABLES IN SCHEMA "
-            f"{_quote_ident(database)}.{_quote_ident(schema)}"
+            f"SHOW TABLES IN SCHEMA {_quote_ident(database)}.{_quote_ident(schema)}"
         )
         return [_pick(columns, row, "name") for row in rows]
 
@@ -265,10 +258,7 @@ class SnowflakeConnector:
         resp.raise_for_status()
         payload = resp.json()
         meta = payload.get("resultSetMetaData", {}) or {}
-        columns = [
-            str(c.get("name", ""))
-            for c in (meta.get("rowType") or [])
-        ]
+        columns = [str(c.get("name", "")) for c in (meta.get("rowType") or [])]
         rows: list[list[Any]] = list(payload.get("data") or [])
         partitions = meta.get("partitionInfo") or []
         handle = payload.get("statementHandle") or payload.get("statementHandles")
@@ -286,7 +276,9 @@ class SnowflakeConnector:
                 rows.extend(part_body.get("data") or [])
         return rows, columns
 
-    async def _acquire_token(self) -> str:  # pragma: no cover - signing path is exercised in integration; unit tests monkeypatch
+    async def _acquire_token(
+        self,
+    ) -> str:  # pragma: no cover - signing path is exercised in integration; unit tests monkeypatch
         """Sign a short-lived RS256 JWT with the user's private key.
 
         Production code wires in `cryptography`-based signing; the
@@ -301,7 +293,9 @@ class SnowflakeConnector:
 # --- helpers ------------------------------------------------------
 
 
-def _sign_jwt(account: str, user: str, private_key_pem: str) -> str:  # pragma: no cover - exercises real RSA crypto in deployment
+def _sign_jwt(
+    account: str, user: str, private_key_pem: str
+) -> str:  # pragma: no cover - exercises real RSA crypto in deployment
     """Build and sign the Snowflake key-pair JWT.
 
     Pulled out of the connector to keep the I/O class testable
@@ -316,16 +310,12 @@ def _sign_jwt(account: str, user: str, private_key_pem: str) -> str:  # pragma: 
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import padding
 
-    key = serialization.load_pem_private_key(
-        private_key_pem.encode(), password=None
-    )
+    key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
     public_bytes = key.public_key().public_bytes(
         encoding=serialization.Encoding.DER,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
-    fp = "SHA256:" + base64.b64encode(
-        hashlib.sha256(public_bytes).digest()
-    ).decode()
+    fp = "SHA256:" + base64.b64encode(hashlib.sha256(public_bytes).digest()).decode()
     sub = f"{account.upper()}.{user.upper()}"
     iss = f"{sub}.{fp}"
     now = int(time.time())
@@ -368,8 +358,9 @@ def _pick(columns: list[str], row: list[Any], wanted: str) -> str:
 
 
 def _project_row(columns: list[str], row: list[Any]) -> dict[str, Any]:
-    return {columns[i] if i < len(columns) else f"_col{i}": v
-            for i, v in enumerate(row)}
+    return {
+        columns[i] if i < len(columns) else f"_col{i}": v for i, v in enumerate(row)
+    }
 
 
 # --- factory / spec -----------------------------------------------
@@ -378,9 +369,7 @@ def _project_row(columns: list[str], row: list[Any]) -> dict[str, Any]:
 def _factory(config: Mapping[str, Any]) -> SourceConnector:
     for required in ("account", "user", "private_key_pem"):
         if required not in config:
-            raise ValueError(
-                f"snowflake connector config requires {required!r}"
-            )
+            raise ValueError(f"snowflake connector config requires {required!r}")
     return SnowflakeConnector(
         SnowflakeConfig(
             account=str(config["account"]),
@@ -390,9 +379,7 @@ def _factory(config: Mapping[str, Any]) -> SourceConnector:
             databases=tuple(config.get("databases", ())),
             schemas=tuple(config.get("schemas", ())),
             sample_rows=int(config.get("sample_rows", 1000)),
-            statement_timeout_seconds=int(
-                config.get("statement_timeout_seconds", 60)
-            ),
+            statement_timeout_seconds=int(config.get("statement_timeout_seconds", 60)),
             role=str(config.get("role", "PUBLIC")),
             id=str(config["id"]) if config.get("id") is not None else None,
         )

--- a/packages/pii-scanner-snowflake/tests/test_connector.py
+++ b/packages/pii-scanner-snowflake/tests/test_connector.py
@@ -43,6 +43,7 @@ def _isolated_registry(monkeypatch: pytest.MonkeyPatch):
 @pytest.fixture(autouse=True)
 def _patch_token(monkeypatch: pytest.MonkeyPatch):
     """Bypass real RS256 signing — tests don't ship key material."""
+
     async def _fixed(self):  # noqa: ARG001
         return _FAKE_JWT
 
@@ -66,7 +67,9 @@ def _config(**overrides) -> SnowflakeConfig:
     return SnowflakeConfig(**base)
 
 
-def _ok(rows: list[list], columns: list[str], *, partitions: int = 1, handle: str = "h") -> dict:
+def _ok(
+    rows: list[list], columns: list[str], *, partitions: int = 1, handle: str = "h"
+) -> dict:
     return {
         "statementHandle": handle,
         "resultSetMetaData": {
@@ -101,9 +104,7 @@ class TestConfig:
 
     def test_rejects_empty_role(self) -> None:
         with pytest.raises(ValueError, match="role"):
-            SnowflakeConfig(
-                account="a", user="u", private_key_pem=_FAKE_KEY, role=""
-            )
+            SnowflakeConfig(account="a", user="u", private_key_pem=_FAKE_KEY, role="")
 
     def test_rejects_zero_statement_timeout(self) -> None:
         with pytest.raises(ValueError, match="statement_timeout_seconds"):
@@ -236,9 +237,7 @@ class TestEndToEnd:
             captured_bodies=bodies,
         )
         async with _client(handler) as client:
-            c = SnowflakeConnector(
-                _config(databases=("PROD",)), client=client
-            )
+            c = SnowflakeConnector(_config(databases=("PROD",)), client=client)
             try:
                 _ = [r async for r in c.discover(SourceFilter(), None)]
             finally:
@@ -258,9 +257,7 @@ class TestEndToEnd:
                 _ = [r async for r in c.discover(SourceFilter(), None)]
             finally:
                 await c.close()
-        assert not any(
-            b["statement"].startswith("SHOW SCHEMAS") for b in bodies
-        )
+        assert not any(b["statement"].startswith("SHOW SCHEMAS") for b in bodies)
 
     async def test_session_parameters_present(self) -> None:
         bodies: list[dict] = []
@@ -356,16 +353,12 @@ class TestPagination:
                 if sql.startswith("SHOW TABLES"):
                     return httpx.Response(200, json=_ok([["T"]], ["name"]))
                 if sql.startswith("SELECT"):
-                    payload = _ok(
-                        [["a"]], ["NAME"], partitions=2, handle="HX"
-                    )
+                    payload = _ok([["a"]], ["NAME"], partitions=2, handle="HX")
                     return httpx.Response(200, json=payload)
             if request.method == "GET":
                 assert "/api/v2/statements/HX" in str(request.url)
                 assert request.url.params["partition"] == "1"
-                return httpx.Response(
-                    200, json={"data": [["b"], ["c"]]}
-                )
+                return httpx.Response(200, json={"data": [["b"], ["c"]]})
             return httpx.Response(404)
 
         async with _client(handler) as client:
@@ -400,9 +393,7 @@ class TestFilter:
             try:
                 refs = [
                     r
-                    async for r in c.discover(
-                        SourceFilter(include=("DB/S/T/0",)), None
-                    )
+                    async for r in c.discover(SourceFilter(include=("DB/S/T/0",)), None)
                 ]
                 assert [r.path for r in refs] == ["DB/S/T/0"]
             finally:
@@ -420,9 +411,7 @@ class TestFilter:
             try:
                 refs = [
                     r
-                    async for r in c.discover(
-                        SourceFilter(exclude=("DB/S/T/0",)), None
-                    )
+                    async for r in c.discover(SourceFilter(exclude=("DB/S/T/0",)), None)
                 ]
                 assert [r.path for r in refs] == ["DB/S/T/1"]
             finally:

--- a/packages/pii-scanner/src/pleno_pii_scanner/cli.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cli.py
@@ -15,7 +15,12 @@ from pleno_pii_scanner import __version__
 from pleno_pii_scanner.cloud_pass import CloudConfig, scan_files_cloud
 from pleno_pii_scanner.git_history import scan_history as _scan_history
 from pleno_pii_scanner.github import list_org_repos, shallow_clone
-from pleno_pii_scanner.ignore import IgnoreSet, filter_findings, load_baseline, write_baseline
+from pleno_pii_scanner.ignore import (
+    IgnoreSet,
+    filter_findings,
+    load_baseline,
+    write_baseline,
+)
 from pleno_pii_scanner.cluster import ClusterPolicy, keep_db_clusters
 from pleno_pii_scanner.models import Finding, ScanStats
 from pleno_pii_scanner.ner_pass import scan_files as scan_files_ner
@@ -27,38 +32,100 @@ from pleno_pii_scanner.walker import walk
 
 
 def _common_options(f):
-    f = click.option("--entities", default=None, help="Comma-separated entity types to scan for.")(f)
-    f = click.option("--language", default="ja", show_default=True, help="Analysis language (ja|en). Cloud mode only.")(f)
-    f = click.option("--base-url", "base_url", default=None,
-                     envvar="PLENO_BASE_URL",
-                     help="Offload analysis to a remote pleno-anonymize at this URL. "
-                          "When omitted, NER + regex run locally (the default).")(f)
-    f = click.option("--api-key", default=None, envvar="PLENO_API_KEY",
-                     help="Bearer token for the cloud API. Cloud mode only.")(f)
-    f = click.option("--concurrency", type=int, default=8, show_default=True,
-                     help="Parallel HTTP requests in cloud mode.")(f)
-    f = click.option("--report-format", type=click.Choice(["human", "json", "sarif"]), default="human")(f)
-    f = click.option("--report-path", type=click.Path(dir_okay=False, path_type=Path), default=None)(f)
-    f = click.option("--baseline", "baseline_path", type=click.Path(dir_okay=False, path_type=Path), default=None)(f)
-    f = click.option("--ignore-file", type=click.Path(dir_okay=False, path_type=Path), default=None)(f)
-    f = click.option("--max-file-size", type=int, default=1024 * 1024, show_default=True)(f)
-    f = click.option("--include", multiple=True, help="Glob to include (gitignore syntax).")(f)
-    f = click.option("--exclude", multiple=True, help="Glob to exclude (gitignore syntax).")(f)
-    f = click.option("--workers", type=int, default=None, help="Reserved for the regex-only history pass (default: CPU count).")(f)
-    f = click.option("--only-verified", is_flag=True, help="Suppress unverified/failed findings.")(f)
-    f = click.option("--db-only", "db_only", is_flag=True,
-                     help="Cluster mode: keep findings only from files (>=2 findings) "
-                          "or folders (>=3 findings) that look like a PII database. "
-                          "Single isolated mentions are dropped — repository-level "
-                          "PII risk follows DB shape, not single contacts.")(f)
-    f = click.option("--db-file-threshold", "db_file_threshold", type=int, default=2,
-                     show_default=True,
-                     help="Minimum findings per file to count as a DB cluster (with --db-only).")(f)
-    f = click.option("--db-folder-threshold", "db_folder_threshold", type=int, default=3,
-                     show_default=True,
-                     help="Minimum findings per folder to count as a DB cluster (with --db-only).")(f)
+    f = click.option(
+        "--entities", default=None, help="Comma-separated entity types to scan for."
+    )(f)
+    f = click.option(
+        "--language",
+        default="ja",
+        show_default=True,
+        help="Analysis language (ja|en). Cloud mode only.",
+    )(f)
+    f = click.option(
+        "--base-url",
+        "base_url",
+        default=None,
+        envvar="PLENO_BASE_URL",
+        help="Offload analysis to a remote pleno-anonymize at this URL. "
+        "When omitted, NER + regex run locally (the default).",
+    )(f)
+    f = click.option(
+        "--api-key",
+        default=None,
+        envvar="PLENO_API_KEY",
+        help="Bearer token for the cloud API. Cloud mode only.",
+    )(f)
+    f = click.option(
+        "--concurrency",
+        type=int,
+        default=8,
+        show_default=True,
+        help="Parallel HTTP requests in cloud mode.",
+    )(f)
+    f = click.option(
+        "--report-format",
+        type=click.Choice(["human", "json", "sarif"]),
+        default="human",
+    )(f)
+    f = click.option(
+        "--report-path", type=click.Path(dir_okay=False, path_type=Path), default=None
+    )(f)
+    f = click.option(
+        "--baseline",
+        "baseline_path",
+        type=click.Path(dir_okay=False, path_type=Path),
+        default=None,
+    )(f)
+    f = click.option(
+        "--ignore-file", type=click.Path(dir_okay=False, path_type=Path), default=None
+    )(f)
+    f = click.option(
+        "--max-file-size", type=int, default=1024 * 1024, show_default=True
+    )(f)
+    f = click.option(
+        "--include", multiple=True, help="Glob to include (gitignore syntax)."
+    )(f)
+    f = click.option(
+        "--exclude", multiple=True, help="Glob to exclude (gitignore syntax)."
+    )(f)
+    f = click.option(
+        "--workers",
+        type=int,
+        default=None,
+        help="Reserved for the regex-only history pass (default: CPU count).",
+    )(f)
+    f = click.option(
+        "--only-verified", is_flag=True, help="Suppress unverified/failed findings."
+    )(f)
+    f = click.option(
+        "--db-only",
+        "db_only",
+        is_flag=True,
+        help="Cluster mode: keep findings only from files (>=2 findings) "
+        "or folders (>=3 findings) that look like a PII database. "
+        "Single isolated mentions are dropped — repository-level "
+        "PII risk follows DB shape, not single contacts.",
+    )(f)
+    f = click.option(
+        "--db-file-threshold",
+        "db_file_threshold",
+        type=int,
+        default=2,
+        show_default=True,
+        help="Minimum findings per file to count as a DB cluster (with --db-only).",
+    )(f)
+    f = click.option(
+        "--db-folder-threshold",
+        "db_folder_threshold",
+        type=int,
+        default=3,
+        show_default=True,
+        help="Minimum findings per folder to count as a DB cluster (with --db-only).",
+    )(f)
     f = click.option("--no-color", is_flag=True, help="Disable ANSI colors.")(f)
-    f = click.option("--exit-zero", is_flag=True, help="Always exit 0 even when findings exist.")(f)
+    f = click.option(
+        "--exit-zero", is_flag=True, help="Always exit 0 even when findings exist."
+    )(f)
     return f
 
 
@@ -91,8 +158,13 @@ def _resolve_entities(entities_csv: str | None) -> tuple[str, ...] | None:
     return wanted
 
 
-def _cloud_config(base_url: str | None, api_key: str | None, language: str,
-                  concurrency: int, entities: tuple[str, ...] | None) -> CloudConfig | None:
+def _cloud_config(
+    base_url: str | None,
+    api_key: str | None,
+    language: str,
+    concurrency: int,
+    entities: tuple[str, ...] | None,
+) -> CloudConfig | None:
     if not base_url:
         return None
     return CloudConfig(
@@ -155,12 +227,14 @@ def _scan_directory(
     recognizers = _select_recognizers(entities)
 
     t0 = time.monotonic()
-    files = list(walk(
-        root,
-        max_file_size=max_file_size,
-        include=list(include) if include else None,
-        exclude=list(exclude) if exclude else None,
-    ))
+    files = list(
+        walk(
+            root,
+            max_file_size=max_file_size,
+            include=list(include) if include else None,
+            exclude=list(exclude) if exclude else None,
+        )
+    )
 
     file_pairs: list[tuple[Path, Path]] = []
     file_text: dict[str, str] = {}
@@ -226,7 +300,9 @@ def _maybe_filter_verified(stats: ScanStats, only_verified: bool) -> ScanStats:
     return stats
 
 
-def _maybe_cluster_db(stats: ScanStats, db_only: bool, file_t: int, folder_t: int) -> ScanStats:
+def _maybe_cluster_db(
+    stats: ScanStats, db_only: bool, file_t: int, folder_t: int
+) -> ScanStats:
     """Apply DB-cluster filtering when --db-only is set.
 
     Repository-level PII risk follows database shape: a single contact email
@@ -278,9 +354,9 @@ _register_builtins()
 # Mount the multi-source CLI groups (#15). They live in sibling modules
 # so backward-compat subcommands (dir/git/github/baseline/protect) above
 # stay byte-identical and the new groups can be tested in isolation.
-from pleno_pii_scanner.cli_connectors import connectors_group as _connectors_group
-from pleno_pii_scanner.cli_schedule import schedule_group as _schedule_group
-from pleno_pii_scanner.cli_scan import scan_group as _scan_group
+from pleno_pii_scanner.cli_connectors import connectors_group as _connectors_group  # noqa: E402
+from pleno_pii_scanner.cli_schedule import schedule_group as _schedule_group  # noqa: E402
+from pleno_pii_scanner.cli_scan import scan_group as _scan_group  # noqa: E402
 
 main.add_command(_connectors_group)
 main.add_command(_schedule_group)
@@ -290,15 +366,34 @@ main.add_command(_scan_group)
 @main.command(name="dir")
 @click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @_common_options
-def cmd_dir(path: Path, entities, language, base_url, api_key, concurrency,
-            report_format, report_path, baseline_path,
-            ignore_file, max_file_size, include, exclude, workers, only_verified,
-            db_only, db_file_threshold, db_folder_threshold,
-            no_color, exit_zero) -> None:
+def cmd_dir(
+    path: Path,
+    entities,
+    language,
+    base_url,
+    api_key,
+    concurrency,
+    report_format,
+    report_path,
+    baseline_path,
+    ignore_file,
+    max_file_size,
+    include,
+    exclude,
+    workers,
+    only_verified,
+    db_only,
+    db_file_threshold,
+    db_folder_threshold,
+    no_color,
+    exit_zero,
+) -> None:
     """Scan a directory tree."""
     ignore_set = _resolve_ignore(ignore_file, path)
     baseline = load_baseline(baseline_path) if baseline_path else set()
-    cloud = _cloud_config(base_url, api_key, language, concurrency, _resolve_entities(entities))
+    cloud = _cloud_config(
+        base_url, api_key, language, concurrency, _resolve_entities(entities)
+    )
     stats = _scan_directory(
         path.resolve(),
         entities=entities,
@@ -322,11 +417,30 @@ def cmd_dir(path: Path, entities, language, base_url, api_key, concurrency,
 @click.option("--no-history", is_flag=True, help="Skip git history pass.")
 @click.option("--max-commits", type=int, default=None, help="Cap commits scanned.")
 @_common_options
-def cmd_git(path: Path, no_history, max_commits, entities, language, base_url, api_key,
-            concurrency, report_format, report_path,
-            baseline_path, ignore_file, max_file_size, include, exclude, workers,
-            only_verified, db_only, db_file_threshold, db_folder_threshold,
-            no_color, exit_zero) -> None:
+def cmd_git(
+    path: Path,
+    no_history,
+    max_commits,
+    entities,
+    language,
+    base_url,
+    api_key,
+    concurrency,
+    report_format,
+    report_path,
+    baseline_path,
+    ignore_file,
+    max_file_size,
+    include,
+    exclude,
+    workers,
+    only_verified,
+    db_only,
+    db_file_threshold,
+    db_folder_threshold,
+    no_color,
+    exit_zero,
+) -> None:
     """Scan a local git repository (working tree + history).
 
     History pass always runs locally (regex only) since per-line cloud calls
@@ -334,7 +448,9 @@ def cmd_git(path: Path, no_history, max_commits, entities, language, base_url, a
     """
     ignore_set = _resolve_ignore(ignore_file, path)
     baseline = load_baseline(baseline_path) if baseline_path else set()
-    cloud = _cloud_config(base_url, api_key, language, concurrency, _resolve_entities(entities))
+    cloud = _cloud_config(
+        base_url, api_key, language, concurrency, _resolve_entities(entities)
+    )
     recognizers = _select_recognizers(entities)
     patterns = compile_patterns(recognizers)
 
@@ -352,9 +468,13 @@ def cmd_git(path: Path, no_history, max_commits, entities, language, base_url, a
 
     if not no_history:
         t0 = time.monotonic()
-        hist_findings, n_commits = _scan_history(path.resolve(), patterns, max_commits=max_commits)
+        hist_findings, n_commits = _scan_history(
+            path.resolve(), patterns, max_commits=max_commits
+        )
         hist_findings = verify(hist_findings, recognizers)
-        kept, _ = filter_findings(hist_findings, ignore_set=ignore_set, baseline=baseline)
+        kept, _ = filter_findings(
+            hist_findings, ignore_set=ignore_set, baseline=baseline
+        )
         stats.findings.extend(kept)
         stats.findings.sort(key=lambda f: (f.commit or "", f.file, f.line))
         stats.commits_scanned = n_commits
@@ -369,15 +489,42 @@ def cmd_git(path: Path, no_history, max_commits, entities, language, base_url, a
 
 @main.command(name="github")
 @click.argument("target")
-@click.option("--org", is_flag=True, help="Treat TARGET as a GitHub org and scan all repos.")
+@click.option(
+    "--org", is_flag=True, help="Treat TARGET as a GitHub org and scan all repos."
+)
 @click.option("--full", is_flag=True, help="Full clone (default: shallow depth=1).")
-@click.option("--scan-history/--no-scan-history", "include_history", default=False, help="Scan git history (requires --full).")
+@click.option(
+    "--scan-history/--no-scan-history",
+    "include_history",
+    default=False,
+    help="Scan git history (requires --full).",
+)
 @_common_options
-def cmd_github(target, org, full, include_history, entities, language, base_url, api_key,
-               concurrency, report_format, report_path,
-               baseline_path, ignore_file, max_file_size, include, exclude, workers,
-               only_verified, db_only, db_file_threshold, db_folder_threshold,
-               no_color, exit_zero) -> None:
+def cmd_github(
+    target,
+    org,
+    full,
+    include_history,
+    entities,
+    language,
+    base_url,
+    api_key,
+    concurrency,
+    report_format,
+    report_path,
+    baseline_path,
+    ignore_file,
+    max_file_size,
+    include,
+    exclude,
+    workers,
+    only_verified,
+    db_only,
+    db_file_threshold,
+    db_folder_threshold,
+    no_color,
+    exit_zero,
+) -> None:
     """Clone a GitHub repo (or all repos in an org) and scan."""
     if include_history and not full:
         raise click.UsageError("--scan-history requires --full")
@@ -385,7 +532,9 @@ def cmd_github(target, org, full, include_history, entities, language, base_url,
     targets = list_org_repos(target) if org else [target]
 
     aggregate = ScanStats()
-    cloud = _cloud_config(base_url, api_key, language, concurrency, _resolve_entities(entities))
+    cloud = _cloud_config(
+        base_url, api_key, language, concurrency, _resolve_entities(entities)
+    )
     recognizers = _select_recognizers(entities)
     patterns = compile_patterns(recognizers)
 
@@ -413,9 +562,7 @@ def cmd_github(target, org, full, include_history, entities, language, base_url,
             # Re-prefix file paths so output is unambiguous across many repos.
             # Finding is a frozen slotted dataclass — use dataclasses.replace,
             # not __dict__ (slots=True removes __dict__).
-            sub.findings = [
-                replace(f, file=f"{slug}:{f.file}") for f in sub.findings
-            ]
+            sub.findings = [replace(f, file=f"{slug}:{f.file}") for f in sub.findings]
             aggregate.files_scanned += sub.files_scanned
             aggregate.bytes_scanned += sub.bytes_scanned
             aggregate.duration_ms += sub.duration_ms
@@ -424,14 +571,18 @@ def cmd_github(target, org, full, include_history, entities, language, base_url,
             if include_history:
                 hist, n_commits = _scan_history(repo, patterns)
                 hist = verify(hist, recognizers)
-                hist, _ = filter_findings(hist, ignore_set=ignore_set, baseline=baseline)
+                hist, _ = filter_findings(
+                    hist, ignore_set=ignore_set, baseline=baseline
+                )
                 aggregate.findings.extend(
                     replace(h, file=f"{slug}:{h.file}") for h in hist
                 )
                 aggregate.commits_scanned += n_commits
 
     aggregate = _maybe_filter_verified(aggregate, only_verified)
-    aggregate = _maybe_cluster_db(aggregate, db_only, db_file_threshold, db_folder_threshold)
+    aggregate = _maybe_cluster_db(
+        aggregate, db_only, db_file_threshold, db_folder_threshold
+    )
     color = sys.stdout.isatty() and not no_color and report_format == "human"
     _emit(aggregate, report_format, report_path, color)
     sys.exit(_exit_code(aggregate, exit_zero))
@@ -439,8 +590,13 @@ def cmd_github(target, org, full, include_history, entities, language, base_url,
 
 @main.command(name="baseline")
 @click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
-@click.option("--out", "out_path", type=click.Path(dir_okay=False, path_type=Path),
-              default=Path(".plenoignore-baseline.json"), show_default=True)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".plenoignore-baseline.json"),
+    show_default=True,
+)
 @click.option("--entities", default=None)
 @click.option("--max-file-size", type=int, default=1024 * 1024)
 @click.option("--workers", type=int, default=None)
@@ -470,7 +626,9 @@ def cmd_protect(entities, only_verified, no_color) -> None:
 
     diff = subprocess.run(
         ["git", "diff", "--cached", "--unified=0", "--no-color"],
-        capture_output=True, text=True, errors="replace",
+        capture_output=True,
+        text=True,
+        errors="replace",
     )
     if diff.returncode != 0:
         click.echo(diff.stderr, err=True)
@@ -483,6 +641,7 @@ def cmd_protect(entities, only_verified, no_color) -> None:
     current_file: str | None = None
     new_line = 0
     import re as _re
+
     file_re = _re.compile(r"^\+\+\+ b/(.+)$")
     hunk_re = _re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
@@ -498,6 +657,7 @@ def cmd_protect(entities, only_verified, no_color) -> None:
         if current_file and line.startswith("+") and not line.startswith("+++"):
             text = line[1:]
             from pleno_pii_scanner.regex_pass import scan_text as _scan_text
+
             for f in _scan_text(text, current_file, patterns):
                 findings.append(replace(f, line=new_line))
             new_line += 1

--- a/packages/pii-scanner/src/pleno_pii_scanner/cli_connectors.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cli_connectors.py
@@ -82,9 +82,7 @@ def cmd_describe(kind: str) -> None:
                     "streaming": spec.capabilities.streaming,
                 },
                 "config_schema": (
-                    dict(spec.config_schema)
-                    if spec.config_schema is not None
-                    else None
+                    dict(spec.config_schema) if spec.config_schema is not None else None
                 ),
             },
             indent=2,

--- a/packages/pii-scanner/src/pleno_pii_scanner/cli_scan.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cli_scan.py
@@ -266,7 +266,9 @@ def _load_config(path: Path | None, inline_json: str | None) -> dict[str, Any]:
             raise click.ClickException(f"{path} is not valid TOML: {exc}") from None
 
 
-def _resolve_recognizers(entities_csv: str | None) -> tuple[Any, tuple[str, ...] | None]:
+def _resolve_recognizers(
+    entities_csv: str | None,
+) -> tuple[Any, tuple[str, ...] | None]:
     """Mirror cli._select_recognizers without inheriting its flags.
 
     Returns `(recognizers, ner_entity_filter)`. The NER filter is None
@@ -441,9 +443,7 @@ def _make_uncached_scan_fn(detector: DetectorFn, emit_findings):
     streams.
     """
 
-    async def scan_fn(
-        ref: DocumentRef, doc: Document | DocumentChunk
-    ) -> int:
+    async def scan_fn(ref: DocumentRef, doc: Document | DocumentChunk) -> int:
         count, payload = await detector(ref, doc)
         await emit_findings(ref.source_id, _sub_id(ref), count, payload, False)
         return count

--- a/packages/pii-scanner/src/pleno_pii_scanner/cli_schedule.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cli_schedule.py
@@ -48,7 +48,9 @@ def schedule_group(ctx: click.Context, registry_path: Path | None) -> None:
 
 @schedule_group.command(name="add")
 @click.option("--id", "schedule_id", required=True, help="Stable identifier.")
-@click.option("--cron", "cron_expr", required=True, help="5-field cron or @hourly/@daily/...")
+@click.option(
+    "--cron", "cron_expr", required=True, help="5-field cron or @hourly/@daily/..."
+)
 @click.option("--plan-ref", required=True, help="Opaque reference passed to RunFn.")
 @click.option(
     "--jitter-seconds",

--- a/packages/pii-scanner/src/pleno_pii_scanner/cloud_pass.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cloud_pass.py
@@ -144,6 +144,7 @@ async def _scan_files_cloud_async(
     findings: list[Finding] = []
 
     async with httpx.AsyncClient(timeout=timeout) as client:
+
         async def _task(rel_str: str) -> list[Finding]:
             async with sem:
                 return await _scan_one(client, cfg, rel_str, file_text[rel_str])

--- a/packages/pii-scanner/src/pleno_pii_scanner/cluster.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/cluster.py
@@ -67,7 +67,12 @@ def _is_high_impact(f: Finding) -> bool:
     """
     if f.verification != "passed":
         return False
-    return f.entity in {"MY_NUMBER", "MY_NUMBER_CORPORATE", "CREDIT_CARD", "BANK_ACCOUNT"}
+    return f.entity in {
+        "MY_NUMBER",
+        "MY_NUMBER_CORPORATE",
+        "CREDIT_CARD",
+        "BANK_ACCOUNT",
+    }
 
 
 def keep_db_clusters(

--- a/packages/pii-scanner/src/pleno_pii_scanner/credentials/broker.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/credentials/broker.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from pleno_pii_scanner.credentials.profile import CredentialProfile
 
 # Keys whose values must be redacted in repr / str. Any Mapping key that
 # matches one of these substrings (case-insensitive) is rendered as
@@ -182,7 +185,7 @@ class CredentialBroker:
             f"tried resolvers={attempted}"
         )
 
-    async def get_for_profile(self, profile: "CredentialProfile") -> Credential:
+    async def get_for_profile(self, profile: CredentialProfile) -> Credential:
         """Resolve the base of `profile`, then apply the assume-role chain.
 
         Imported lazily to avoid the broker module depending on profile

--- a/packages/pii-scanner/src/pleno_pii_scanner/credentials/profile.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/credentials/profile.py
@@ -72,9 +72,7 @@ class CredentialProfile:
             raise ValueError(f"profile {self.name!r} has empty base")
         kind, _, name = self.base.partition(":")
         if not kind:
-            raise ValueError(
-                f"profile {self.name!r} base {self.base!r} missing kind"
-            )
+            raise ValueError(f"profile {self.name!r} base {self.base!r} missing kind")
         return kind, name or "default"
 
 

--- a/packages/pii-scanner/src/pleno_pii_scanner/detector.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/detector.py
@@ -88,9 +88,7 @@ def recognizer_pack_fingerprint(
     context keyword all flip the fingerprint and auto-invalidate the
     cache on next scan.
     """
-    sorted_recognizers = sorted(
-        recognizers, key=lambda r: (r.entity, r.language)
-    )
+    sorted_recognizers = sorted(recognizers, key=lambda r: (r.entity, r.language))
     h = sha256()
     for r in sorted_recognizers:
         h.update(r.entity.encode())

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/archive.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/archive.py
@@ -97,9 +97,7 @@ class ArchiveExtractor:
         if isinstance(payload, str):
             # An archive served as text/* is almost certainly a connector
             # bug; refuse rather than silently mojibake-decode.
-            raise BombGuardError(
-                "ArchiveExtractor requires binary payload, got text"
-            )
+            raise BombGuardError("ArchiveExtractor requires binary payload, got text")
         mime = sniff(payload)
         for fragment in _walk(
             payload,
@@ -129,33 +127,41 @@ def _walk(
     Document — important for line-number recovery in `regex_pass`.
     """
     if depth >= cfg.max_depth:
-        raise BombGuardError(
-            f"archive depth {depth} >= max_depth={cfg.max_depth}"
-        )
+        raise BombGuardError(f"archive depth {depth} >= max_depth={cfg.max_depth}")
 
     if mime == "application/gzip":
         yield from _walk_gzip(
-            data, depth=depth, base_offset=base_offset, base_path=base_path,
+            data,
+            depth=depth,
+            base_offset=base_offset,
+            base_path=base_path,
             cfg=cfg,
         )
         return
     if mime == "application/zstd":
         yield from _walk_zstd(
-            data, depth=depth, base_offset=base_offset, base_path=base_path,
+            data,
+            depth=depth,
+            base_offset=base_offset,
+            base_path=base_path,
             cfg=cfg,
         )
         return
     if mime == "application/x-tar":
         yield from _walk_tar(
-            data, depth=depth, base_offset=base_offset, base_path=base_path,
+            data,
+            depth=depth,
+            base_offset=base_offset,
+            base_path=base_path,
             cfg=cfg,
         )
         return
-    if mime == "application/zip" or mime.startswith(
-        "application/vnd.openxmlformats"
-    ):
+    if mime == "application/zip" or mime.startswith("application/vnd.openxmlformats"):
         yield from _walk_zip(
-            data, depth=depth, base_offset=base_offset, base_path=base_path,
+            data,
+            depth=depth,
+            base_offset=base_offset,
+            base_path=base_path,
             cfg=cfg,
         )
         return
@@ -337,7 +343,7 @@ def _walk_zstd(
     # decompress loop from the core 100% gate.
     compressed_total = len(data)  # pragma: no cover
     dctx = _zstd.ZstdDecompressor(  # pragma: no cover
-        max_window_size=2 ** 31,
+        max_window_size=2**31,
     )
     out = bytearray()  # pragma: no cover
     with dctx.stream_reader(io.BytesIO(data)) as reader:  # pragma: no cover

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/base.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/base.py
@@ -98,9 +98,7 @@ class ExtractorRegistry:
         with self._lock:
             # Replace if the exact same pattern is registered again so test
             # fixtures can override without leaking across cases.
-            self._patterns = [
-                (p, e) for (p, e) in self._patterns if p != mime_pattern
-            ]
+            self._patterns = [(p, e) for (p, e) in self._patterns if p != mime_pattern]
             self._patterns.append((mime_pattern, extractor))
 
     def for_mime(self, mime: str) -> Extractor:
@@ -112,14 +110,10 @@ class ExtractorRegistry:
                 if fnmatch.fnmatchcase(mime, pattern)
             ]
         if not matches:
-            raise UnknownExtractorError(
-                f"no extractor registered for MIME {mime!r}"
-            )
+            raise UnknownExtractorError(f"no extractor registered for MIME {mime!r}")
         # Specificity = literal-character count (wildcards don't count).
         # Tie-break on raw length so ``text/x-*`` beats ``text/*``.
-        matches.sort(
-            key=lambda pe: (_specificity(pe[0]), len(pe[0])), reverse=True
-        )
+        matches.sort(key=lambda pe: (_specificity(pe[0]), len(pe[0])), reverse=True)
         return matches[0][1]
 
     def patterns(self) -> tuple[str, ...]:

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/columnar.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/columnar.py
@@ -75,9 +75,7 @@ class AvroExtractor:
         try:
             import fastavro
         except ImportError as exc:
-            raise ExtractorError(
-                "AvroExtractor requires the [columnar] extra"
-            ) from exc
+            raise ExtractorError("AvroExtractor requires the [columnar] extra") from exc
         self._fastavro = fastavro
 
     async def extract(

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/html.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/html.py
@@ -44,15 +44,25 @@ class _TextCollector(HTMLParser):
         self._buf: list[str] = []
         self._skip_depth = 0
 
-    def handle_starttag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag in _SKIP_TAGS:
             self._skip_depth += 1
         # Block-level tags get a newline so adjacent <p>s don't run together.
         elif tag in {
-            "p", "br", "div", "li", "tr", "td", "h1", "h2", "h3", "h4",
-            "h5", "h6", "blockquote", "pre",
+            "p",
+            "br",
+            "div",
+            "li",
+            "tr",
+            "td",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "blockquote",
+            "pre",
         }:
             self._buf.append("\n")
 
@@ -60,9 +70,7 @@ class _TextCollector(HTMLParser):
         if tag in _SKIP_TAGS and self._skip_depth > 0:
             self._skip_depth -= 1
 
-    def handle_startendtag(
-        self, tag: str, attrs: list[tuple[str, str | None]]
-    ) -> None:
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         # <br/>, <img/>, etc. — treat <br/> as a line break, ignore others.
         if tag == "br":
             self._buf.append("\n")

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/office.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/office.py
@@ -30,8 +30,7 @@ class DocxExtractor:
     name = "office:docx"
     accepts = frozenset(
         {
-            "application/vnd.openxmlformats-officedocument."
-            "wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         }
     )
 
@@ -39,9 +38,7 @@ class DocxExtractor:
         try:
             import docx
         except ImportError as exc:
-            raise ExtractorError(
-                "DocxExtractor requires the [office] extra"
-            ) from exc
+            raise ExtractorError("DocxExtractor requires the [office] extra") from exc
         self._docx = docx
 
     async def extract(
@@ -74,8 +71,7 @@ class XlsxExtractor:
     name = "office:xlsx"
     accepts = frozenset(
         {
-            "application/vnd.openxmlformats-officedocument."
-            "spreadsheetml.sheet",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         }
     )
 
@@ -83,9 +79,7 @@ class XlsxExtractor:
         try:
             import openpyxl
         except ImportError as exc:
-            raise ExtractorError(
-                "XlsxExtractor requires the [office] extra"
-            ) from exc
+            raise ExtractorError("XlsxExtractor requires the [office] extra") from exc
         self._openpyxl = openpyxl
 
     async def extract(
@@ -102,9 +96,7 @@ class XlsxExtractor:
                 ws = wb[sheet_name]
                 for row in ws.iter_rows(values_only=False):
                     for cell in row:
-                        if cell.value is None or not isinstance(
-                            cell.value, str
-                        ):
+                        if cell.value is None or not isinstance(cell.value, str):
                             continue
                         yield ExtractedFragment(
                             text=cell.value,
@@ -122,8 +114,7 @@ class PptxExtractor:
     name = "office:pptx"
     accepts = frozenset(
         {
-            "application/vnd.openxmlformats-officedocument."
-            "presentationml.presentation",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         }
     )
 
@@ -131,9 +122,7 @@ class PptxExtractor:
         try:
             from pptx import Presentation
         except ImportError as exc:
-            raise ExtractorError(
-                "PptxExtractor requires the [office] extra"
-            ) from exc
+            raise ExtractorError("PptxExtractor requires the [office] extra") from exc
         self._Presentation = Presentation
 
     async def extract(

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/pdf.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/pdf.py
@@ -42,9 +42,7 @@ class PdfExtractor:
     ) -> AsyncIterator[ExtractedFragment]:
         payload = doc_payload(doc)
         if isinstance(payload, str):
-            raise ExtractorError(
-                "PdfExtractor requires binary payload, got text"
-            )
+            raise ExtractorError("PdfExtractor requires binary payload, got text")
         pdf = self._pdfium.PdfDocument(payload)
         try:
             for page_idx in range(len(pdf)):

--- a/packages/pii-scanner/src/pleno_pii_scanner/extractors/sniff.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/extractors/sniff.py
@@ -77,19 +77,12 @@ def _sniff_zip_family(data: bytes) -> str:
     seeking from the file tail and we may only hold a prefix.
     """
     if b"word/" in data and b"[Content_Types].xml" in data:
-        return (
-            "application/vnd.openxmlformats-officedocument."
-            "wordprocessingml.document"
-        )
+        return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     if b"xl/" in data and b"[Content_Types].xml" in data:
-        return (
-            "application/vnd.openxmlformats-officedocument."
-            "spreadsheetml.sheet"
-        )
+        return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     if b"ppt/" in data and b"[Content_Types].xml" in data:
         return (
-            "application/vnd.openxmlformats-officedocument."
-            "presentationml.presentation"
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         )
     if data[30:38] == b"mimetype" and b"opendocument" in data[:512]:
         return "application/vnd.oasis.opendocument"
@@ -122,7 +115,5 @@ def _is_text_likely(data: bytes) -> bool:
         return False
     if not sample:
         return False
-    control = sum(
-        1 for b in sample if b < 0x09 or (0x0E <= b <= 0x1F) or b == 0x7F
-    )
+    control = sum(1 for b in sample if b < 0x09 or (0x0E <= b <= 0x1F) or b == 0x7F)
     return control / len(sample) < 0.30

--- a/packages/pii-scanner/src/pleno_pii_scanner/findings_store/base.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/findings_store/base.py
@@ -259,9 +259,7 @@ class FindingsStore(Protocol):
         """Return one record by primary key, or None."""
         ...
 
-    async def reveal_value(
-        self, finding_id: str, *, audit_principal: str
-    ) -> str:
+    async def reveal_value(self, finding_id: str, *, audit_principal: str) -> str:
         """Decrypt and return the raw `matched` value.
 
         Implementations MUST emit an audit-log event (via the hook

--- a/packages/pii-scanner/src/pleno_pii_scanner/findings_store/encryption.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/findings_store/encryption.py
@@ -106,9 +106,7 @@ class InMemoryKekProvider:
 
     async def wrap_dek(self, tenant_id: str, dek: bytes) -> bytes:
         if len(dek) != DEK_SIZE:
-            raise ValueError(
-                f"DEK must be {DEK_SIZE} bytes; got {len(dek)}"
-            )
+            raise ValueError(f"DEK must be {DEK_SIZE} bytes; got {len(dek)}")
         nonce = os.urandom(NONCE_SIZE)
         aad = tenant_id.encode("utf-8")
         ct = self._aead.encrypt(nonce, dek, aad)
@@ -187,9 +185,7 @@ def encrypt_payload(
         raise ValueError(f"DEK must be {DEK_SIZE} bytes; got {len(dek)}")
     aead = AESGCM(dek)
     nonce = os.urandom(NONCE_SIZE)
-    pt_bytes = json.dumps(plaintext, ensure_ascii=False, sort_keys=True).encode(
-        "utf-8"
-    )
+    pt_bytes = json.dumps(plaintext, ensure_ascii=False, sort_keys=True).encode("utf-8")
     aad = tenant_id.encode("utf-8")
     combined = aead.encrypt(nonce, pt_bytes, aad)
     # WHY: cryptography's AESGCM returns ciphertext||tag concatenated. We
@@ -208,9 +204,7 @@ def decrypt_payload(dek: bytes, payload: EncryptedPayload) -> dict[str, object]:
     aead = AESGCM(dek)
     aad = payload.tenant_id.encode("utf-8")
     try:
-        pt_bytes = aead.decrypt(
-            payload.nonce, payload.ciphertext + payload.tag, aad
-        )
+        pt_bytes = aead.decrypt(payload.nonce, payload.ciphertext + payload.tag, aad)
     except InvalidTag as exc:
         raise EncryptionError(
             "failed to decrypt payload: wrong DEK, tenant, or tampered ciphertext"

--- a/packages/pii-scanner/src/pleno_pii_scanner/findings_store/jsonl_shard.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/findings_store/jsonl_shard.py
@@ -22,9 +22,7 @@ from .encryption import EncryptedPayload, EncryptionError
 #   ~/.local/state/pleno/<scan_id>/findings/<source_id>/<shard_index>.jsonl
 # A separate path component for source_id means concurrent connectors
 # never share a writer — no asyncio.Lock contention across sources.
-def shard_path(
-    base: Path, scan_id: str, source_id: str, shard_index: int
-) -> Path:
+def shard_path(base: Path, scan_id: str, source_id: str, shard_index: int) -> Path:
     """Resolve the on-disk path for a single shard file."""
     return base / scan_id / "findings" / source_id / f"{shard_index}.jsonl"
 
@@ -77,9 +75,7 @@ class JsonlShardWriter:
         if not finding_ids:
             return 0
         lines: list[bytes] = []
-        for fid, fp, payload in zip(
-            finding_ids, fingerprints, payloads, strict=True
-        ):
+        for fid, fp, payload in zip(finding_ids, fingerprints, payloads, strict=True):
             obj: dict[str, object] = {
                 "finding_id": fid,
                 "fingerprint": fp,
@@ -132,9 +128,7 @@ def read_shard(path: Path) -> list[tuple[str, str, EncryptedPayload]]:
             try:
                 obj = json.loads(raw.decode("utf-8"))
             except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                raise EncryptionError(
-                    f"corrupt shard line in {path}: {exc}"
-                ) from exc
+                raise EncryptionError(f"corrupt shard line in {path}: {exc}") from exc
             if not isinstance(obj, dict):
                 raise EncryptionError(f"non-object shard line in {path}")
             payload = EncryptedPayload.from_jsonl(obj)

--- a/packages/pii-scanner/src/pleno_pii_scanner/findings_store/memory_store.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/findings_store/memory_store.py
@@ -183,9 +183,7 @@ class MemoryFindingsStore:
             self._raise_if_closed()
             return self._records.get(finding_id)
 
-    async def reveal_value(
-        self, finding_id: str, *, audit_principal: str
-    ) -> str:
+    async def reveal_value(self, finding_id: str, *, audit_principal: str) -> str:
         async with self._lock:
             self._raise_if_closed()
             payload = self._payloads.get(finding_id)
@@ -199,9 +197,7 @@ class MemoryFindingsStore:
             raise EncryptionError("decrypted payload missing 'matched' string")
         return matched
 
-    async def _emit_audit(
-        self, finding_id: str, audit_principal: str
-    ) -> None:
+    async def _emit_audit(self, finding_id: str, audit_principal: str) -> None:
         if self._audit_hook is None:
             return
         result = self._audit_hook(finding_id, audit_principal)

--- a/packages/pii-scanner/src/pleno_pii_scanner/findings_store/sqlite_index.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/findings_store/sqlite_index.py
@@ -154,8 +154,8 @@ class SqliteFindingsStore:
         severity_classifier: SeverityClassifier | None = None,
     ) -> SqliteFindingsStore:
         """Open (or create) the index DB and prepare the shard directory."""
-        index_target = index_path if index_path is not None else default_index_path(
-            scan_id
+        index_target = (
+            index_path if index_path is not None else default_index_path(scan_id)
         )
         shard_target = shard_base if shard_base is not None else default_shard_base()
         index_target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -224,9 +224,7 @@ class SqliteFindingsStore:
                 )
                 await self._conn.commit()
             else:
-                dek = await self._kek.unwrap_dek(
-                    self._tenant_id, bytes(row[0])
-                )
+                dek = await self._kek.unwrap_dek(self._tenant_id, bytes(row[0]))
         self._dek_cache[self._tenant_id] = dek
         return dek
 
@@ -398,9 +396,7 @@ class SqliteFindingsStore:
                 await cur.close()
         return _row_to_record(row) if row is not None else None
 
-    async def reveal_value(
-        self, finding_id: str, *, audit_principal: str
-    ) -> str:
+    async def reveal_value(self, finding_id: str, *, audit_principal: str) -> str:
         """Decrypt the raw matched value for one finding.
 
         Every call — success or failure — fires the audit hook so the
@@ -419,9 +415,7 @@ class SqliteFindingsStore:
         if row is None:
             raise KeyError(f"finding_id not found: {finding_id}")
         scan_id, source_id, shard_index, fingerprint, tenant_id = row
-        path = shard_path(
-            self._shard_base, scan_id, source_id, int(shard_index)
-        )
+        path = shard_path(self._shard_base, scan_id, source_id, int(shard_index))
         entries = await asyncio.to_thread(read_shard, path)
         for fid, fp, payload in entries:
             if fid == finding_id and fp == fingerprint:
@@ -433,9 +427,7 @@ class SqliteFindingsStore:
                 obj = decrypt_payload(dek, payload)
                 matched = obj.get("matched")
                 if not isinstance(matched, str):
-                    raise EncryptionError(
-                        "decrypted payload missing 'matched' string"
-                    )
+                    raise EncryptionError("decrypted payload missing 'matched' string")
                 return matched
         raise EncryptionError(
             f"finding {finding_id} indexed but absent from shard {path}"
@@ -458,9 +450,7 @@ class SqliteFindingsStore:
         self._dek_cache[tenant_id] = dek
         return dek
 
-    async def _emit_audit(
-        self, finding_id: str, audit_principal: str
-    ) -> None:
+    async def _emit_audit(self, finding_id: str, audit_principal: str) -> None:
         if self._audit_hook is None:
             return
         result = self._audit_hook(finding_id, audit_principal)

--- a/packages/pii-scanner/src/pleno_pii_scanner/git_history.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/git_history.py
@@ -53,7 +53,13 @@ def iter_history(
     if max_commits is not None:
         cmd.insert(4, f"-n{max_commits}")
 
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, errors="replace")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        errors="replace",
+    )
     assert proc.stdout is not None
 
     commit: CommitMeta | None = None

--- a/packages/pii-scanner/src/pleno_pii_scanner/github.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/github.py
@@ -12,7 +12,9 @@ from typing import Iterator
 
 
 @contextmanager
-def shallow_clone(slug_or_url: str, *, depth: int = 1, full: bool = False) -> Iterator[Path]:
+def shallow_clone(
+    slug_or_url: str, *, depth: int = 1, full: bool = False
+) -> Iterator[Path]:
     """Clone `<owner>/<repo>` or a full URL into a temp dir; yield path."""
     if "://" not in slug_or_url and "@" not in slug_or_url:
         url = f"https://github.com/{slug_or_url}.git"
@@ -25,7 +27,9 @@ def shallow_clone(slug_or_url: str, *, depth: int = 1, full: bool = False) -> It
         if not full:
             cmd += [f"--depth={depth}"]
         cmd += [url, tmp]
-        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        subprocess.run(
+            cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
+        )
         yield Path(tmp)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -46,7 +50,5 @@ def list_org_repos(org: str, *, include_archived: bool = False) -> list[str]:
     out = subprocess.check_output(cmd, text=True)
     items = json.loads(out)
     return [
-        i["nameWithOwner"]
-        for i in items
-        if include_archived or not i.get("isArchived")
+        i["nameWithOwner"] for i in items if include_archived or not i.get("isArchived")
     ]

--- a/packages/pii-scanner/src/pleno_pii_scanner/governance/suppression.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/governance/suppression.py
@@ -236,9 +236,7 @@ def load_suppression_policy_from_toml(
         keys = set(rd.keys())
         unknown = keys - _RULE_KEYS_ALLOWED
         if unknown:
-            raise SuppressionLoadError(
-                f"rule[{idx}] unknown keys: {sorted(unknown)}"
-            )
+            raise SuppressionLoadError(f"rule[{idx}] unknown keys: {sorted(unknown)}")
         scope = rd.get("scope")
         if scope != expected_scope:
             raise SuppressionLoadError(

--- a/packages/pii-scanner/src/pleno_pii_scanner/hf_ner_pass.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/hf_ner_pass.py
@@ -48,7 +48,9 @@ _NER_CHUNK_CHAR_LIMIT = 12_000  # mirror ner_pass.py for parity with the spaCy p
 
 # Per-(model, revision) cache so `auto` mode keeps both pipelines warm
 # across files within one scan.
-_pipeline_cache: dict[tuple[str, str | None], tuple[object, object, dict[int, str]]] = {}
+_pipeline_cache: dict[
+    tuple[str, str | None], tuple[object, object, dict[int, str]]
+] = {}
 
 
 def _parse_thresholds(env_value: str | None) -> dict[str, float]:
@@ -168,7 +170,9 @@ def _decode_spans(
         cur_end = None
         cur_min_score = 1.0
 
-    for (tok_start, tok_end), label_id, score in zip(offsets, pred_label_ids, token_scores):
+    for (tok_start, tok_end), label_id, score in zip(
+        offsets, pred_label_ids, token_scores
+    ):
         if tok_start == 0 and tok_end == 0:
             _flush()
             continue

--- a/packages/pii-scanner/src/pleno_pii_scanner/ner_pass.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/ner_pass.py
@@ -140,9 +140,7 @@ def _latin_ratio(chunk: str) -> float:
     return latin / len(chunk)
 
 
-def _spans_overlap(
-    a_start: int, a_end: int, b_start: int, b_end: int
-) -> bool:
+def _spans_overlap(a_start: int, a_end: int, b_start: int, b_end: int) -> bool:
     return a_start < b_end and b_start < a_end
 
 
@@ -181,8 +179,10 @@ def scan_text(
     en_secondary_enabled = (
         language == "ja"
         and "en" in getattr(analyzer, "supported_languages", [])
-        and (entity_filter is None
-             or any(e in _EN_SECONDARY_ENTITIES for e in entity_filter))
+        and (
+            entity_filter is None
+            or any(e in _EN_SECONDARY_ENTITIES for e in entity_filter)
+        )
     )
     en_entity_filter = (
         [e for e in entity_filter if e in _EN_SECONDARY_ENTITIES]
@@ -200,7 +200,11 @@ def scan_text(
         # Japanese-mixed text. Run the English NER on chunks whose Latin
         # ratio crosses the threshold and merge non-overlapping PERSON
         # detections. Scoped to PERSON to keep precision losses bounded.
-        if en_secondary_enabled and en_entity_filter and _latin_ratio(chunk) >= _LATIN_PASS_THRESHOLD:
+        if (
+            en_secondary_enabled
+            and en_entity_filter
+            and _latin_ratio(chunk) >= _LATIN_PASS_THRESHOLD
+        ):
             try:
                 en_results = analyzer.analyze(
                     text=chunk,
@@ -270,7 +274,5 @@ def scan_files(
     for rel, _ in files:
         rel_str = rel.as_posix()
         text = file_text.get(rel_str, "")
-        findings.extend(
-            scan_text(text, rel_str, language=language, entities=entities)
-        )
+        findings.extend(scan_text(text, rel_str, language=language, entities=entities))
     return findings

--- a/packages/pii-scanner/src/pleno_pii_scanner/noise_filters.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/noise_filters.py
@@ -147,9 +147,7 @@ def _in_code_span(line: str, col_1based: int, matched: str) -> bool:
 # the captured span against a strict pattern catches both classes.
 # ---------------------------------------------------------------------------
 
-_STRICT_EMAIL_RE = re.compile(
-    r"\A[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\Z"
-)
+_STRICT_EMAIL_RE = re.compile(r"\A[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\Z")
 
 # RFC 2606 plus the conventional ``example.co.jp``. Never real PII.
 _RESERVED_EMAIL_DOMAINS = frozenset(
@@ -234,15 +232,33 @@ def _in_product_url(line: str) -> bool:
 
 _NER_FP_NOUN_SUFFIXES = (
     # Generic head nouns frequent in dev-doc prose
-    "一覧", "番号", "設計", "機能", "属性", "定数", "変数",
-    "関数", "引数", "戻り値", "演算子", "例外", "数値",
-    "残置",                          # 原則残置 (leave-as-is)
-    "呼び出し",                       # サンプル呼び出し
+    "一覧",
+    "番号",
+    "設計",
+    "機能",
+    "属性",
+    "定数",
+    "変数",
+    "関数",
+    "引数",
+    "戻り値",
+    "演算子",
+    "例外",
+    "数値",
+    "残置",  # 原則残置 (leave-as-is)
+    "呼び出し",  # サンプル呼び出し
     # Verb-form deverbal nouns (action-of-X) — never personal names
-    "割り当て", "割り当てる",
-    "書き込み", "書き出し", "読み込み", "読み出し",
-    "貼り付け", "切り出し", "差し替え",
-    "立ち上げ", "立ち上がり",
+    "割り当て",
+    "割り当てる",
+    "書き込み",
+    "書き出し",
+    "読み込み",
+    "読み出し",
+    "貼り付け",
+    "切り出し",
+    "差し替え",
+    "立ち上げ",
+    "立ち上がり",
     "問い合わせ",
 )
 
@@ -377,20 +393,64 @@ _LATIN_NAME_CONTEXT_RE = re.compile(
 # the v0.2.x eval (LICENSE files, READMEs, changelog headers).
 _NON_NAME_LATIN_TOKENS = frozenset(
     {
-        "License", "Public", "Apache", "Mozilla", "Foundation",
-        "Pull", "Request", "Requests", "Issue", "Issues",
-        "Source", "Open", "Free", "Software",
-        "Code", "Conduct", "Contributing", "Community",
-        "Copyright", "Reserved", "Rights",
-        "Read", "Quick", "Start", "Hello", "World",
-        "Lorem", "Ipsum",
-        "Java", "JavaScript", "TypeScript", "Node", "Script",
-        "York", "America", "Asia", "Europe", "Africa", "Australia",
-        "Major", "Minor", "Patch", "Stable", "Latest",
-        "Table", "Contents",
-        "Section", "Chapter", "Appendix",
-        "Note", "Notes", "Warning", "Caution", "Tip",
-        "True", "False", "None", "Null",
+        "License",
+        "Public",
+        "Apache",
+        "Mozilla",
+        "Foundation",
+        "Pull",
+        "Request",
+        "Requests",
+        "Issue",
+        "Issues",
+        "Source",
+        "Open",
+        "Free",
+        "Software",
+        "Code",
+        "Conduct",
+        "Contributing",
+        "Community",
+        "Copyright",
+        "Reserved",
+        "Rights",
+        "Read",
+        "Quick",
+        "Start",
+        "Hello",
+        "World",
+        "Lorem",
+        "Ipsum",
+        "Java",
+        "JavaScript",
+        "TypeScript",
+        "Node",
+        "Script",
+        "York",
+        "America",
+        "Asia",
+        "Europe",
+        "Africa",
+        "Australia",
+        "Major",
+        "Minor",
+        "Patch",
+        "Stable",
+        "Latest",
+        "Table",
+        "Contents",
+        "Section",
+        "Chapter",
+        "Appendix",
+        "Note",
+        "Notes",
+        "Warning",
+        "Caution",
+        "Tip",
+        "True",
+        "False",
+        "None",
+        "Null",
     }
 )
 
@@ -465,7 +525,9 @@ def _line_for(file_text: str, line: int) -> str:
 def _window_around(file_text: str, line_text: str, matched: str) -> str:
     if matched and matched in line_text:
         idx = line_text.find(matched)
-        return line_text[max(0, idx - _NOISE_WINDOW) : idx + len(matched) + _NOISE_WINDOW]
+        return line_text[
+            max(0, idx - _NOISE_WINDOW) : idx + len(matched) + _NOISE_WINDOW
+        ]
     return line_text
 
 
@@ -598,7 +660,9 @@ def _should_drop(f: Finding, file_text_for: dict[str, str]) -> bool:
         idx = line.find(f.matched) if f.matched else -1
         if idx >= 0:
             left = line[idx - 1] if idx > 0 else ""
-            right = line[idx + len(f.matched)] if idx + len(f.matched) < len(line) else ""
+            right = (
+                line[idx + len(f.matched)] if idx + len(f.matched) < len(line) else ""
+            )
             if left == "`" or right == "`":
                 return True
         # ASCII art "─────>│" runs of box-drawing chars — never a real entity.

--- a/packages/pii-scanner/src/pleno_pii_scanner/notify/_adf.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/notify/_adf.py
@@ -21,9 +21,10 @@ def build_issue_adf(
     metadata: Mapping[str, str],
 ) -> dict:
     """Return an ADF document describing the batch."""
-    summary_text = ", ".join(
-        f"{sev}: {n}" for sev, n in sorted(severity_summary.items())
-    ) or "no findings"
+    summary_text = (
+        ", ".join(f"{sev}: {n}" for sev, n in sorted(severity_summary.items()))
+        or "no findings"
+    )
     metadata_pairs = ", ".join(f"{k}={v}" for k, v in sorted(metadata.items()))
 
     rows: list[dict] = [_table_row_header()]
@@ -46,7 +47,9 @@ def build_issue_adf(
         "content": [
             _heading(f"PII scan {scan_id}"),
             _paragraph(f"Severity summary: {summary_text}."),
-            _paragraph(f"Metadata: {metadata_pairs}" if metadata_pairs else "Metadata: -"),
+            _paragraph(
+                f"Metadata: {metadata_pairs}" if metadata_pairs else "Metadata: -"
+            ),
             {"type": "table", "content": rows},
         ],
     }

--- a/packages/pii-scanner/src/pleno_pii_scanner/notify/router.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/notify/router.py
@@ -82,10 +82,7 @@ class Router:
             raise ValueError(
                 f"Routing rule references unknown transport(s): {', '.join(unknown_in_rules)}"
             )
-        if (
-            default_transport is not None
-            and default_transport not in self._notifiers
-        ):
+        if default_transport is not None and default_transport not in self._notifiers:
             raise ValueError(
                 f"Default transport {default_transport!r} not in notifiers"
             )
@@ -153,9 +150,7 @@ class Router:
                     error=f"unhandled transport error: {exc!r}",
                 )
 
-        results = await asyncio.gather(
-            *[_send(t, fs) for t, fs in buckets.items()]
-        )
+        results = await asyncio.gather(*[_send(t, fs) for t, fs in buckets.items()])
         return list(results)
 
     async def close(self) -> None:

--- a/packages/pii-scanner/src/pleno_pii_scanner/notify/transports/jira.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/notify/transports/jira.py
@@ -102,8 +102,8 @@ class JiraNotifier:
     async def _find_existing(self, finding: Finding) -> str | None:
         fp = finding.fingerprint()
         jql = (
-            f'project = {self._project_key} '
-            f'AND status in {OPEN_STATUS_JQL} '
+            f"project = {self._project_key} "
+            f"AND status in {OPEN_STATUS_JQL} "
             f'AND summary ~ "{fp}"'
         )
 

--- a/packages/pii-scanner/src/pleno_pii_scanner/notify/transports/smtp.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/notify/transports/smtp.py
@@ -106,8 +106,7 @@ class SMTPNotifier:
         critical = batch.severity_summary.get("critical", 0)
         subject_prefix = "[CRITICAL] " if critical else "[PII] "
         msg["Subject"] = (
-            f"{subject_prefix}scan {batch.scan_id} — "
-            f"{len(batch.findings)} finding(s)"
+            f"{subject_prefix}scan {batch.scan_id} — {len(batch.findings)} finding(s)"
         )
         msg["From"] = self._sender
         msg["To"] = ", ".join(self._recipients)

--- a/packages/pii-scanner/src/pleno_pii_scanner/recognizers/custom.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/recognizers/custom.py
@@ -79,9 +79,7 @@ def load_custom_recognizers(
         with p.open("rb") as f:
             raw = tomllib.load(f)
     except tomllib.TOMLDecodeError as exc:
-        raise CustomRecognizerLoadError(
-            f"could not parse {p} as TOML: {exc}"
-        ) from exc
+        raise CustomRecognizerLoadError(f"could not parse {p} as TOML: {exc}") from exc
     except OSError as exc:
         raise CustomRecognizerLoadError(f"could not read {p}: {exc}") from exc
 
@@ -109,8 +107,7 @@ def load_custom_recognizers(
     for idx, item in enumerate(recognizers_raw):
         if not isinstance(item, dict):
             raise CustomRecognizerSchemaError(
-                f"{p}: recognizer[{idx}] must be a table, "
-                f"got {type(item).__name__}"
+                f"{p}: recognizer[{idx}] must be a table, got {type(item).__name__}"
             )
         recognizer, verifier = _parse_recognizer(p, idx, item)
         if recognizer.entity in seen_entities:
@@ -183,9 +180,7 @@ def _parse_recognizer(
     )
 
 
-def _parse_patterns(
-    p: Path, idx: int, raw: Iterable[Any]
-) -> tuple[PiiPattern, ...]:
+def _parse_patterns(p: Path, idx: int, raw: Iterable[Any]) -> tuple[PiiPattern, ...]:
     if not isinstance(raw, list) or not raw:
         raise CustomRecognizerSchemaError(
             f"{p}: recognizer[{idx}].patterns must be a non-empty array"
@@ -207,8 +202,7 @@ def _parse_patterns(
         extra = keys - _ALLOWED_PATTERN_KEYS
         if extra:
             raise CustomRecognizerSchemaError(
-                f"{p}: recognizer[{idx}].patterns[{pidx}] unknown keys: "
-                f"{sorted(extra)}"
+                f"{p}: recognizer[{idx}].patterns[{pidx}] unknown keys: {sorted(extra)}"
             )
         name = item["name"]
         regex_str = item["regex"]
@@ -248,9 +242,7 @@ def _parse_patterns(
     return tuple(patterns)
 
 
-def _parse_verifier(
-    p: Path, idx: int, raw: Any
-) -> Verifier:
+def _parse_verifier(p: Path, idx: int, raw: Any) -> Verifier:
     if not isinstance(raw, dict):
         raise CustomRecognizerSchemaError(
             f"{p}: recognizer[{idx}].verifier must be a table"

--- a/packages/pii-scanner/src/pleno_pii_scanner/recognizers/verifiers.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/recognizers/verifiers.py
@@ -112,8 +112,7 @@ def _verify_callable(value: str, params: Mapping[str, Any]) -> VerifierResult:
         fn = getattr(module, function_name)
     except AttributeError as exc:
         raise VerifierResolutionError(
-            f"callable verifier could not resolve "
-            f"{module_name}:{function_name}: {exc}"
+            f"callable verifier could not resolve {module_name}:{function_name}: {exc}"
         ) from exc
     if not callable(fn):
         raise VerifierResolutionError(
@@ -155,7 +154,6 @@ def resolve_verifier(name: str, params: Mapping[str, Any]) -> Verifier:
         fn = BUILTIN_VERIFIERS[name]
     except KeyError as exc:
         raise VerifierResolutionError(
-            f"unknown verifier type: {name!r}. "
-            f"Built-in: {sorted(BUILTIN_VERIFIERS)}"
+            f"unknown verifier type: {name!r}. Built-in: {sorted(BUILTIN_VERIFIERS)}"
         ) from exc
     return Verifier(name=name, fn=fn, params=dict(params))

--- a/packages/pii-scanner/src/pleno_pii_scanner/regex_pass.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/regex_pass.py
@@ -73,9 +73,7 @@ def _line_col(line_starts: list[int], offset: int) -> tuple[int, int]:
     return line_idx + 1, offset - line_starts[line_idx] + 1
 
 
-def _scan_text(
-    text: str, file: str, patterns: list[CompiledPattern]
-) -> list[Finding]:
+def _scan_text(text: str, file: str, patterns: list[CompiledPattern]) -> list[Finding]:
     if not text:
         return []
     line_starts = _line_offsets(text)
@@ -85,7 +83,11 @@ def _scan_text(
             start = m.start()
             line, col = _line_col(line_starts, start)
             line_end_idx = bisect.bisect_right(line_starts, start)
-            line_end = line_starts[line_end_idx] if line_end_idx < len(line_starts) else len(text)
+            line_end = (
+                line_starts[line_end_idx]
+                if line_end_idx < len(line_starts)
+                else len(text)
+            )
             snippet = text[line_starts[line - 1] : line_end].rstrip("\n")
             if len(snippet) > 240:
                 # Center the snippet on the match.

--- a/packages/pii-scanner/src/pleno_pii_scanner/report.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/report.py
@@ -20,25 +20,30 @@ _VERIFICATION_BADGE = {
 
 def _badge(v: str, color: bool) -> str:
     if not color:
-        return {"passed": "verified", "failed": "checksum failed", "unverified": "unverified"}[v]
+        return {
+            "passed": "verified",
+            "failed": "checksum failed",
+            "unverified": "unverified",
+        }[v]
     return _VERIFICATION_BADGE[v]
 
 
-def render_human(stats: ScanStats, out: TextIO = sys.stdout, *, color: bool = True) -> None:
+def render_human(
+    stats: ScanStats, out: TextIO = sys.stdout, *, color: bool = True
+) -> None:
     findings = stats.findings
     if not findings:
         out.write(
             f"pleno-pii-scanner v{__version__}: scanned {stats.files_scanned} files "
             f"({stats.bytes_scanned:,} bytes) in {stats.duration_ms} ms — "
-            f"\033[32mno findings\033[0m\n" if color
+            f"\033[32mno findings\033[0m\n"
+            if color
             else f"pleno-pii-scanner v{__version__}: scanned {stats.files_scanned} files in {stats.duration_ms} ms — no findings\n"
         )
         return
 
     out.write(f"pleno-pii-scanner v{__version__}\n")
-    out.write(
-        f"Scanned {stats.files_scanned} files ({stats.bytes_scanned:,} bytes)"
-    )
+    out.write(f"Scanned {stats.files_scanned} files ({stats.bytes_scanned:,} bytes)")
     if stats.commits_scanned:
         out.write(f", {stats.commits_scanned} commits")
     out.write(f" in {stats.duration_ms} ms\n\n")

--- a/packages/pii-scanner/src/pleno_pii_scanner/schedule/cron.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/schedule/cron.py
@@ -70,9 +70,7 @@ def _parse_field(spec: str, lo: int, hi: int) -> frozenset[int]:
             except ValueError as exc:
                 raise ValueError(f"non-integer value in {part!r}") from exc
         if start < lo or end > hi or start > end:
-            raise ValueError(
-                f"value(s) out of range [{lo}, {hi}] in {part!r}"
-            )
+            raise ValueError(f"value(s) out of range [{lo}, {hi}] in {part!r}")
         out.update(range(start, end + 1, step))
     return frozenset(out)
 
@@ -143,9 +141,8 @@ class CronExpression:
         """
         if after.tzinfo is None:
             raise ValueError("naive datetime not allowed; pass tz-aware UTC")
-        candidate = (
-            after.astimezone(UTC).replace(second=0, microsecond=0)
-            + timedelta(minutes=1)
+        candidate = after.astimezone(UTC).replace(second=0, microsecond=0) + timedelta(
+            minutes=1
         )
         deadline = candidate + timedelta(days=_MAX_LOOKAHEAD_DAYS)
         while candidate <= deadline:
@@ -153,9 +150,7 @@ class CronExpression:
                 candidate = _first_of_next_month(candidate)
                 continue
             if not self._matches_day(candidate):
-                candidate = (candidate + timedelta(days=1)).replace(
-                    hour=0, minute=0
-                )
+                candidate = (candidate + timedelta(days=1)).replace(hour=0, minute=0)
                 continue
             if candidate.hour not in self.hours:
                 candidate = candidate.replace(minute=0) + timedelta(hours=1)

--- a/packages/pii-scanner/src/pleno_pii_scanner/schedule/memory_store.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/schedule/memory_store.py
@@ -41,9 +41,7 @@ class MemoryScheduleStore(ScheduleStore):
             return [
                 s
                 for s in self._items.values()
-                if s.enabled
-                and s.next_run_at is not None
-                and s.next_run_at <= now
+                if s.enabled and s.next_run_at is not None and s.next_run_at <= now
             ]
 
     async def close(self) -> None:

--- a/packages/pii-scanner/src/pleno_pii_scanner/schedule/registry.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/schedule/registry.py
@@ -248,9 +248,7 @@ class ScheduleRegistry:
             delay = self._jitter_fn(0.0, float(sched.jitter_seconds))
             await asyncio.sleep(delay)
 
-    async def _invoke_run(
-        self, sched: Schedule
-    ) -> tuple[ScheduleOutcome, str | None]:
+    async def _invoke_run(self, sched: Schedule) -> tuple[ScheduleOutcome, str | None]:
         try:
             outcome = await self._run_fn(sched)
             return outcome, None

--- a/packages/pii-scanner/src/pleno_pii_scanner/schedule/sqlite_store.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/schedule/sqlite_store.py
@@ -123,9 +123,7 @@ class SqliteScheduleStore:
     async def delete(self, schedule_id: str) -> None:
         async with self._lock:
             self._raise_if_closed()
-            await self._conn.execute(
-                "DELETE FROM schedules WHERE id=?", (schedule_id,)
-            )
+            await self._conn.execute("DELETE FROM schedules WHERE id=?", (schedule_id,))
             await self._conn.commit()
 
     async def due(self, now: datetime) -> list[Schedule]:

--- a/packages/pii-scanner/src/pleno_pii_scanner/scheduler/core.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/scheduler/core.py
@@ -71,9 +71,7 @@ class CheckpointStoreProtocol(Protocol):
     """
 
     async def save(self, cp: object) -> None: ...
-    async def load(
-        self, scan_id: str, source_id: str
-    ) -> object | None: ...
+    async def load(self, scan_id: str, source_id: str) -> object | None: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/pii-scanner/src/pleno_pii_scanner/scheduler/incremental.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/scheduler/incremental.py
@@ -289,9 +289,7 @@ class IncrementalRunner:
             stats=stats,
         )
 
-        result = await self._scheduler.run_one(
-            plan, scan_id=scan_id, scan_fn=scan_fn
-        )
+        result = await self._scheduler.run_one(plan, scan_id=scan_id, scan_fn=scan_fn)
 
         # On clean completion, persist per-sub-source rollups so the
         # next run hits at tier 1. Errored plans skip this — partial
@@ -305,9 +303,7 @@ class IncrementalRunner:
                 skipped=skipped,
             )
 
-        return IncrementalResult(
-            source_result=result, cache_stats=stats.freeze()
-        )
+        return IncrementalResult(source_result=result, cache_stats=stats.freeze())
 
     async def _apply_subsource_skip(
         self,
@@ -364,9 +360,7 @@ class IncrementalRunner:
             blob = hits.get(lk.key)
             if blob is None:
                 stats.subsource_misses += 1
-                sub_buffers[sub.sub_id] = _SubsourceBuffer(
-                    fingerprint=sub.fingerprint
-                )
+                sub_buffers[sub.sub_id] = _SubsourceBuffer(fingerprint=sub.fingerprint)
                 continue
             count, payload = _decode(blob)
             stats.subsource_hits += 1
@@ -392,9 +386,7 @@ class IncrementalRunner:
         cache = self._cache
         schema_version = self._schema_version
 
-        async def scan_fn(
-            ref: DocumentRef, doc: Document | DocumentChunk
-        ) -> int:
+        async def scan_fn(ref: DocumentRef, doc: Document | DocumentChunk) -> int:
             stats.document_total += 1
             sub_id = ref.metadata.get(SUBSOURCE_METADATA_KEY)
 

--- a/packages/pii-scanner/src/pleno_pii_scanner/scheduler/rate_limit.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/scheduler/rate_limit.py
@@ -62,7 +62,7 @@ class AdaptiveTokenBucket:
     """
 
     capacity: float
-    rate: float                       # ceiling (tokens/sec)
+    rate: float  # ceiling (tokens/sec)
     current_rate: float = field(init=False)
     tokens: float = field(init=False)
     last_refill: float = field(default_factory=monotonic, init=False)
@@ -162,9 +162,7 @@ class GlobalRateLimiter:
         self._overrides: dict[str, tuple[float, float]] = {}
         self._lock = asyncio.Lock()
 
-    def configure(
-        self, connector_kind: str, *, capacity: float, rate: float
-    ) -> None:
+    def configure(self, connector_kind: str, *, capacity: float, rate: float) -> None:
         """Pin (capacity, rate) for a kind — applied to future bucket creation.
 
         Doesn't retroactively replace existing buckets; the Scheduler

--- a/packages/pii-scanner/src/pleno_pii_scanner/scheduler/retry.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/scheduler/retry.py
@@ -111,7 +111,7 @@ def _compute_delay(
     attempt: int,
     rand: Callable[[float, float], float],
 ) -> float:
-    raw = cfg.initial_backoff * (cfg.base ** attempt)
+    raw = cfg.initial_backoff * (cfg.base**attempt)
     capped = min(raw, cfg.max_backoff)
     lo, hi = cfg.jitter
     return capped * rand(lo, hi)
@@ -130,9 +130,7 @@ def collect_retryable(*types: type[BaseException]) -> tuple[type[BaseException],
     return tuple(seen)
 
 
-def merge_configs(
-    base: RetryConfig, **overrides: object
-) -> RetryConfig:
+def merge_configs(base: RetryConfig, **overrides: object) -> RetryConfig:
     """Return a new RetryConfig with selected fields overridden.
 
     Used by per-connector `RetryConfig` overrides ("Slack uses 8 attempts
@@ -153,6 +151,8 @@ def merge_configs(
     return RetryConfig(**fields)  # type: ignore[arg-type]
 
 
-def retryable_sequence(seq: Sequence[type[BaseException]]) -> tuple[type[BaseException], ...]:
+def retryable_sequence(
+    seq: Sequence[type[BaseException]],
+) -> tuple[type[BaseException], ...]:
     """Materialize an iterable of exception types as a frozen tuple."""
     return tuple(seq)

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/base.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/base.py
@@ -80,6 +80,4 @@ class LivenessVerifier(Protocol):
     name: str
     entities: frozenset[str]
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult: ...
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult: ...

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/aws.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/aws.py
@@ -34,9 +34,7 @@ class AwsVerifier:
     name = "aws"
     entities = frozenset({"AWS_ACCESS_KEY", "AWS_SECRET_KEY"})
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult:
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
         secret_key = ctx.extra.get("aws_secret_access_key") if ctx.extra else None
         if not isinstance(secret_key, str) or not secret_key:
             return VerificationResult(
@@ -48,9 +46,17 @@ class AwsVerifier:
         if session_token is not None and not isinstance(session_token, str):
             session_token = None
         region_value = ctx.extra.get("aws_region") if ctx.extra else None
-        region = region_value if isinstance(region_value, str) and region_value else "us-east-1"
+        region = (
+            region_value
+            if isinstance(region_value, str) and region_value
+            else "us-east-1"
+        )
         now_value = ctx.extra.get("_aws_now") if ctx.extra else None
-        now = now_value if isinstance(now_value, _dt.datetime) else _dt.datetime.now(_dt.UTC)
+        now = (
+            now_value
+            if isinstance(now_value, _dt.datetime)
+            else _dt.datetime.now(_dt.UTC)
+        )
 
         host = _HOST_TEMPLATE.format(region=region)
         url = f"https://{host}/"
@@ -185,7 +191,9 @@ def sigv4_sign_post(
         ]
     )
     signing_key = _derive_signing_key(secret_access_key, date_stamp, region, _SERVICE)
-    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+    signature = hmac.new(
+        signing_key, string_to_sign.encode(), hashlib.sha256
+    ).hexdigest()
 
     authorization = (
         f"AWS4-HMAC-SHA256 "
@@ -221,5 +229,3 @@ def _derive_signing_key(
     k_region = hmac.new(k_date, region.encode(), hashlib.sha256).digest()
     k_service = hmac.new(k_region, service.encode(), hashlib.sha256).digest()
     return hmac.new(k_service, b"aws4_request", hashlib.sha256).digest()
-
-

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/generic_bearer.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/generic_bearer.py
@@ -38,9 +38,7 @@ class GenericBearerVerifier:
         if name is not None:
             self.name = name
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult:
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
         if not self._url:
             raise RuntimeError(
                 "GenericBearerVerifier.url is unset; configure via TOML before use"

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/github.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/github.py
@@ -29,9 +29,7 @@ class GitHubVerifier:
         }
     )
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult:
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
         headers = {
             "Authorization": f"Bearer {value}",
             "Accept": "application/vnd.github+json",

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/openai.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/openai.py
@@ -24,9 +24,7 @@ class OpenAiVerifier:
         }
     )
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult:
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
         headers = {
             "Authorization": f"Bearer {value}",
             "User-Agent": "pleno-pii-scanner",

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/slack.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/slack.py
@@ -26,9 +26,7 @@ class SlackVerifier:
         }
     )
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult:
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
         headers = {
             "Authorization": f"Bearer {value}",
             "Content-Type": "application/x-www-form-urlencoded",
@@ -58,7 +56,9 @@ class SlackVerifier:
         except ValueError:
             return VerificationResult(state="error", detail="bad json", ttl_seconds=60)
         if not isinstance(payload, dict):
-            return VerificationResult(state="error", detail="bad payload", ttl_seconds=60)
+            return VerificationResult(
+                state="error", detail="bad payload", ttl_seconds=60
+            )
         if payload.get("ok") is True:
             metadata = {
                 key: payload[key]
@@ -75,7 +75,13 @@ class SlackVerifier:
             return VerificationResult(
                 state="rate_limited", detail="slack rate limited", ttl_seconds=60
             )
-        if error in {"invalid_auth", "not_authed", "account_inactive", "token_revoked", "token_expired"}:
+        if error in {
+            "invalid_auth",
+            "not_authed",
+            "account_inactive",
+            "token_revoked",
+            "token_expired",
+        }:
             return VerificationResult(state="revoked", detail=error)
         return VerificationResult(
             state="unknown", detail=f"slack error: {error}", ttl_seconds=300

--- a/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/stripe.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/secret_verifiers/providers/stripe.py
@@ -26,9 +26,7 @@ class StripeVerifier:
         }
     )
 
-    async def verify(
-        self, value: str, *, ctx: VerifyContext
-    ) -> VerificationResult:
+    async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
         headers = {
             "Authorization": f"Bearer {value}",
             "User-Agent": "pleno-pii-scanner",

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/dir_source.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/dir_source.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -102,12 +102,8 @@ class DirConnector:
             if filter.max_size is not None
             else self._config.max_file_size
         )
-        include = (
-            list(filter.include) if filter.include else list(self._config.include)
-        )
-        exclude = (
-            list(filter.exclude) if filter.exclude else list(self._config.exclude)
-        )
+        include = list(filter.include) if filter.include else list(self._config.include)
+        exclude = list(filter.exclude) if filter.exclude else list(self._config.exclude)
 
         files = await asyncio.to_thread(
             _collect_walk,

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/github_source.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/builtin/github_source.py
@@ -83,9 +83,7 @@ class GithubConfig:
 
     def __post_init__(self) -> None:
         if (self.repo is None) == (self.org is None):
-            raise ValueError(
-                "GithubConfig must set exactly one of `repo` or `org`"
-            )
+            raise ValueError("GithubConfig must set exactly one of `repo` or `org`")
         if self.depth < 1:
             raise ValueError("depth must be >= 1")
 
@@ -181,9 +179,7 @@ class GithubConnector:
                 # repo's findings; we must not clone or yield refs for it.
                 continue
             repo_path = await self._ensure_clone(slug)
-            inner = DirConnector(
-                DirConfig(root=repo_path, id=f"github:{slug}")
-            )
+            inner = DirConnector(DirConfig(root=repo_path, id=f"github:{slug}"))
             try:
                 async for inner_ref in inner.discover(filter, None):
                     yield self._wrap_ref(inner_ref, slug)
@@ -322,11 +318,7 @@ def _default_head_sha(slug: str) -> str | None:
     no working tree on disk. Returns None on any failure so the runner
     can fall back to a full clone instead of risking a stale-cache hit.
     """
-    url = (
-        slug
-        if "://" in slug or "@" in slug
-        else f"https://github.com/{slug}.git"
-    )
+    url = slug if "://" in slug or "@" in slug else f"https://github.com/{slug}.git"
     try:
         proc = subprocess.run(
             ["git", "ls-remote", url, "HEAD"],
@@ -363,11 +355,7 @@ def _clone_into_tempdir(slug: str, config: GithubConfig) -> Path:
         # call instead of using its contextmanager — the contextmanager
         # auto-rmtree's on exit and we want the connector's `close()` to
         # own that lifecycle. Duplication is intentional and tiny.
-        url = (
-            slug
-            if "://" in slug or "@" in slug
-            else f"https://github.com/{slug}.git"
-        )
+        url = slug if "://" in slug or "@" in slug else f"https://github.com/{slug}.git"
         cmd: list[str] = ["git", "clone", "--quiet"]
         if not config.full:
             cmd += [f"--depth={config.depth}"]

--- a/packages/pii-scanner/src/pleno_pii_scanner/sources/registry.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/sources/registry.py
@@ -107,8 +107,7 @@ class _Registry:
             return self._specs[kind]
         except KeyError:
             raise UnknownConnectorError(
-                f"unknown connector kind: {kind!r}. "
-                f"Available: {sorted(self._specs)}"
+                f"unknown connector kind: {kind!r}. Available: {sorted(self._specs)}"
             ) from None
 
     def list_kinds(self) -> tuple[str, ...]:

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/checkpoint.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/checkpoint.py
@@ -109,9 +109,7 @@ class CheckpointStore(Protocol):
         """
         ...
 
-    async def load(
-        self, scan_id: str, source_id: str
-    ) -> Checkpoint | None:
+    async def load(self, scan_id: str, source_id: str) -> Checkpoint | None:
         """Return the latest checkpoint for the pair, or None if absent."""
         ...
 
@@ -133,9 +131,7 @@ class CheckpointStore(Protocol):
         """Record that a findings shard was successfully written."""
         ...
 
-    async def list_shards(
-        self, scan_id: str, source_id: str
-    ) -> list[ShardRecord]:
+    async def list_shards(self, scan_id: str, source_id: str) -> list[ShardRecord]:
         """Return all shard receipts for a (scan_id, source_id) pair."""
         ...
 

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/memory_store.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/memory_store.py
@@ -43,24 +43,18 @@ class MemoryCheckpointStore:
             self._raise_if_closed()
             self._checkpoints.update(staged)
 
-    async def load(
-        self, scan_id: str, source_id: str
-    ) -> Checkpoint | None:
+    async def load(self, scan_id: str, source_id: str) -> Checkpoint | None:
         async with self._lock:
             self._raise_if_closed()
             return self._checkpoints.get((scan_id, source_id))
 
-    async def list_for_scan(
-        self, scan_id: str
-    ) -> AsyncIterator[Checkpoint]:
+    async def list_for_scan(self, scan_id: str) -> AsyncIterator[Checkpoint]:
         async with self._lock:
             self._raise_if_closed()
             # WHY: snapshot under the lock so the caller can iterate
             # without racing concurrent saves.
             snapshot = [
-                cp
-                for (sid, _), cp in self._checkpoints.items()
-                if sid == scan_id
+                cp for (sid, _), cp in self._checkpoints.items() if sid == scan_id
             ]
         for cp in snapshot:
             yield cp
@@ -91,9 +85,7 @@ class MemoryCheckpointStore:
                 written_at=datetime.now(UTC),
             )
 
-    async def list_shards(
-        self, scan_id: str, source_id: str
-    ) -> list[ShardRecord]:
+    async def list_shards(self, scan_id: str, source_id: str) -> list[ShardRecord]:
         async with self._lock:
             self._raise_if_closed()
             bucket = self._shards.get((scan_id, source_id), {})

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/scan_cache.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/scan_cache.py
@@ -84,9 +84,7 @@ class ScanCache(Protocol):
         """
         ...
 
-    async def get_many(
-        self, lookups: Sequence[CacheLookup]
-    ) -> dict[str, bytes]:
+    async def get_many(self, lookups: Sequence[CacheLookup]) -> dict[str, bytes]:
         """Resolve every lookup against the store in a single round-trip.
 
         Returns a dict mapping `lookup.key` → `value` for every entry
@@ -182,16 +180,12 @@ class MemoryScanCache:
             return None
         return entry.value
 
-    async def get_many(
-        self, lookups: Sequence[CacheLookup]
-    ) -> dict[str, bytes]:
+    async def get_many(self, lookups: Sequence[CacheLookup]) -> dict[str, bytes]:
         if not lookups:
             return {}
         async with self._lock:
             self._raise_if_closed()
-            snapshot = {
-                lk.key: self._entries.get(lk.key) for lk in lookups
-            }
+            snapshot = {lk.key: self._entries.get(lk.key) for lk in lookups}
         out: dict[str, bytes] = {}
         for lk in lookups:
             entry = snapshot.get(lk.key)
@@ -231,7 +225,8 @@ class MemoryScanCache:
         async with self._lock:
             self._raise_if_closed()
             stale = [
-                k for k, e in self._entries.items()
+                k
+                for k, e in self._entries.items()
                 if e.schema_version != schema_version
             ]
             for k in stale:
@@ -323,8 +318,7 @@ class SqliteScanCache:
         async with self._lock:
             self._raise_if_closed()
             cur = await self._conn.execute(
-                "SELECT fingerprint, schema_version, value "
-                "FROM scan_cache WHERE key=?",
+                "SELECT fingerprint, schema_version, value FROM scan_cache WHERE key=?",
                 (key,),
             )
             try:
@@ -338,9 +332,7 @@ class SqliteScanCache:
             return None
         return bytes(value)
 
-    async def get_many(
-        self, lookups: Sequence[CacheLookup]
-    ) -> dict[str, bytes]:
+    async def get_many(self, lookups: Sequence[CacheLookup]) -> dict[str, bytes]:
         if not lookups:
             return {}
         # Single SELECT … WHERE key IN (?, ?, ...) so a sub-source pre-
@@ -361,9 +353,7 @@ class SqliteScanCache:
                 rows = await cur.fetchall()
             finally:
                 await cur.close()
-        rows_by_key = {
-            row[0]: (row[1], row[2], bytes(row[3])) for row in rows
-        }
+        rows_by_key = {row[0]: (row[1], row[2], bytes(row[3])) for row in rows}
         out: dict[str, bytes] = {}
         for lk in lookups:
             row = rows_by_key.get(lk.key)
@@ -400,9 +390,7 @@ class SqliteScanCache:
     async def delete(self, key: str) -> None:
         async with self._lock:
             self._raise_if_closed()
-            await self._conn.execute(
-                "DELETE FROM scan_cache WHERE key=?", (key,)
-            )
+            await self._conn.execute("DELETE FROM scan_cache WHERE key=?", (key,))
             await self._conn.commit()
 
     async def purge_other_schemas(self, schema_version: str) -> int:

--- a/packages/pii-scanner/src/pleno_pii_scanner/state/sqlite_store.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/state/sqlite_store.py
@@ -143,14 +143,10 @@ class SqliteCheckpointStore:
             await self._conn.executemany(_UPSERT_CP, [_cp_row(cp) for cp in cps])
             await self._conn.commit()
 
-    async def load(
-        self, scan_id: str, source_id: str
-    ) -> Checkpoint | None:
+    async def load(self, scan_id: str, source_id: str) -> Checkpoint | None:
         async with self._lock:
             self._raise_if_closed()
-            cur = await self._conn.execute(
-                _SELECT_CP, (scan_id, source_id)
-            )
+            cur = await self._conn.execute(_SELECT_CP, (scan_id, source_id))
             try:
                 row = await cur.fetchone()
             finally:
@@ -159,9 +155,7 @@ class SqliteCheckpointStore:
             return None
         return _row_to_cp(row)
 
-    async def list_for_scan(
-        self, scan_id: str
-    ) -> AsyncIterator[Checkpoint]:
+    async def list_for_scan(self, scan_id: str) -> AsyncIterator[Checkpoint]:
         async with self._lock:
             self._raise_if_closed()
             cur = await self._conn.execute(_SELECT_BY_SCAN, (scan_id,))
@@ -180,8 +174,7 @@ class SqliteCheckpointStore:
                 (scan_id, source_id),
             )
             await self._conn.execute(
-                "DELETE FROM scan_findings_shard "
-                "WHERE scan_id=? AND source_id=?",
+                "DELETE FROM scan_findings_shard WHERE scan_id=? AND source_id=?",
                 (scan_id, source_id),
             )
             await self._conn.commit()
@@ -207,14 +200,10 @@ class SqliteCheckpointStore:
             )
             await self._conn.commit()
 
-    async def list_shards(
-        self, scan_id: str, source_id: str
-    ) -> list[ShardRecord]:
+    async def list_shards(self, scan_id: str, source_id: str) -> list[ShardRecord]:
         async with self._lock:
             self._raise_if_closed()
-            cur = await self._conn.execute(
-                _SELECT_SHARDS, (scan_id, source_id)
-            )
+            cur = await self._conn.execute(_SELECT_SHARDS, (scan_id, source_id))
             try:
                 rows = await cur.fetchall()
             finally:

--- a/packages/pii-scanner/src/pleno_pii_scanner/verify.py
+++ b/packages/pii-scanner/src/pleno_pii_scanner/verify.py
@@ -17,7 +17,9 @@ from pleno_recognizers.validators import validate
 from pleno_pii_scanner.models import Finding
 
 
-def _context_keywords(recognizers: Iterable[PiiRecognizer]) -> dict[str, tuple[str, ...]]:
+def _context_keywords(
+    recognizers: Iterable[PiiRecognizer],
+) -> dict[str, tuple[str, ...]]:
     # Multiple recognizers may share an entity (e.g. PERSON regex layers);
     # union their context keyword tuples instead of clobbering.
     keywords: dict[str, tuple[str, ...]] = {}
@@ -50,14 +52,13 @@ def _keyword_in_window(window: str, keyword: str) -> bool:
     pattern = r"(?<!\w)" + re.escape(keyword) + r"(?!\w)"
     return bool(re.search(pattern, window, re.IGNORECASE))
 
+
 # Latin-script PERSON candidates (issue #102) gain a stronger boost when an
 # email pattern is in the immediate context, since "Name <email>" is the
 # strongest possible attribution signal. Wider window than the keyword path
 # because PEP-style author lists put email on a continuation line.
 _PERSON_EMAIL_WINDOW = 96
-_EMAIL_NEAR_NAME_RE = re.compile(
-    r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"
-)
+_EMAIL_NEAR_NAME_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 
 
 def verify(
@@ -73,7 +74,9 @@ def verify(
         # 1. Checksum.
         checksum = validate(f.entity, f.matched)
         if checksum is False:
-            out.append(replace(f, verification="failed", score=max(0.05, f.score - 0.4)))
+            out.append(
+                replace(f, verification="failed", score=max(0.05, f.score - 0.4))
+            )
             continue
 
         # 2. Context proximity boost.
@@ -97,7 +100,7 @@ def verify(
                     keyword_haystack = (
                         window[:match_in_window]
                         + " "
-                        + window[match_in_window + len(f.matched):]
+                        + window[match_in_window + len(f.matched) :]
                     )
                 else:
                     keyword_haystack = window
@@ -112,9 +115,7 @@ def verify(
                 # doesn't get filtered as low-confidence noise.
                 if f.entity == "PERSON":
                     wide_start = max(0, offset - _PERSON_EMAIL_WINDOW)
-                    wide_end = (
-                        wide_start + _PERSON_EMAIL_WINDOW * 2 + len(f.matched)
-                    )
+                    wide_end = wide_start + _PERSON_EMAIL_WINDOW * 2 + len(f.matched)
                     if _EMAIL_NEAR_NAME_RE.search(text[wide_start:wide_end]):
                         score = min(0.99, max(score, 0.4) + 0.4)
                         verification = "passed"

--- a/packages/pii-scanner/tests/credentials/resolvers/test_env.py
+++ b/packages/pii-scanner/tests/credentials/resolvers/test_env.py
@@ -34,7 +34,9 @@ class TestEnvCredentialResolver:
         assert cred.payload == {"token": "ghp_xxx"}
         assert "ghp_xxx" not in repr(cred)
 
-    async def test_github_pat_legacy_token_form(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_github_pat_legacy_token_form(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Backwards-compat: PLENO_<KIND>_TOKEN with no _NAME_ segment.
         monkeypatch.setenv("PLENO_GITHUB_PAT_TOKEN", "ghp_legacy")
         r = EnvCredentialResolver()
@@ -62,7 +64,9 @@ class TestEnvCredentialResolver:
         assert cred.payload["session_token"] == "FwoG"
         assert cred.payload["region"] == "us-west-2"
 
-    async def test_aws_iam_partial_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_aws_iam_partial_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Missing secret half: resolver yields None so the chain falls
         # through to the next resolver (file / keyring) instead of
         # synthesizing a half-credential.
@@ -115,7 +119,9 @@ class TestEnvCredentialResolver:
         assert "xoxb-secret" not in repr(cred)
 
     async def test_gcp_sa_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("PLENO_GCP_SA_KEY_CLIENT_EMAIL", "scanner@proj.iam.gserviceaccount.com")
+        monkeypatch.setenv(
+            "PLENO_GCP_SA_KEY_CLIENT_EMAIL", "scanner@proj.iam.gserviceaccount.com"
+        )
         monkeypatch.setenv("PLENO_GCP_SA_KEY_PRIVATE_KEY", "-----BEGIN-----")
         r = EnvCredentialResolver()
         cred = await r.resolve("gcp-sa-key", "default")
@@ -132,7 +138,9 @@ class TestEnvCredentialResolver:
         assert cred.payload["tenant_id"] == "tid"
         assert "csecret" not in repr(cred)
 
-    async def test_bitbucket_app_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_bitbucket_app_password(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("PLENO_BITBUCKET_APP_PASSWORD_USERNAME", "alice")
         monkeypatch.setenv("PLENO_BITBUCKET_APP_PASSWORD_APP_PASSWORD", "secret")
         r = EnvCredentialResolver()

--- a/packages/pii-scanner/tests/credentials/resolvers/test_file.py
+++ b/packages/pii-scanner/tests/credentials/resolvers/test_file.py
@@ -14,14 +14,21 @@ from pleno_pii_scanner.credentials.resolvers.file import default_credentials_pat
 
 
 class TestDefaultCredentialsPath:
-    def test_xdg_config_home_honored(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def test_xdg_config_home_honored(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         assert default_credentials_path() == tmp_path / "pleno" / "credentials.toml"
 
-    def test_falls_back_to_home(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def test_falls_back_to_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
-        assert default_credentials_path() == tmp_path / ".config" / "pleno" / "credentials.toml"
+        assert (
+            default_credentials_path()
+            == tmp_path / ".config" / "pleno" / "credentials.toml"
+        )
 
 
 class TestFileCredentialResolver:
@@ -48,7 +55,7 @@ class TestFileCredentialResolver:
     async def test_aws_iam_with_extra_fields(self, tmp_path: Path) -> None:
         f = tmp_path / "creds.toml"
         f.write_text(
-            '[aws.prod]\n'
+            "[aws.prod]\n"
             'kind = "aws-iam"\n'
             'access_key_id = "AKIA..."\n'
             'secret_access_key = "wJa..."\n'
@@ -64,13 +71,15 @@ class TestFileCredentialResolver:
 
     async def test_private_key_path_expansion(self, tmp_path: Path) -> None:
         pem_path = tmp_path / "github-app.pem"
-        pem_path.write_text("-----BEGIN PRIVATE KEY-----\nDATA\n-----END-----\n", encoding="utf-8")
+        pem_path.write_text(
+            "-----BEGIN PRIVATE KEY-----\nDATA\n-----END-----\n", encoding="utf-8"
+        )
         f = tmp_path / "creds.toml"
         f.write_text(
-            f'[github.work]\n'
+            f"[github.work]\n"
             f'kind = "github-app"\n'
-            f'app_id = 12345\n'
-            f'installation_id = 678\n'
+            f"app_id = 12345\n"
+            f"installation_id = 678\n"
             f'private_key_path = "{pem_path}"\n',
             encoding="utf-8",
         )
@@ -85,10 +94,10 @@ class TestFileCredentialResolver:
     async def test_private_key_path_unreadable(self, tmp_path: Path) -> None:
         f = tmp_path / "creds.toml"
         f.write_text(
-            '[github.work]\n'
+            "[github.work]\n"
             'kind = "github-app"\n'
-            'app_id = 1\n'
-            'installation_id = 1\n'
+            "app_id = 1\n"
+            "installation_id = 1\n"
             'private_key_path = "/nonexistent/path/key.pem"\n',
             encoding="utf-8",
         )
@@ -107,7 +116,9 @@ class TestFileCredentialResolver:
         f = tmp_path / "creds.toml"
         f.write_text('[github.default]\ntoken = "x"\n', encoding="utf-8")
         r = FileCredentialResolver(path=f)
-        with pytest.raises(CredentialMisconfiguredError, match="missing required `kind`"):
+        with pytest.raises(
+            CredentialMisconfiguredError, match="missing required `kind`"
+        ):
             await r.resolve("github-pat", "default")
 
     async def test_kind_must_be_string(self, tmp_path: Path) -> None:
@@ -123,10 +134,7 @@ class TestFileCredentialResolver:
         # github-pat was requested.
         f = tmp_path / "creds.toml"
         f.write_text(
-            '[github.default]\n'
-            'kind = "github-app"\n'
-            'app_id = 1\n'
-            'installation_id = 1\n',
+            '[github.default]\nkind = "github-app"\napp_id = 1\ninstallation_id = 1\n',
             encoding="utf-8",
         )
         r = FileCredentialResolver(path=f)
@@ -134,13 +142,18 @@ class TestFileCredentialResolver:
 
     async def test_missing_section_returns_none(self, tmp_path: Path) -> None:
         f = tmp_path / "creds.toml"
-        f.write_text('[aws.prod]\nkind = "aws-iam"\naccess_key_id = "x"\nsecret_access_key = "y"\n', encoding="utf-8")
+        f.write_text(
+            '[aws.prod]\nkind = "aws-iam"\naccess_key_id = "x"\nsecret_access_key = "y"\n',
+            encoding="utf-8",
+        )
         r = FileCredentialResolver(path=f)
         assert await r.resolve("github-pat", "default") is None
 
     async def test_missing_name_returns_none(self, tmp_path: Path) -> None:
         f = tmp_path / "creds.toml"
-        f.write_text('[github.work]\nkind = "github-pat"\ntoken = "x"\n', encoding="utf-8")
+        f.write_text(
+            '[github.work]\nkind = "github-pat"\ntoken = "x"\n', encoding="utf-8"
+        )
         r = FileCredentialResolver(path=f)
         assert await r.resolve("github-pat", "missing-name") is None
 
@@ -176,35 +189,44 @@ class TestFileCredentialResolver:
         with pytest.raises(NotImplementedError, match="SOPS"):
             await r.resolve("github-pat", "default")
 
-    async def test_default_path_used_when_explicit_none(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    async def test_default_path_used_when_explicit_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         # Set XDG so default path lands inside tmp_path; create credential there.
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         creds = tmp_path / "pleno" / "credentials.toml"
         creds.parent.mkdir(parents=True)
-        creds.write_text('[github.default]\nkind = "github-pat"\ntoken = "x"\n', encoding="utf-8")
+        creds.write_text(
+            '[github.default]\nkind = "github-pat"\ntoken = "x"\n', encoding="utf-8"
+        )
         r = FileCredentialResolver()
         cred = await r.resolve("github-pat", "default")
         assert cred is not None
 
     async def test_load_caches(self, tmp_path: Path) -> None:
         f = tmp_path / "creds.toml"
-        f.write_text('[github.default]\nkind = "github-pat"\ntoken = "x"\n', encoding="utf-8")
+        f.write_text(
+            '[github.default]\nkind = "github-pat"\ntoken = "x"\n', encoding="utf-8"
+        )
         r = FileCredentialResolver(path=f)
         await r.resolve("github-pat", "default")
         # Mutate file: cached resolver should still return the original.
-        f.write_text('[github.default]\nkind = "github-pat"\ntoken = "rotated"\n', encoding="utf-8")
+        f.write_text(
+            '[github.default]\nkind = "github-pat"\ntoken = "rotated"\n',
+            encoding="utf-8",
+        )
         cred = await r.resolve("github-pat", "default")
         assert cred is not None
         assert cred.payload["token"] == "x"
 
-    async def test_exact_kind_lookup_used_when_family_misses(self, tmp_path: Path) -> None:
+    async def test_exact_kind_lookup_used_when_family_misses(
+        self, tmp_path: Path
+    ) -> None:
         # When the TOML uses [github-pat.default] form rather than the
         # family form, exact-kind lookup must still find it.
         f = tmp_path / "creds.toml"
         f.write_text(
-            '[github-pat.default]\n'
-            'kind = "github-pat"\n'
-            'token = "exact"\n',
+            '[github-pat.default]\nkind = "github-pat"\ntoken = "exact"\n',
             encoding="utf-8",
         )
         r = FileCredentialResolver(path=f)

--- a/packages/pii-scanner/tests/credentials/resolvers/test_keyring.py
+++ b/packages/pii-scanner/tests/credentials/resolvers/test_keyring.py
@@ -12,7 +12,11 @@ from pleno_pii_scanner.credentials.resolvers.keyring import SERVICE_NAME
 
 
 class FakeBackend:
-    def __init__(self, store: dict[tuple[str, str], str] | None = None, raises: Exception | None = None) -> None:
+    def __init__(
+        self,
+        store: dict[tuple[str, str], str] | None = None,
+        raises: Exception | None = None,
+    ) -> None:
         self.store = store or {}
         self.raises = raises
         self.calls: list[tuple[str, str]] = []
@@ -40,7 +44,9 @@ class TestKeyringResolverNoOp:
 
 class TestKeyringResolverWithBackend:
     async def test_bare_token(self) -> None:
-        backend = FakeBackend(store={(SERVICE_NAME, "github-pat:default"): "ghp_secret"})
+        backend = FakeBackend(
+            store={(SERVICE_NAME, "github-pat:default"): "ghp_secret"}
+        )
         r = KeyringCredentialResolver(backend=backend)
         cred = await r.resolve("github-pat", "default")
         assert cred is not None
@@ -52,7 +58,10 @@ class TestKeyringResolverWithBackend:
     async def test_json_payload(self) -> None:
         backend = FakeBackend(
             store={
-                (SERVICE_NAME, "aws-iam:prod"): '{"access_key_id":"AKIA","secret_access_key":"wJa","region":"us-east-1"}'
+                (
+                    SERVICE_NAME,
+                    "aws-iam:prod",
+                ): '{"access_key_id":"AKIA","secret_access_key":"wJa","region":"us-east-1"}'
             }
         )
         r = KeyringCredentialResolver(backend=backend)
@@ -77,7 +86,9 @@ class TestKeyringResolverWithBackend:
     async def test_json_root_must_be_object(self) -> None:
         backend = FakeBackend(store={(SERVICE_NAME, "x:default"): "[1,2,3]"})
         r = KeyringCredentialResolver(backend=backend)
-        with pytest.raises(CredentialMisconfiguredError, match="JSON root must be an object"):
+        with pytest.raises(
+            CredentialMisconfiguredError, match="JSON root must be an object"
+        ):
             await r.resolve("x", "default")
 
     async def test_backend_exception_wraps(self) -> None:
@@ -87,7 +98,9 @@ class TestKeyringResolverWithBackend:
             await r.resolve("github-pat", "default")
 
     async def test_whitespace_around_bare_token(self) -> None:
-        backend = FakeBackend(store={(SERVICE_NAME, "github-pat:default"): "  ghp_xxx  \n"})
+        backend = FakeBackend(
+            store={(SERVICE_NAME, "github-pat:default"): "  ghp_xxx  \n"}
+        )
         r = KeyringCredentialResolver(backend=backend)
         cred = await r.resolve("github-pat", "default")
         assert cred is not None
@@ -124,7 +137,9 @@ class TestKeyringLibraryImport:
         result = _try_import_keyring()
         assert result is None or hasattr(result, "get_password")
 
-    def test_loader_returns_module_when_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_loader_returns_module_when_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Inject a fake `keyring` module so the import-success branch
         # is exercised even when the real library is not installed.
         import sys

--- a/packages/pii-scanner/tests/credentials/test_broker.py
+++ b/packages/pii-scanner/tests/credentials/test_broker.py
@@ -157,8 +157,12 @@ class TestCredentialBroker:
     async def test_returns_first_matching_resolver(self) -> None:
         target = Credential(kind="github-pat", payload={"token": "x"})
         r1 = StaticResolver("low", priority=10, match=None)
-        r2 = StaticResolver("hit", priority=50, match=("github-pat", "default"), cred=target)
-        r3 = StaticResolver("never", priority=5, match=("github-pat", "default"), cred=target)
+        r2 = StaticResolver(
+            "hit", priority=50, match=("github-pat", "default"), cred=target
+        )
+        r3 = StaticResolver(
+            "never", priority=5, match=("github-pat", "default"), cred=target
+        )
         broker = CredentialBroker([r1, r2, r3])
         got = await broker.get("github-pat")
         assert got is target
@@ -168,8 +172,12 @@ class TestCredentialBroker:
     async def test_priority_order_descending(self) -> None:
         target_high = Credential(kind="aws-iam", payload={"token": "high"})
         target_low = Credential(kind="aws-iam", payload={"token": "low"})
-        low = StaticResolver("low", priority=1, match=("aws-iam", "default"), cred=target_low)
-        high = StaticResolver("high", priority=99, match=("aws-iam", "default"), cred=target_high)
+        low = StaticResolver(
+            "low", priority=1, match=("aws-iam", "default"), cred=target_low
+        )
+        high = StaticResolver(
+            "high", priority=99, match=("aws-iam", "default"), cred=target_high
+        )
         broker = CredentialBroker([low, high])
         got = await broker.get("aws-iam")
         assert got is target_high
@@ -178,10 +186,14 @@ class TestCredentialBroker:
 
     async def test_register_resolver_re_sorts(self) -> None:
         existing = Credential(kind="github-pat", payload={"token": "old"})
-        r_old = StaticResolver("old", priority=10, match=("github-pat", "default"), cred=existing)
+        r_old = StaticResolver(
+            "old", priority=10, match=("github-pat", "default"), cred=existing
+        )
         broker = CredentialBroker([r_old])
         new_target = Credential(kind="github-pat", payload={"token": "new"})
-        r_new = StaticResolver("new", priority=99, match=("github-pat", "default"), cred=new_target)
+        r_new = StaticResolver(
+            "new", priority=99, match=("github-pat", "default"), cred=new_target
+        )
         broker.register_resolver(r_new)
         got = await broker.get("github-pat")
         assert got is new_target
@@ -213,7 +225,9 @@ class TestCredentialBroker:
 
     async def test_default_name_is_default(self) -> None:
         target = Credential(kind="slack-bot", payload={"token": "x"})
-        r = StaticResolver("env", priority=10, match=("slack-bot", "default"), cred=target)
+        r = StaticResolver(
+            "env", priority=10, match=("slack-bot", "default"), cred=target
+        )
         broker = CredentialBroker([r])
         await broker.get("slack-bot")
         assert r.calls == [("slack-bot", "default")]
@@ -236,8 +250,12 @@ class TestCredentialBroker:
     async def test_get_for_profile_delegates(self) -> None:
         from pleno_pii_scanner.credentials import CredentialProfile
 
-        target = Credential(kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"})
-        r = StaticResolver("env", priority=10, match=("aws-iam", "default"), cred=target)
+        target = Credential(
+            kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"}
+        )
+        r = StaticResolver(
+            "env", priority=10, match=("aws-iam", "default"), cred=target
+        )
         broker = CredentialBroker([r])
         profile = CredentialProfile(name="p", base="aws-iam:default")
         got = await broker.get_for_profile(profile)

--- a/packages/pii-scanner/tests/credentials/test_profile.py
+++ b/packages/pii-scanner/tests/credentials/test_profile.py
@@ -83,25 +83,33 @@ class TestCredentialProfile:
 
 class TestApplyChain:
     async def test_no_chain_returns_base(self) -> None:
-        base = Credential(kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"})
+        base = Credential(
+            kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"}
+        )
         broker = CredentialBroker([StaticResolver("aws-iam", "default", base)])
         profile = CredentialProfile(name="p", base="aws-iam:default")
         got = await apply_chain(broker, profile)
         assert got is base
 
     async def test_missing_plugin_raises(self) -> None:
-        base = Credential(kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"})
+        base = Credential(
+            kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"}
+        )
         broker = CredentialBroker([StaticResolver("aws-iam", "default", base)])
         profile = CredentialProfile(
             name="p",
             base="aws-iam:default",
-            chain=(AssumeRoleHop(provider="aws", role_arn_or_id="arn:aws:iam::1:role/x"),),
+            chain=(
+                AssumeRoleHop(provider="aws", role_arn_or_id="arn:aws:iam::1:role/x"),
+            ),
         )
         with pytest.raises(NotImplementedError, match="pleno-pii-scanner-aws"):
             await apply_chain(broker, profile)
 
     async def test_plugin_invocation(self) -> None:
-        base = Credential(kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"})
+        base = Credential(
+            kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"}
+        )
         broker = CredentialBroker([StaticResolver("aws-iam", "default", base)])
         captured: list[tuple[Credential, AssumeRoleHop]] = []
 
@@ -114,7 +122,9 @@ class TestApplyChain:
             )
 
         register_hop_plugin("aws", fake_aws)
-        hop = AssumeRoleHop(provider="aws", role_arn_or_id="arn:aws:iam::1:role/x", external_id="ext")
+        hop = AssumeRoleHop(
+            provider="aws", role_arn_or_id="arn:aws:iam::1:role/x", external_id="ext"
+        )
         profile = CredentialProfile(name="p", base="aws-iam:default", chain=(hop,))
         result = await apply_chain(broker, profile)
         assert result.payload["access_key_id"] == "STS-id"
@@ -122,7 +132,10 @@ class TestApplyChain:
         assert captured == [(base, hop)]
 
     async def test_plugin_chain_walks_in_order(self) -> None:
-        base = Credential(kind="aws-iam", payload={"access_key_id": "base", "secret_access_key": "base"})
+        base = Credential(
+            kind="aws-iam",
+            payload={"access_key_id": "base", "secret_access_key": "base"},
+        )
         broker = CredentialBroker([StaticResolver("aws-iam", "default", base)])
 
         async def aws(cred: Credential, hop: AssumeRoleHop) -> Credential:
@@ -148,14 +161,22 @@ class TestApplyChain:
         assert result.payload["access_key_id"] == "base->role-A->role-B"
 
     async def test_register_hop_plugin_replaces(self) -> None:
-        base = Credential(kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"})
+        base = Credential(
+            kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"}
+        )
         broker = CredentialBroker([StaticResolver("aws-iam", "default", base)])
 
         async def first(cred: Credential, hop: AssumeRoleHop) -> Credential:
-            return Credential(kind="aws-iam", payload={"access_key_id": "first", "secret_access_key": "x"})
+            return Credential(
+                kind="aws-iam",
+                payload={"access_key_id": "first", "secret_access_key": "x"},
+            )
 
         async def second(cred: Credential, hop: AssumeRoleHop) -> Credential:
-            return Credential(kind="aws-iam", payload={"access_key_id": "second", "secret_access_key": "x"})
+            return Credential(
+                kind="aws-iam",
+                payload={"access_key_id": "second", "secret_access_key": "x"},
+            )
 
         register_hop_plugin("aws", first)
         register_hop_plugin("aws", second)
@@ -173,11 +194,16 @@ class TestApplyChain:
         assert registered_hop_providers() == ()
 
     async def test_broker_get_for_profile_uses_apply_chain(self) -> None:
-        base = Credential(kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"})
+        base = Credential(
+            kind="aws-iam", payload={"access_key_id": "x", "secret_access_key": "y"}
+        )
         broker = CredentialBroker([StaticResolver("aws-iam", "default", base)])
 
         async def aws(cred: Credential, hop: AssumeRoleHop) -> Credential:
-            return Credential(kind="aws-iam", payload={"access_key_id": "STS", "secret_access_key": "STS"})
+            return Credential(
+                kind="aws-iam",
+                payload={"access_key_id": "STS", "secret_access_key": "STS"},
+            )
 
         register_hop_plugin("aws", aws)
         profile = CredentialProfile(

--- a/packages/pii-scanner/tests/extractors/test_archive.py
+++ b/packages/pii-scanner/tests/extractors/test_archive.py
@@ -103,9 +103,7 @@ class TestBombGuard:
 
     @pytest.mark.asyncio
     async def test_oversized_member_skipped_with_warning(self) -> None:
-        ex = ArchiveExtractor(
-            BombGuardConfig(max_member_size=10, max_expansion=1000)
-        )
+        ex = ArchiveExtractor(BombGuardConfig(max_member_size=10, max_expansion=1000))
         blob = make_zip(
             {
                 "small.txt": b"ok",
@@ -153,9 +151,7 @@ class TestTarExtraction:
 
     @pytest.mark.asyncio
     async def test_tar_oversized_member_skipped(self) -> None:
-        ex = ArchiveExtractor(
-            BombGuardConfig(max_member_size=4, max_expansion=10000)
-        )
+        ex = ArchiveExtractor(BombGuardConfig(max_member_size=4, max_expansion=10000))
         blob = make_tar({"big.txt": b"x" * 50, "small.txt": b"hi"})
         with pytest.warns(ExtractionWarning, match="big.txt"):
             frags = await collect(ex, _doc(blob))
@@ -271,7 +267,6 @@ class TestEdgeCases:
 
         ex = ArchiveExtractor()
         blob = make_tar({"a.txt": b"hello"})
-        original = tarfile.TarFile.extractfile
 
         def fake_extractfile(self, member):  # noqa: ANN001, ANN201
             return None

--- a/packages/pii-scanner/tests/extractors/test_base.py
+++ b/packages/pii-scanner/tests/extractors/test_base.py
@@ -24,21 +24,19 @@ from pleno_pii_scanner.sources.base import Document, DocumentRef
 
 
 def _ref(**overrides: object) -> DocumentRef:
-    base: dict[str, object] = dict(
-        source_id="t:s", source_kind="t", path="p"
-    )
+    base: dict[str, object] = dict(source_id="t:s", source_kind="t", path="p")
     base.update(overrides)
     return DocumentRef(**base)  # type: ignore[arg-type]
 
 
 class _FakeExtractor:
-    def __init__(self, name: str = "fake", patterns_: frozenset[str] = frozenset()) -> None:
+    def __init__(
+        self, name: str = "fake", patterns_: frozenset[str] = frozenset()
+    ) -> None:
         self.name = name
         self.accepts = patterns_
 
-    async def extract(
-        self, doc: Document
-    ) -> AsyncIterator[ExtractedFragment]:
+    async def extract(self, doc: Document) -> AsyncIterator[ExtractedFragment]:
         yield ExtractedFragment(
             text="x", path_hint="hint", byte_offset=0, extractor=self.name
         )

--- a/packages/pii-scanner/tests/extractors/test_columnar.py
+++ b/packages/pii-scanner/tests/extractors/test_columnar.py
@@ -56,9 +56,7 @@ class TestCsvExtractor:
     @pytest.mark.asyncio
     async def test_binary_input_decoded(self) -> None:
         ex = CsvExtractor()
-        frags = await collect(
-            ex, Document(ref=_ref(), binary=b"name\nfoo\nbar\n")
-        )
+        frags = await collect(ex, Document(ref=_ref(), binary=b"name\nfoo\nbar\n"))
         texts = [f.text for f in frags]
         assert "foo" in texts
         assert "bar" in texts
@@ -82,8 +80,7 @@ class TestJsonlExtractor:
         text = '{"user":{"contact":{"email":"a@b.c"}}}\n'
         frags = await collect(ex, Document(ref=_ref(), text=text))
         assert any(
-            f.text == "a@b.c" and "/user/contact/email" in f.path_hint
-            for f in frags
+            f.text == "a@b.c" and "/user/contact/email" in f.path_hint for f in frags
         )
 
     @pytest.mark.asyncio

--- a/packages/pii-scanner/tests/extractors/test_html.py
+++ b/packages/pii-scanner/tests/extractors/test_html.py
@@ -25,7 +25,7 @@ class TestHtmlExtractor:
     async def test_script_block_dropped(self) -> None:
         ex = HtmlExtractor()
         html = (
-            "<html><body><script>secret_token=\"abc123\"</script>"
+            '<html><body><script>secret_token="abc123"</script>'
             "<p>visible</p></body></html>"
         )
         frags = await collect(ex, Document(ref=_ref(), text=html))
@@ -76,10 +76,8 @@ class TestHtmlExtractor:
     async def test_meta_charset_honored(self) -> None:
         ex = HtmlExtractor()
         body = (
-            b"<html><head><meta charset=\"shift_jis\"></head>"
-            b"<body><p>"
-            + "山田".encode("shift_jis")
-            + b"</p></body></html>"
+            b'<html><head><meta charset="shift_jis"></head>'
+            b"<body><p>" + "山田".encode("shift_jis") + b"</p></body></html>"
         )
         frags = await collect(ex, Document(ref=_ref(), binary=body))
         assert "山田" in frags[0].text
@@ -88,7 +86,7 @@ class TestHtmlExtractor:
     async def test_unknown_meta_charset_falls_back(self) -> None:
         ex = HtmlExtractor()
         body = (
-            b"<html><head><meta charset=\"definitely-not-real\"></head>"
+            b'<html><head><meta charset="definitely-not-real"></head>'
             b"<body>x</body></html>"
         )
         frags = await collect(ex, Document(ref=_ref(), binary=body))

--- a/packages/pii-scanner/tests/extractors/test_office.py
+++ b/packages/pii-scanner/tests/extractors/test_office.py
@@ -10,13 +10,13 @@ docx_mod = pytest.importorskip("docx")
 openpyxl = pytest.importorskip("openpyxl")
 pptx_mod = pytest.importorskip("pptx")
 
-from pleno_pii_scanner.extractors import collect
-from pleno_pii_scanner.extractors.office import (
+from pleno_pii_scanner.extractors import collect  # noqa: E402
+from pleno_pii_scanner.extractors.office import (  # noqa: E402
     DocxExtractor,
     PptxExtractor,
     XlsxExtractor,
 )
-from pleno_pii_scanner.sources.base import Document, DocumentRef
+from pleno_pii_scanner.sources.base import Document, DocumentRef  # noqa: E402
 
 
 def _ref() -> DocumentRef:

--- a/packages/pii-scanner/tests/extractors/test_pdf.py
+++ b/packages/pii-scanner/tests/extractors/test_pdf.py
@@ -6,9 +6,9 @@ import pytest
 
 pdfium = pytest.importorskip("pypdfium2")
 
-from pleno_pii_scanner.extractors import collect
-from pleno_pii_scanner.extractors.pdf import PdfExtractor
-from pleno_pii_scanner.sources.base import Document, DocumentRef
+from pleno_pii_scanner.extractors import collect  # noqa: E402
+from pleno_pii_scanner.extractors.pdf import PdfExtractor  # noqa: E402
+from pleno_pii_scanner.sources.base import Document, DocumentRef  # noqa: E402
 
 
 def _ref() -> DocumentRef:

--- a/packages/pii-scanner/tests/extractors/test_sniff.py
+++ b/packages/pii-scanner/tests/extractors/test_sniff.py
@@ -107,6 +107,7 @@ class TestSniffMagic:
         # ODF: a zip whose first member is "mimetype" carrying an
         # opendocument MIME string, stored uncompressed at offset 30.
         import zipfile
+
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w") as zf:
             zi = zipfile.ZipInfo("mimetype")

--- a/packages/pii-scanner/tests/extractors/test_text.py
+++ b/packages/pii-scanner/tests/extractors/test_text.py
@@ -62,7 +62,9 @@ class TestDecodeBytes:
     def test_utf8_round_trip(self) -> None:
         assert decode_bytes("hello".encode()) == "hello"
 
-    def test_garbage_falls_back_to_replace(self, recwarn: pytest.WarningsRecorder) -> None:
+    def test_garbage_falls_back_to_replace(
+        self, recwarn: pytest.WarningsRecorder
+    ) -> None:
         # A short fully-random byte string defeats charset detection;
         # the decoder must still return a usable str rather than raise.
         # Repeated 0xFF is not valid UTF-8 nor any common encoding's

--- a/packages/pii-scanner/tests/findings_store/test_encryption.py
+++ b/packages/pii-scanner/tests/findings_store/test_encryption.py
@@ -165,9 +165,7 @@ class TestPayloadAEAD:
         dek = generate_dek()
         aead = AESGCM(dek)
         nonce = os.urandom(NONCE_SIZE)
-        combined = aead.encrypt(
-            nonce, _json.dumps([1, 2, 3]).encode(), b"tenant-a"
-        )
+        combined = aead.encrypt(nonce, _json.dumps([1, 2, 3]).encode(), b"tenant-a")
         bad = EncryptedPayload(
             tenant_id="tenant-a",
             nonce=nonce,
@@ -181,9 +179,7 @@ class TestPayloadAEAD:
 class TestEncryptedPayloadHygiene:
     def test_repr_does_not_leak_ciphertext(self) -> None:
         dek = generate_dek()
-        payload = encrypt_payload(
-            dek, "tenant-a", {"matched": "DO-NOT-LOG-RAW"}
-        )
+        payload = encrypt_payload(dek, "tenant-a", {"matched": "DO-NOT-LOG-RAW"})
         text = repr(payload)
         assert "redacted" in text
         # The base64 of the ciphertext should not appear; in particular

--- a/packages/pii-scanner/tests/findings_store/test_jsonl_shard.py
+++ b/packages/pii-scanner/tests/findings_store/test_jsonl_shard.py
@@ -89,7 +89,8 @@ class TestWriterReader:
         await writer.close()
         with pytest.raises(RuntimeError, match="closed"):
             await writer.write_batch(
-                ["a"], ["b"],
+                ["a"],
+                ["b"],
                 [encrypt_payload(dek, "t", {"matched": "x"})],
             )
 
@@ -109,11 +110,13 @@ class TestWriterReader:
         dek = generate_dek()
         try:
             await writer.write_batch(
-                ["a"], ["fp-a"],
+                ["a"],
+                ["fp-a"],
                 [encrypt_payload(dek, "t", {"matched": "1"})],
             )
             await writer.write_batch(
-                ["b"], ["fp-b"],
+                ["b"],
+                ["fp-b"],
                 [encrypt_payload(dek, "t", {"matched": "2"})],
             )
         finally:

--- a/packages/pii-scanner/tests/findings_store/test_memory_store.py
+++ b/packages/pii-scanner/tests/findings_store/test_memory_store.py
@@ -53,9 +53,7 @@ class TestSaveAndQuery:
 
     @pytest.mark.asyncio
     async def test_query_filters(self, kek: InMemoryKekProvider) -> None:
-        async with MemoryFindingsStore(
-            kek=kek, source_kind="dir"
-        ) as store:
+        async with MemoryFindingsStore(kek=kek, source_kind="dir") as store:
             await store.save_findings(
                 "scan-1",
                 "src-a",
@@ -114,9 +112,7 @@ class TestSaveAndQuery:
 
 class TestRevealValueAudit:
     @pytest.mark.asyncio
-    async def test_reveal_round_trip(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_reveal_round_trip(self, kek: InMemoryKekProvider) -> None:
         spy: list[tuple[str, str]] = []
 
         def hook(fid: str, who: str) -> None:
@@ -148,9 +144,7 @@ class TestRevealValueAudit:
             )
             assert ref.finding_count == 1
             recs = await store.query(scan_id="scan-1")
-            await store.reveal_value(
-                recs[0].finding_id, audit_principal="bob@ops"
-            )
+            await store.reveal_value(recs[0].finding_id, audit_principal="bob@ops")
             assert spy == ["bob@ops"]
 
     @pytest.mark.asyncio
@@ -175,9 +169,7 @@ class TestRevealValueAudit:
             )
             recs = await store.query()
             assert ref.finding_count == 1
-            value = await store.reveal_value(
-                recs[0].finding_id, audit_principal="ops"
-            )
+            value = await store.reveal_value(recs[0].finding_id, audit_principal="ops")
             assert value == "y@z"
 
 
@@ -208,9 +200,7 @@ class TestSecretHygiene:
         assert "sneaky-pw-321" not in caplog.text
 
     @pytest.mark.asyncio
-    async def test_exception_message_no_raw(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_exception_message_no_raw(self, kek: InMemoryKekProvider) -> None:
         async with MemoryFindingsStore(kek=kek) as store:
             await store.save_findings(
                 "scan-1", "src-a", [_finding(matched="trace-leak-999")]
@@ -224,9 +214,7 @@ class TestSecretHygiene:
 
 class TestLifecycle:
     @pytest.mark.asyncio
-    async def test_use_after_close_raises(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_use_after_close_raises(self, kek: InMemoryKekProvider) -> None:
         store = MemoryFindingsStore(kek=kek)
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):
@@ -239,9 +227,7 @@ class TestLifecycle:
             await store.reveal_value("x", audit_principal="ops")
 
     @pytest.mark.asyncio
-    async def test_close_idempotent(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_close_idempotent(self, kek: InMemoryKekProvider) -> None:
         store = MemoryFindingsStore(kek=kek)
         await store.close()
         await store.close()
@@ -249,14 +235,13 @@ class TestLifecycle:
 
 class TestCustomSeverityClassifier:
     @pytest.mark.asyncio
-    async def test_classifier_overrides_default(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_classifier_overrides_default(self, kek: InMemoryKekProvider) -> None:
         def always_low(_: Finding) -> str:
             return "low"
 
         async with MemoryFindingsStore(
-            kek=kek, severity_classifier=always_low  # type: ignore[arg-type]
+            kek=kek,
+            severity_classifier=always_low,  # type: ignore[arg-type]
         ) as store:
             await store.save_findings(
                 "scan-1",
@@ -287,17 +272,13 @@ class TestCustomSeverityClassifier:
                 ],
             )
             recs = await store.query()
-            f = _finding(
-                entity="AWS_SECRET_ACCESS_KEY", verification="passed"
-            )
+            f = _finding(entity="AWS_SECRET_ACCESS_KEY", verification="passed")
             assert recs[0].severity == default_severity(f)
 
 
 class TestEmptySaves:
     @pytest.mark.asyncio
-    async def test_empty_findings_returns_zero(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_empty_findings_returns_zero(self, kek: InMemoryKekProvider) -> None:
         async with MemoryFindingsStore(kek=kek) as store:
             ref = await store.save_findings("scan-1", "src-a", [])
             assert ref.finding_count == 0
@@ -324,9 +305,7 @@ class TestDekRehydration:
 
 class TestDecryptedPayloadShape:
     @pytest.mark.asyncio
-    async def test_missing_matched_field_raises(
-        self, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_missing_matched_field_raises(self, kek: InMemoryKekProvider) -> None:
         from pleno_pii_scanner.findings_store.encryption import (
             EncryptionError,
             encrypt_payload,
@@ -336,9 +315,7 @@ class TestDecryptedPayloadShape:
         try:
             dek = await store._ensure_dek()
             # Hand-craft a payload whose plaintext lacks "matched".
-            payload = encrypt_payload(
-                dek, store._tenant_id, {"snippet": "..."}
-            )
+            payload = encrypt_payload(dek, store._tenant_id, {"snippet": "..."})
             store._payloads["forged"] = payload
             from datetime import UTC, datetime
 
@@ -380,15 +357,10 @@ class TestParallelSources:
                 await store.save_findings(
                     "scan-1",
                     src,
-                    [
-                        _finding(matched=f"v-{src}-{i}")
-                        for i in range(5)
-                    ],
+                    [_finding(matched=f"v-{src}-{i}") for i in range(5)],
                 )
 
-            await asyncio.gather(
-                *(save(f"src-{i:02d}") for i in range(8))
-            )
+            await asyncio.gather(*(save(f"src-{i:02d}") for i in range(8)))
             recs = await store.query(scan_id="scan-1", limit=1000)
             ids = [r.finding_id for r in recs]
             assert len(ids) == 8 * 5

--- a/packages/pii-scanner/tests/findings_store/test_sqlite_index.py
+++ b/packages/pii-scanner/tests/findings_store/test_sqlite_index.py
@@ -42,9 +42,7 @@ def kek(capsys: pytest.CaptureFixture[str]) -> InMemoryKekProvider:
 
 
 class TestDefaultIndexPath:
-    def test_uses_xdg(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_uses_xdg(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
         assert default_index_path("scan-x") == (
             tmp_path / "pleno" / "scan-x" / "findings.sqlite"
@@ -56,8 +54,7 @@ class TestDefaultIndexPath:
         monkeypatch.delenv("XDG_STATE_HOME", raising=False)
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         assert default_index_path("scan-x") == (
-            tmp_path / ".local" / "state" / "pleno" / "scan-x"
-            / "findings.sqlite"
+            tmp_path / ".local" / "state" / "pleno" / "scan-x" / "findings.sqlite"
         )
 
     def test_empty_xdg_falls_back(
@@ -66,8 +63,7 @@ class TestDefaultIndexPath:
         monkeypatch.setenv("XDG_STATE_HOME", "")
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         assert default_index_path("scan-x") == (
-            tmp_path / ".local" / "state" / "pleno" / "scan-x"
-            / "findings.sqlite"
+            tmp_path / ".local" / "state" / "pleno" / "scan-x" / "findings.sqlite"
         )
 
 
@@ -152,9 +148,7 @@ class TestOpenAndClose:
             index_path=tmp_path / "f.sqlite",
             shard_base=tmp_path / "shards",
         ) as store:
-            await store.save_findings(
-                "scan-1", "src-a", [_finding()]
-            )
+            await store.save_findings("scan-1", "src-a", [_finding()])
         # Reopen and confirm survival
         async with await SqliteFindingsStore.open(
             "scan-1",
@@ -214,9 +208,7 @@ class TestSaveQueryGet:
             assert await store.get("absent") is None
 
     @pytest.mark.asyncio
-    async def test_pagination(
-        self, tmp_path: Path, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_pagination(self, tmp_path: Path, kek: InMemoryKekProvider) -> None:
         async with await SqliteFindingsStore.open(
             "scan-1",
             kek=kek,
@@ -347,9 +339,7 @@ class TestRevealValue:
                 "scan-1", "src-a", [_finding(matched="async-secret")]
             )
             recs = await store.query()
-            value = await store.reveal_value(
-                recs[0].finding_id, audit_principal="ops"
-            )
+            value = await store.reveal_value(recs[0].finding_id, audit_principal="ops")
             assert value == "async-secret"
             assert spy == ["ops"]
 
@@ -383,14 +373,10 @@ class TestRevealValue:
             index_path=tmp_path / "f.sqlite",
             shard_base=tmp_path / "shards",
         ) as store:
-            await store.save_findings(
-                "scan-1", "src-a", [_finding(matched="silent")]
-            )
+            await store.save_findings("scan-1", "src-a", [_finding(matched="silent")])
             recs = await store.query()
             assert (
-                await store.reveal_value(
-                    recs[0].finding_id, audit_principal="x"
-                )
+                await store.reveal_value(recs[0].finding_id, audit_principal="x")
                 == "silent"
             )
 
@@ -411,9 +397,7 @@ class TestRevealValue:
             # Wipe the shard file to simulate disk-side loss.
             ref.path.unlink()
             with pytest.raises(EncryptionError, match="indexed but absent"):
-                await store.reveal_value(
-                    recs[0].finding_id, audit_principal="ops"
-                )
+                await store.reveal_value(recs[0].finding_id, audit_principal="ops")
 
     @pytest.mark.asyncio
     async def test_reveal_with_wrong_kek_fails(
@@ -431,9 +415,7 @@ class TestRevealValue:
             index_path=tmp_path / "f.sqlite",
             shard_base=tmp_path / "shards",
         )
-        await store.save_findings(
-            "scan-1", "src-a", [_finding(matched="protected")]
-        )
+        await store.save_findings("scan-1", "src-a", [_finding(matched="protected")])
         await store.close()
 
         kek_b = InMemoryKekProvider(master_key=b"\x22" * DEK_SIZE)
@@ -447,18 +429,14 @@ class TestRevealValue:
         try:
             recs = await reopened.query()
             with pytest.raises(EncryptionError):
-                await reopened.reveal_value(
-                    recs[0].finding_id, audit_principal="ops"
-                )
+                await reopened.reveal_value(recs[0].finding_id, audit_principal="ops")
         finally:
             await reopened.close()
 
 
 class TestSecretHygiene:
     @pytest.mark.asyncio
-    async def test_repr_no_raw(
-        self, tmp_path: Path, kek: InMemoryKekProvider
-    ) -> None:
+    async def test_repr_no_raw(self, tmp_path: Path, kek: InMemoryKekProvider) -> None:
         async with await SqliteFindingsStore.open(
             "scan-1",
             kek=kek,
@@ -619,9 +597,7 @@ class TestCorruptionPaths:
             shard_base=tmp_path / "shards",
         )
         try:
-            await store.save_findings(
-                "scan-1", "src-a", [_finding(matched="forged")]
-            )
+            await store.save_findings("scan-1", "src-a", [_finding(matched="forged")])
             recs = await store.query()
             dek = await store._ensure_dek()
             # Overwrite the shard with a payload whose tenant_id is wrong.
@@ -640,12 +616,8 @@ class TestCorruptionPaths:
                 [forged],
             )
             await writer.close()
-            with pytest.raises(
-                EncryptionError, match="tenant_id does not match"
-            ):
-                await store.reveal_value(
-                    recs[0].finding_id, audit_principal="ops"
-                )
+            with pytest.raises(EncryptionError, match="tenant_id does not match"):
+                await store.reveal_value(recs[0].finding_id, audit_principal="ops")
         finally:
             await store.close()
 
@@ -668,14 +640,10 @@ class TestCorruptionPaths:
             shard_base=tmp_path / "shards",
         )
         try:
-            await store.save_findings(
-                "scan-1", "src-a", [_finding(matched="trace")]
-            )
+            await store.save_findings("scan-1", "src-a", [_finding(matched="trace")])
             recs = await store.query()
             dek = await store._ensure_dek()
-            path = shard_path(
-                store.shard_base, "scan-1", "src-a", recs[0].shard_index
-            )
+            path = shard_path(store.shard_base, "scan-1", "src-a", recs[0].shard_index)
             path.unlink()
             writer = JsonlShardWriter(path)
             no_matched = encrypt_payload(
@@ -688,9 +656,7 @@ class TestCorruptionPaths:
             )
             await writer.close()
             with pytest.raises(EncryptionError, match="missing 'matched'"):
-                await store.reveal_value(
-                    recs[0].finding_id, audit_principal="ops"
-                )
+                await store.reveal_value(recs[0].finding_id, audit_principal="ops")
         finally:
             await store.close()
 
@@ -725,9 +691,7 @@ class TestNaiveDatetimeBackfill:
             shard_base=tmp_path / "shards",
         )
         try:
-            await store.save_findings(
-                "scan-1", "src-a", [_finding(matched="x")]
-            )
+            await store.save_findings("scan-1", "src-a", [_finding(matched="x")])
             recs = await store.query()
             # Forcibly write a naive datetime to simulate a legacy row.
             await store._conn.execute(
@@ -743,12 +707,8 @@ class TestNaiveDatetimeBackfill:
             await store._conn.commit()
             got = await store.get(recs[0].finding_id)
             assert got is not None
-            assert got.created_at == datetime(
-                2026, 5, 4, 12, tzinfo=UTC
-            )
-            assert got.sla_due_at == datetime(
-                2026, 5, 4, 12, tzinfo=UTC
-            )
+            assert got.created_at == datetime(2026, 5, 4, 12, tzinfo=UTC)
+            assert got.sla_due_at == datetime(2026, 5, 4, 12, tzinfo=UTC)
         finally:
             await store.close()
 

--- a/packages/pii-scanner/tests/fixtures/negative/clean.py
+++ b/packages/pii-scanner/tests/fixtures/negative/clean.py
@@ -1,6 +1,8 @@
 """No PII here. Just code."""
+
 TIMEOUT_SECONDS = 30
 RETRY_COUNT = 3
+
 
 def hello(name: str) -> str:
     return f"Hello, {name}"

--- a/packages/pii-scanner/tests/governance/test_suppression.py
+++ b/packages/pii-scanner/tests/governance/test_suppression.py
@@ -67,9 +67,7 @@ def test_rule_matches_by_fingerprint() -> None:
 
 
 def test_rule_combined_criteria_must_all_match() -> None:
-    r = SuppressionRule(
-        scope="repo", entity="PHONE_NUMBER", path_glob="src/**"
-    )
+    r = SuppressionRule(scope="repo", entity="PHONE_NUMBER", path_glob="src/**")
     assert r.matches(_f(entity="PHONE_NUMBER", file="src/app.py")) is True
     assert r.matches(_f(entity="EMAIL", file="src/app.py")) is False
     assert r.matches(_f(entity="PHONE_NUMBER", file="tests/x.py")) is False
@@ -195,9 +193,7 @@ def test_engine_fingerprint_does_not_apply_to_other_findings() -> None:
     a = _f(matched="090-1111-2222")
     b = _f(matched="090-3333-4444")
     rule = SuppressionRule(scope="repo", fingerprint=a.fingerprint())
-    e = SuppressionEngine(
-        [SuppressionPolicy(scope="repo", name="r", rules=(rule,))]
-    )
+    e = SuppressionEngine([SuppressionPolicy(scope="repo", name="r", rules=(rule,))])
     sa, _ = e.is_suppressed(a, now=NOW)
     sb, _ = e.is_suppressed(b, now=NOW)
     assert sa is True

--- a/packages/pii-scanner/tests/notify/_helpers.py
+++ b/packages/pii-scanner/tests/notify/_helpers.py
@@ -34,7 +34,9 @@ def make_finding(
     )
 
 
-def make_batch(*findings: Finding, scan_id: str = "scan-1", **metadata) -> NotificationBatch:
+def make_batch(
+    *findings: Finding, scan_id: str = "scan-1", **metadata
+) -> NotificationBatch:
     summary: dict[str, int] = {}
     for f in findings:
         bucket = severity_for(f)

--- a/packages/pii-scanner/tests/notify/test_base.py
+++ b/packages/pii-scanner/tests/notify/test_base.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 
 import pytest
 
@@ -226,7 +225,9 @@ async def test_notifier_protocol_runtime_check():
         name = "stub"
 
         async def send(self, batch):
-            return NotificationResult(transport="stub", delivered=True, delivered_count=0)
+            return NotificationResult(
+                transport="stub", delivered=True, delivered_count=0
+            )
 
         async def close(self):
             pass

--- a/packages/pii-scanner/tests/notify/transports/test_jira.py
+++ b/packages/pii-scanner/tests/notify/transports/test_jira.py
@@ -244,9 +244,7 @@ def test_adf_empty_metadata_renders_dash():
         severity_summary={"low": 1},
         metadata={},
     )
-    paragraphs = [
-        node for node in doc["content"] if node["type"] == "paragraph"
-    ]
+    paragraphs = [node for node in doc["content"] if node["type"] == "paragraph"]
     texts = [p["content"][0]["text"] for p in paragraphs]
     assert any("Metadata: -" in t for t in texts)
 
@@ -265,8 +263,6 @@ def test_adf_empty_severity_summary_renders_no_findings():
         severity_summary={},
         metadata={},
     )
-    paragraphs = [
-        node for node in doc["content"] if node["type"] == "paragraph"
-    ]
+    paragraphs = [node for node in doc["content"] if node["type"] == "paragraph"]
     texts = [p["content"][0]["text"] for p in paragraphs]
     assert any("no findings" in t for t in texts)

--- a/packages/pii-scanner/tests/notify/transports/test_slack.py
+++ b/packages/pii-scanner/tests/notify/transports/test_slack.py
@@ -171,9 +171,7 @@ async def test_slack_close_does_not_close_external_client():
         return httpx.Response(200)
 
     client = _client(handler)
-    n = SlackWebhookNotifier(
-        webhook_url="https://hooks.slack.com/x", client=client
-    )
+    n = SlackWebhookNotifier(webhook_url="https://hooks.slack.com/x", client=client)
     await n.close()
     # External client survived (still usable).
     captured["alive"] = not client.is_closed

--- a/packages/pii-scanner/tests/notify/transports/test_smtp.py
+++ b/packages/pii-scanner/tests/notify/transports/test_smtp.py
@@ -37,9 +37,7 @@ def _make(**overrides):
 
 def test_smtp_requires_recipients():
     with pytest.raises(ValueError):
-        SMTPNotifier(
-            host="x", sender="a@b", recipients=[], sender_factory=FakeSender()
-        )
+        SMTPNotifier(host="x", sender="a@b", recipients=[], sender_factory=FakeSender())
 
 
 def test_smtp_requires_tls():

--- a/packages/pii-scanner/tests/notify/transports/test_webhook.py
+++ b/packages/pii-scanner/tests/notify/transports/test_webhook.py
@@ -91,7 +91,6 @@ async def test_webhook_unsigned_request_omits_signature_header():
 
 async def test_verify_hmac_rejects_tampered_payload():
     secret = "k"
-    body = b'{"x":1}'
 
     def handler(request):
         return httpx.Response(200)

--- a/packages/pii-scanner/tests/recognizers/test_custom.py
+++ b/packages/pii-scanner/tests/recognizers/test_custom.py
@@ -96,7 +96,9 @@ score = 0.6
         recognizers, _ = load_custom_recognizers(p)
         assert [r.entity for r in recognizers] == ["A", "B"]
 
-    def test_path_is_expanded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_path_is_expanded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # `~/.config/pleno/custom.toml` style paths must work.
         monkeypatch.setenv("HOME", str(tmp_path))
         target = tmp_path / "custom.toml"

--- a/packages/pii-scanner/tests/recognizers/test_verifiers.py
+++ b/packages/pii-scanner/tests/recognizers/test_verifiers.py
@@ -129,9 +129,7 @@ class TestCallable:
                 {"module": "_pleno_test_no_attr", "function": "nonexistent"},
             ).check("x")
 
-    def test_non_callable_target_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_non_callable_target_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mod = types.ModuleType("_pleno_test_not_callable")
         mod.verify = "not a function"  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "_pleno_test_not_callable", mod)

--- a/packages/pii-scanner/tests/schedule/test_cron.py
+++ b/packages/pii-scanner/tests/schedule/test_cron.py
@@ -164,6 +164,7 @@ class TestNextAfter:
 
     def test_non_utc_input_normalised(self) -> None:
         from datetime import timezone
+
         c = CronExpression.parse("@hourly")
         jst = timezone(timedelta(hours=9))
         # 21:30 JST = 12:30 UTC; next hourly = 13:00 UTC.

--- a/packages/pii-scanner/tests/schedule/test_memory_store.py
+++ b/packages/pii-scanner/tests/schedule/test_memory_store.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import pytest
 
 from pleno_pii_scanner.schedule.base import Schedule
 from pleno_pii_scanner.schedule.cron import CronExpression

--- a/packages/pii-scanner/tests/schedule/test_registry.py
+++ b/packages/pii-scanner/tests/schedule/test_registry.py
@@ -194,9 +194,7 @@ class TestTickCron:
             jitter_calls.append((lo, hi))
             return 0.001
 
-        reg = ScheduleRegistry(
-            store, runner, now_fn=now_fn, jitter_fn=jitter
-        )
+        reg = ScheduleRegistry(store, runner, now_fn=now_fn, jitter_fn=jitter)
         await reg.register(_hourly_schedule(jitter_seconds=15))
         box[0] = datetime(2026, 5, 4, 13, 5, tzinfo=UTC)
         await asyncio.gather(*(await reg.tick()))
@@ -209,12 +207,8 @@ class TestTickCron:
         runner = _Recorder()
         box, now_fn = _frozen_now(datetime(2026, 5, 4, 12, 30, tzinfo=UTC))
         reg = ScheduleRegistry(store, runner, now_fn=now_fn)
-        await reg.register(
-            _hourly_schedule(id="a", plan_ref="shared")
-        )
-        await reg.register(
-            _hourly_schedule(id="b", plan_ref="shared")
-        )
+        await reg.register(_hourly_schedule(id="a", plan_ref="shared"))
+        await reg.register(_hourly_schedule(id="b", plan_ref="shared"))
         box[0] = datetime(2026, 5, 4, 13, 5, tzinfo=UTC)
         await asyncio.gather(*(await reg.tick()))
         # The second due schedule had its plan_ref already claimed.

--- a/packages/pii-scanner/tests/schedule/test_sqlite_store.py
+++ b/packages/pii-scanner/tests/schedule/test_sqlite_store.py
@@ -54,9 +54,7 @@ class TestSqliteScheduleStore:
         loaded = await store.load("s1")
         assert loaded == s
 
-    async def test_load_missing_returns_none(
-        self, store: SqliteScheduleStore
-    ) -> None:
+    async def test_load_missing_returns_none(self, store: SqliteScheduleStore) -> None:
         assert await store.load("missing") is None
 
     async def test_save_upserts(self, store: SqliteScheduleStore) -> None:
@@ -103,31 +101,23 @@ class TestSqliteScheduleStore:
         with pytest.raises(RuntimeError, match="closed"):
             await store.save(_sched())
 
-    async def test_list_after_close_raises(
-        self, store: SqliteScheduleStore
-    ) -> None:
+    async def test_list_after_close_raises(self, store: SqliteScheduleStore) -> None:
         await store.save(_sched())
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):
             await store.list()
 
-    async def test_delete_after_close_raises(
-        self, store: SqliteScheduleStore
-    ) -> None:
+    async def test_delete_after_close_raises(self, store: SqliteScheduleStore) -> None:
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):
             await store.delete("x")
 
-    async def test_load_after_close_raises(
-        self, store: SqliteScheduleStore
-    ) -> None:
+    async def test_load_after_close_raises(self, store: SqliteScheduleStore) -> None:
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):
             await store.load("x")
 
-    async def test_due_after_close_raises(
-        self, store: SqliteScheduleStore
-    ) -> None:
+    async def test_due_after_close_raises(self, store: SqliteScheduleStore) -> None:
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):
             await store.due(datetime(2026, 5, 4, tzinfo=UTC))

--- a/packages/pii-scanner/tests/scheduler/test_core.py
+++ b/packages/pii-scanner/tests/scheduler/test_core.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
-import pytest
 
 from pleno_pii_scanner.scheduler import (
     GlobalRateLimiter,
@@ -113,9 +111,7 @@ async def _scan_collect(emitted: list[tuple[str, str]]):
 
 class TestRunOne:
     async def test_happy_path_emits_all_refs(self) -> None:
-        c = _FakeConnector(
-            id="fake:1", refs=(_ref("fake:1", "a"), _ref("fake:1", "b"))
-        )
+        c = _FakeConnector(id="fake:1", refs=(_ref("fake:1", "a"), _ref("fake:1", "b")))
         emitted: list[tuple[str, str]] = []
         s = Scheduler(config=_config())
         result = await s.run_one(
@@ -269,9 +265,7 @@ class TestRun:
         assert sorted(p for p, _ in emitted) == ["a", "b"]
 
     async def test_one_failing_plan_does_not_cancel_siblings(self) -> None:
-        c_ok = _FakeConnector(
-            id="fake:ok", refs=(_ref("fake:ok", "x"),)
-        )
+        c_ok = _FakeConnector(id="fake:ok", refs=(_ref("fake:ok", "x"),))
         c_bad = _FakeConnector(
             id="fake:bad",
             refs=(_ref("fake:bad", "y"),),

--- a/packages/pii-scanner/tests/scheduler/test_incremental.py
+++ b/packages/pii-scanner/tests/scheduler/test_incremental.py
@@ -52,9 +52,7 @@ class _FlatConnector:
                 path=path,
             )
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         body = next(b for p, b in self.refs if p == ref.path)
         yield Document(ref=ref, text=body, content_hash=f"h:{body}")
 
@@ -109,9 +107,7 @@ class _HierarchicalConnector:
                     metadata={SUBSOURCE_METADATA_KEY: sub_id},
                 )
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         sub_id = ref.metadata[SUBSOURCE_METADATA_KEY]
         path = ref.path[len(sub_id) + 1 :]
         body = next(b for p, b in self.sub_layout[sub_id][1] if p == path)
@@ -187,9 +183,7 @@ class TestDocumentLevelCache:
             assert all(not replayed for *_, replayed in received)
 
             # Re-create the connector — same content, fresh discover.
-            connector2 = _FlatConnector(
-                refs=(("a.txt", "alpha"), ("b.txt", "bravo"))
-            )
+            connector2 = _FlatConnector(refs=(("a.txt", "alpha"), ("b.txt", "bravo")))
             plan2 = SourcePlan(connector=connector2)
             received2, on_findings2 = _collect_findings()
             results2 = await runner.run(

--- a/packages/pii-scanner/tests/scheduler/test_rate_limit.py
+++ b/packages/pii-scanner/tests/scheduler/test_rate_limit.py
@@ -34,7 +34,7 @@ class TestBucketConstruction:
 
     def test_acquire_zero_cost_immediate(self) -> None:
         # not really sensible but should not deadlock.
-        b = AdaptiveTokenBucket(capacity=10, rate=5)
+        AdaptiveTokenBucket(capacity=10, rate=5)
         # we still consume zero tokens, so acquire returns immediately.
         # No assertion needed beyond "doesn't hang".
 

--- a/packages/pii-scanner/tests/secret_verifiers/providers/test_aws.py
+++ b/packages/pii-scanner/tests/secret_verifiers/providers/test_aws.py
@@ -40,7 +40,9 @@ def test_derive_signing_key_matches_aws_docs_example() -> None:
         "us-east-1",
         "iam",
     )
-    assert key.hex() == "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
+    assert (
+        key.hex() == "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
+    )
 
 
 def test_sigv4_sign_post_is_deterministic_for_fixed_inputs() -> None:
@@ -84,9 +86,7 @@ async def test_missing_secret_returns_unknown() -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         raise AssertionError("must not be called when secret is missing")
 
-    result = await AwsVerifier().verify(
-        "AKIAIOSFODNN7EXAMPLE", ctx=_ctx(handler)
-    )
+    result = await AwsVerifier().verify("AKIAIOSFODNN7EXAMPLE", ctx=_ctx(handler))
     assert result.state == "unknown"
     assert "aws_secret_access_key" in result.detail
 

--- a/packages/pii-scanner/tests/secret_verifiers/providers/test_generic_bearer.py
+++ b/packages/pii-scanner/tests/secret_verifiers/providers/test_generic_bearer.py
@@ -64,9 +64,7 @@ async def test_custom_method_post() -> None:
         captured["method"] = request.method
         return httpx.Response(200)
 
-    verifier = GenericBearerVerifier(
-        url="https://api.example.com/me", method="post"
-    )
+    verifier = GenericBearerVerifier(url="https://api.example.com/me", method="post")
     await verifier.verify("tok", ctx=_ctx(handler))
     assert captured["method"] == "POST"
 

--- a/packages/pii-scanner/tests/secret_verifiers/test_base.py
+++ b/packages/pii-scanner/tests/secret_verifiers/test_base.py
@@ -70,9 +70,7 @@ def test_liveness_verifier_protocol_is_runtime_checkable() -> None:
         name = "stub"
         entities = frozenset({"X"})
 
-        async def verify(
-            self, value: str, *, ctx: VerifyContext
-        ) -> VerificationResult:
+        async def verify(self, value: str, *, ctx: VerifyContext) -> VerificationResult:
             return VerificationResult(state="unknown")
 
     assert isinstance(_Stub(), LivenessVerifier)

--- a/packages/pii-scanner/tests/secret_verifiers/test_cache.py
+++ b/packages/pii-scanner/tests/secret_verifiers/test_cache.py
@@ -8,7 +8,9 @@ from pleno_pii_scanner.secret_verifiers.base import VerificationResult
 from pleno_pii_scanner.secret_verifiers.cache import VerificationCache
 
 
-def _result(*, ttl: int = 3600, state: str = "live", at: datetime | None = None) -> VerificationResult:
+def _result(
+    *, ttl: int = 3600, state: str = "live", at: datetime | None = None
+) -> VerificationResult:
     return VerificationResult(
         state=state,  # type: ignore[arg-type]
         detail="",

--- a/packages/pii-scanner/tests/secret_verifiers/test_registry.py
+++ b/packages/pii-scanner/tests/secret_verifiers/test_registry.py
@@ -34,7 +34,9 @@ def _finding(entity: str = "GITHUB_PAT", matched: str = "ghp_token") -> Finding:
 
 
 class _StubVerifier:
-    def __init__(self, name: str, entities: frozenset[str], result: VerificationResult) -> None:
+    def __init__(
+        self, name: str, entities: frozenset[str], result: VerificationResult
+    ) -> None:
         self.name = name
         self.entities = entities
         self.result = result
@@ -58,16 +60,24 @@ def test_register_get_for_entity_names_iter_len() -> None:
 
 def test_register_duplicate_name_rejected() -> None:
     registry = ProviderRegistry()
-    registry.register(_StubVerifier("a", frozenset({"X"}), VerificationResult(state="live")))
+    registry.register(
+        _StubVerifier("a", frozenset({"X"}), VerificationResult(state="live"))
+    )
     with pytest.raises(ValueError):
-        registry.register(_StubVerifier("a", frozenset({"Y"}), VerificationResult(state="live")))
+        registry.register(
+            _StubVerifier("a", frozenset({"Y"}), VerificationResult(state="live"))
+        )
 
 
 def test_register_duplicate_entity_rejected() -> None:
     registry = ProviderRegistry()
-    registry.register(_StubVerifier("a", frozenset({"X"}), VerificationResult(state="live")))
+    registry.register(
+        _StubVerifier("a", frozenset({"X"}), VerificationResult(state="live"))
+    )
     with pytest.raises(ValueError):
-        registry.register(_StubVerifier("b", frozenset({"X"}), VerificationResult(state="live")))
+        registry.register(
+            _StubVerifier("b", frozenset({"X"}), VerificationResult(state="live"))
+        )
 
 
 def test_unregister_removes_provider_and_entity_index() -> None:
@@ -139,7 +149,9 @@ async def test_verify_finding_live_marks_passed() -> None:
 async def test_verify_finding_revoked_marks_failed() -> None:
     registry = ProviderRegistry()
     registry.register(
-        _StubVerifier("s", frozenset({"GITHUB_PAT"}), VerificationResult(state="revoked"))
+        _StubVerifier(
+            "s", frozenset({"GITHUB_PAT"}), VerificationResult(state="revoked")
+        )
     )
     out = await verify_finding(_finding(), registry=registry)
     assert out.verification == "failed"
@@ -148,7 +160,9 @@ async def test_verify_finding_revoked_marks_failed() -> None:
 async def test_verify_finding_unknown_keeps_unverified() -> None:
     registry = ProviderRegistry()
     registry.register(
-        _StubVerifier("s", frozenset({"GITHUB_PAT"}), VerificationResult(state="unknown"))
+        _StubVerifier(
+            "s", frozenset({"GITHUB_PAT"}), VerificationResult(state="unknown")
+        )
     )
     out = await verify_finding(_finding(), registry=registry)
     assert out.verification == "unverified"
@@ -165,7 +179,9 @@ async def test_verify_finding_error_keeps_unverified() -> None:
 
 async def test_verify_finding_uses_cache_hit() -> None:
     registry = ProviderRegistry()
-    stub = _StubVerifier("s", frozenset({"GITHUB_PAT"}), VerificationResult(state="live"))
+    stub = _StubVerifier(
+        "s", frozenset({"GITHUB_PAT"}), VerificationResult(state="live")
+    )
     registry.register(stub)
     cache = VerificationCache()
     finding = _finding()
@@ -249,7 +265,9 @@ async def test_verify_finding_explicit_ctx_passed_through() -> None:
 
     registry = ProviderRegistry()
     registry.register(_CaptureCtx())
-    await verify_finding(_finding(), registry=registry, ctx=VerifyContext(timeout_seconds=2.0))
+    await verify_finding(
+        _finding(), registry=registry, ctx=VerifyContext(timeout_seconds=2.0)
+    )
     assert seen == [2.0]
 
 
@@ -293,7 +311,9 @@ async def test_cache_expired_entry_triggers_re_probe() -> None:
         "s",
         frozenset({"GITHUB_PAT"}),
         VerificationResult(
-            state="live", ttl_seconds=1, checked_at=datetime.now(UTC) - timedelta(seconds=10)
+            state="live",
+            ttl_seconds=1,
+            checked_at=datetime.now(UTC) - timedelta(seconds=10),
         ),
     )
     registry.register(stub)

--- a/packages/pii-scanner/tests/sources/builtin/test_dir_source.py
+++ b/packages/pii-scanner/tests/sources/builtin/test_dir_source.py
@@ -17,7 +17,12 @@ from pleno_pii_scanner.sources import (
     register,
 )
 from pleno_pii_scanner.sources import registry as _registry_mod
-from pleno_pii_scanner.sources.builtin import DIR_KIND, DIR_SPEC, DirConfig, DirConnector
+from pleno_pii_scanner.sources.builtin import (
+    DIR_KIND,
+    DIR_SPEC,
+    DirConfig,
+    DirConnector,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -116,9 +121,7 @@ class TestDiscover:
         assert "secret.txt" not in names
         assert not any("node_modules" in n for n in names)
 
-    async def test_filter_max_size_takes_min_with_config(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_filter_max_size_takes_min_with_config(self, tmp_path: Path) -> None:
         # Discover-time `filter.max_size` is the operator's `--max-file-size`;
         # the connector's own config sets the safety ceiling. The lower of the
         # two wins so a per-scan filter cannot escalate above the configured
@@ -142,18 +145,14 @@ class TestDiscover:
         (tmp_path / "a.txt").write_text("x")
         (tmp_path / "a.md").write_text("y")
         c = DirConnector(DirConfig(root=tmp_path))
-        refs = await _drain_refs(
-            c.discover(SourceFilter(include=("*.md",)), None)
-        )
+        refs = await _drain_refs(c.discover(SourceFilter(include=("*.md",)), None))
         assert [r.path for r in refs] == ["a.md"]
 
     async def test_filter_exclude_overrides_config(self, tmp_path: Path) -> None:
         (tmp_path / "a.txt").write_text("x")
         (tmp_path / "b.txt").write_text("y")
         c = DirConnector(DirConfig(root=tmp_path))
-        refs = await _drain_refs(
-            c.discover(SourceFilter(exclude=("a.txt",)), None)
-        )
+        refs = await _drain_refs(c.discover(SourceFilter(exclude=("a.txt",)), None))
         assert [r.path for r in refs] == ["b.txt"]
 
     async def test_cursor_is_ignored(self, tmp_path: Path) -> None:
@@ -175,9 +174,7 @@ class TestFetch:
         assert docs[0].text == "hello"
         assert docs[0].fetched_at is not None
 
-    async def test_decodes_invalid_utf8_with_replacement(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_decodes_invalid_utf8_with_replacement(self, tmp_path: Path) -> None:
         # walker filters NUL-bearing files; a file with garbled but
         # NUL-free bytes still gets through and must not crash fetch().
         (tmp_path / "broken.txt").write_bytes(b"\xff\xfeABC")
@@ -226,23 +223,21 @@ class TestRaceConditions:
                 raise OSError("simulated race: file disappeared")
             return original_stat(self)
 
-        monkeypatch.setattr(ds, "_safe_size", lambda p: None if p.name == "a.txt" else p.stat().st_size)
+        monkeypatch.setattr(
+            ds, "_safe_size", lambda p: None if p.name == "a.txt" else p.stat().st_size
+        )
 
         refs = await _drain_refs(c.discover(SourceFilter(), None))
         assert refs == []
 
-    async def test_safe_size_returns_none_on_oserror(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_safe_size_returns_none_on_oserror(self, tmp_path: Path) -> None:
         # Direct unit test of the helper used by discover().
         from pleno_pii_scanner.sources.builtin.dir_source import _safe_size
 
         ghost = tmp_path / "does-not-exist"
         assert _safe_size(ghost) is None
 
-    async def test_safe_mtime_returns_none_on_oserror(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_safe_mtime_returns_none_on_oserror(self, tmp_path: Path) -> None:
         from pleno_pii_scanner.sources.builtin.dir_source import _safe_mtime
 
         ghost = tmp_path / "does-not-exist"

--- a/packages/pii-scanner/tests/sources/builtin/test_git_source.py
+++ b/packages/pii-scanner/tests/sources/builtin/test_git_source.py
@@ -135,9 +135,7 @@ class TestDiscover:
         refs = await _drain(c.discover(SourceFilter(since=future), None))
         assert refs == []
 
-    async def test_filter_max_size_passes_when_size_unknown(
-        self, repo: Path
-    ) -> None:
+    async def test_filter_max_size_passes_when_size_unknown(self, repo: Path) -> None:
         # GitConnector never sets ref.size, so max_size never filters
         # anything out — we still want the branch executed for coverage.
         c = GitConnector(GitConfig(repo=repo))
@@ -174,9 +172,7 @@ class TestFetch:
             assert d.created_by.email == "alice@example.com"
             assert d.created_by.display_name == "Alice"
 
-    async def test_fetch_for_unknown_ref_yields_nothing(
-        self, repo: Path
-    ) -> None:
+    async def test_fetch_for_unknown_ref_yields_nothing(self, repo: Path) -> None:
         c = GitConnector(GitConfig(repo=repo))
         unknown = DocumentRef(
             source_id=c.id,
@@ -300,9 +296,7 @@ class TestIncrementalSubsources:
         subs = await c.list_subsources()
         assert subs[0].fingerprint.startswith("unknown:")
 
-    async def test_set_subsource_skip_yields_zero_refs(
-        self, repo: Path
-    ) -> None:
+    async def test_set_subsource_skip_yields_zero_refs(self, repo: Path) -> None:
         c = GitConnector(GitConfig(repo=repo))
         c.set_subsource_skip(frozenset({c.id}))
         try:
@@ -311,9 +305,7 @@ class TestIncrementalSubsources:
         finally:
             await c.close()
 
-    async def test_subsource_metadata_attached_to_refs(
-        self, repo: Path
-    ) -> None:
+    async def test_subsource_metadata_attached_to_refs(self, repo: Path) -> None:
         c = GitConnector(GitConfig(repo=repo))
         try:
             refs = await _drain(c.discover(SourceFilter(), None))

--- a/packages/pii-scanner/tests/sources/builtin/test_github_source.py
+++ b/packages/pii-scanner/tests/sources/builtin/test_github_source.py
@@ -186,9 +186,7 @@ class TestSingleRepo:
 
     async def test_fetch_ref_without_slug_returns_empty(self) -> None:
         c = GithubConnector(GithubConfig(repo="acme/widgets"))
-        ghost = DocumentRef(
-            source_id=c.id, source_kind=c.kind, path="x/y/z"
-        )
+        ghost = DocumentRef(source_id=c.id, source_kind=c.kind, path="x/y/z")
         async for _ in c.fetch(ghost):
             pytest.fail("must yield nothing without slug metadata")
 
@@ -254,9 +252,7 @@ class TestOrgEnumeration:
 
 
 class TestClose:
-    async def test_close_rmtree_tempdirs(
-        self, fake_repo: Path, tmp_path: Path
-    ) -> None:
+    async def test_close_rmtree_tempdirs(self, fake_repo: Path, tmp_path: Path) -> None:
         for f in fake_repo.iterdir():
             if f.is_file():
                 (tmp_path / f.name).write_text(f.read_text())
@@ -334,7 +330,9 @@ class TestProductionHelpers:
 
         monkeypatch.setattr(mod.subprocess, "run", fake_run)
         # Drive with a slug (no scheme) so the helper synthesizes a URL.
-        path = mod._clone_into_tempdir("acme/widgets", GithubConfig(repo="acme/widgets"))
+        path = mod._clone_into_tempdir(
+            "acme/widgets", GithubConfig(repo="acme/widgets")
+        )
         assert path.exists()
         assert any("https://github.com/acme/widgets.git" in c for c in seen_cmds[0])
         assert "--depth=1" in seen_cmds[0]
@@ -350,8 +348,9 @@ class TestProductionHelpers:
         monkeypatch.setattr(
             mod.subprocess,
             "run",
-            lambda cmd, **kw: seen_cmds.append(list(cmd))
-            or type("R", (), {"returncode": 0})(),
+            lambda cmd, **kw: (
+                seen_cmds.append(list(cmd)) or type("R", (), {"returncode": 0})()
+            ),
         )
         url = "git@github.com:acme/widgets.git"
         path = mod._clone_into_tempdir(url, GithubConfig(repo=url))
@@ -367,8 +366,9 @@ class TestProductionHelpers:
         monkeypatch.setattr(
             mod.subprocess,
             "run",
-            lambda cmd, **kw: seen_cmds.append(list(cmd))
-            or type("R", (), {"returncode": 0})(),
+            lambda cmd, **kw: (
+                seen_cmds.append(list(cmd)) or type("R", (), {"returncode": 0})()
+            ),
         )
         path = mod._clone_into_tempdir(
             "acme/widgets", GithubConfig(repo="acme/widgets", full=True)
@@ -429,15 +429,15 @@ class TestIncrementalSubsources:
         subs = await c.list_subsources()
         assert len(subs) == 1
         assert subs[0].sub_id == "acme/widgets"
-        assert subs[0].fingerprint == (
-            "deadbeefcafebabe1234567890abcdef12345678"
-        )
+        assert subs[0].fingerprint == ("deadbeefcafebabe1234567890abcdef12345678")
 
     async def test_list_subsources_for_org(self) -> None:
         c = GithubConnector(
             GithubConfig(org="acme"),
             enumerate_fn=lambda org, archived: ["acme/one", "acme/two"],
-            head_sha_fn=lambda slug: f"sha-{slug.split('/')[-1]}-pad-pad-pad-pad-pad-pad-pad",
+            head_sha_fn=lambda slug: (
+                f"sha-{slug.split('/')[-1]}-pad-pad-pad-pad-pad-pad-pad"
+            ),
         )
         subs = await c.list_subsources()
         slug_set = {s.sub_id for s in subs}
@@ -482,9 +482,7 @@ class TestIncrementalSubsources:
     ) -> None:
         from pleno_pii_scanner.sources.builtin import github_source as mod
 
-        sample = (
-            b"abcdef0123456789abcdef0123456789abcdef01\tHEAD\n"
-        )
+        sample = b"abcdef0123456789abcdef0123456789abcdef01\tHEAD\n"
         monkeypatch.setattr(
             mod.subprocess,
             "run",
@@ -514,8 +512,6 @@ class TestIncrementalSubsources:
         monkeypatch.setattr(
             mod.subprocess,
             "run",
-            lambda cmd, **kw: type(
-                "R", (), {"stdout": b"<html>nope</html>\n"}
-            )(),
+            lambda cmd, **kw: type("R", (), {"stdout": b"<html>nope</html>\n"})(),
         )
         assert mod._default_head_sha("acme/widgets") is None

--- a/packages/pii-scanner/tests/sources/test_all_connectors_smoke.py
+++ b/packages/pii-scanner/tests/sources/test_all_connectors_smoke.py
@@ -88,13 +88,9 @@ class TestEveryConnector:
         assert spec.version, f"{kind} SPEC.version must be non-empty"
         assert callable(spec.factory)
         assert isinstance(spec.capabilities, Capabilities)
-        assert spec.required_scopes, (
-            f"{kind} SPEC.required_scopes should be non-empty"
-        )
+        assert spec.required_scopes, f"{kind} SPEC.required_scopes should be non-empty"
 
-    def test_factory_rejects_empty_config(
-        self, kind: str, spec: ConnectorSpec
-    ) -> None:
+    def test_factory_rejects_empty_config(self, kind: str, spec: ConnectorSpec) -> None:
         # Every connector requires at least one credential or endpoint —
         # an empty config must raise ValueError (not KeyError or
         # AttributeError) so the registry can surface the violation

--- a/packages/pii-scanner/tests/sources/test_base.py
+++ b/packages/pii-scanner/tests/sources/test_base.py
@@ -127,8 +127,12 @@ class TestDocumentChunk:
         # (that's the connector's contract) but we verify the data shape
         # is suitable for it.
         chunks = [
-            DocumentChunk(ref=_ref(), byte_range=(0, 1023), is_final=False, binary=b"a" * 1024),
-            DocumentChunk(ref=_ref(), byte_range=(1024, 2047), is_final=True, binary=b"b" * 1024),
+            DocumentChunk(
+                ref=_ref(), byte_range=(0, 1023), is_final=False, binary=b"a" * 1024
+            ),
+            DocumentChunk(
+                ref=_ref(), byte_range=(1024, 2047), is_final=True, binary=b"b" * 1024
+            ),
         ]
         assert sorted(chunks, key=lambda c: c.byte_range[0]) == chunks
         assert chunks[-1].is_final

--- a/packages/pii-scanner/tests/sources/test_registry.py
+++ b/packages/pii-scanner/tests/sources/test_registry.py
@@ -40,9 +40,7 @@ class _StubConnector:
     ) -> AsyncIterator[DocumentRef]:
         yield DocumentRef(source_id=self.id, source_kind=self.kind, path="x")
 
-    async def fetch(
-        self, ref: DocumentRef
-    ) -> AsyncIterator[Document | DocumentChunk]:
+    async def fetch(self, ref: DocumentRef) -> AsyncIterator[Document | DocumentChunk]:
         yield Document(ref=ref, text="ok")
 
     def capabilities(self) -> Capabilities:
@@ -94,9 +92,7 @@ class TestRegistration:
     def test_duplicate_registration_raises(self) -> None:
         register(ConnectorSpec(kind="stub", version="0.0.1", factory=_stub_factory))
         with pytest.raises(DuplicateConnectorError) as exc:
-            register(
-                ConnectorSpec(kind="stub", version="0.0.2", factory=_stub_factory)
-            )
+            register(ConnectorSpec(kind="stub", version="0.0.2", factory=_stub_factory))
         assert "0.0.1" in str(exc.value)
         assert "0.0.2" in str(exc.value)
 
@@ -150,7 +146,9 @@ class TestFactory:
 
 
 class TestEntryPointsDiscovery:
-    def test_discover_loads_valid_entry_point(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_discover_loads_valid_entry_point(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         spec = ConnectorSpec(kind="ep-stub", version="0.0.1", factory=_stub_factory)
         ep = _make_ep("ep-stub", spec)
         _patch_entry_points(monkeypatch, [ep])
@@ -279,9 +277,7 @@ def _make_broken_ep(name: str) -> EntryPoint:
     return _BrokenEntryPoint()  # type: ignore[return-value]
 
 
-def _patch_entry_points(
-    monkeypatch: pytest.MonkeyPatch, eps: list[EntryPoint]
-) -> None:
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[EntryPoint]) -> None:
     def fake(group: str | None = None, **_kwargs: Any) -> list[EntryPoint]:
         if group != _registry_mod.ENTRY_POINT_GROUP:
             return []

--- a/packages/pii-scanner/tests/state/test_checkpoint_protocol.py
+++ b/packages/pii-scanner/tests/state/test_checkpoint_protocol.py
@@ -8,7 +8,7 @@ extending the `store_factory` parametrization.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -43,9 +43,7 @@ def sqlite_factory(tmp_path: Path) -> StoreFactory:
     async def _make() -> CheckpointStore:
         counter["i"] += 1
         target = tmp_path / f"store-{counter['i']}.sqlite"
-        return await SqliteCheckpointStore.open(
-            "scan-test", path=target
-        )
+        return await SqliteCheckpointStore.open("scan-test", path=target)
 
     return _make
 
@@ -143,9 +141,7 @@ class TestByteRangeCodec:
 
 class TestCheckpointStoreContract:
     @pytest.mark.asyncio
-    async def test_isinstance_protocol(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_isinstance_protocol(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             assert isinstance(store, CheckpointStore)
@@ -153,9 +149,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_load_missing_returns_none(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_load_missing_returns_none(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             assert await store.load("scan-x", "src-x") is None
@@ -163,9 +157,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_save_then_load_round_trip(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_save_then_load_round_trip(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             cp = _cp()
@@ -188,9 +180,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_save_overwrites_same_key(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_save_overwrites_same_key(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             t0 = datetime(2026, 5, 4, 12, tzinfo=UTC)
@@ -205,9 +195,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_save_many_atomic(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_save_many_atomic(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             batch = [
@@ -223,9 +211,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_save_many_empty_is_noop(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_save_many_empty_is_noop(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             await store.save_many([])
@@ -234,9 +220,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_save_many_dedups_same_key(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_save_many_dedups_same_key(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             await store.save_many(
@@ -266,9 +250,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_list_for_scan_empty(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_list_for_scan_empty(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             collected = [cp async for cp in store.list_for_scan("scan-empty")]
@@ -277,9 +259,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_delete_removes_checkpoint(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_delete_removes_checkpoint(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             await store.save(_cp())
@@ -289,9 +269,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_delete_missing_is_noop(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_delete_missing_is_noop(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             await store.delete("scan-x", "src-x")
@@ -299,9 +277,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_record_and_list_shards(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_record_and_list_shards(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             await store.record_shard("scan-1", "src-a", 0, 5)
@@ -328,9 +304,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_list_shards_empty(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_list_shards_empty(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             assert await store.list_shards("scan-1", "src-a") == []
@@ -338,9 +312,7 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_delete_purges_shards(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_delete_purges_shards(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         try:
             await store.save(_cp())
@@ -385,9 +357,7 @@ class TestCheckpointStoreContract:
             n = 20
 
             async def write(i: int) -> None:
-                await store.save(
-                    _cp(source_id=f"src-{i:02d}", cursor=f"v{i}")
-                )
+                await store.save(_cp(source_id=f"src-{i:02d}", cursor=f"v{i}"))
 
             await asyncio.gather(*(write(i) for i in range(n)))
             collected: list[Checkpoint] = [
@@ -401,17 +371,13 @@ class TestCheckpointStoreContract:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_close_is_idempotent(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_close_is_idempotent(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         await store.close()
         await store.close()
 
     @pytest.mark.asyncio
-    async def test_use_after_close_raises(
-        self, store_factory: StoreFactory
-    ) -> None:
+    async def test_use_after_close_raises(self, store_factory: StoreFactory) -> None:
         store = await store_factory()
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):

--- a/packages/pii-scanner/tests/state/test_scan_cache.py
+++ b/packages/pii-scanner/tests/state/test_scan_cache.py
@@ -52,9 +52,7 @@ class TestRoundTrip:
     @pytest.mark.asyncio
     async def test_get_missing_key_returns_none(self, cache: ScanCache) -> None:
         try:
-            assert (
-                await cache.get("k", fingerprint="fp", schema_version="sv")
-            ) is None
+            assert (await cache.get("k", fingerprint="fp", schema_version="sv")) is None
         finally:
             await cache.close()
 
@@ -63,18 +61,14 @@ class TestRoundTrip:
         try:
             await cache.put("k", fingerprint="fp", schema_version="sv", value=b"a")
             await cache.put("k", fingerprint="fp", schema_version="sv", value=b"b")
-            assert (
-                await cache.get("k", fingerprint="fp", schema_version="sv")
-            ) == b"b"
+            assert (await cache.get("k", fingerprint="fp", schema_version="sv")) == b"b"
         finally:
             await cache.close()
 
 
 class TestFingerprintGating:
     @pytest.mark.asyncio
-    async def test_stale_fingerprint_returns_none(
-        self, cache: ScanCache
-    ) -> None:
+    async def test_stale_fingerprint_returns_none(self, cache: ScanCache) -> None:
         try:
             await cache.put("k", fingerprint="old", schema_version="sv", value=b"v")
             assert (
@@ -86,12 +80,8 @@ class TestFingerprintGating:
     @pytest.mark.asyncio
     async def test_stale_schema_returns_none(self, cache: ScanCache) -> None:
         try:
-            await cache.put(
-                "k", fingerprint="fp", schema_version="v1", value=b"v"
-            )
-            assert (
-                await cache.get("k", fingerprint="fp", schema_version="v2")
-            ) is None
+            await cache.put("k", fingerprint="fp", schema_version="v1", value=b"v")
+            assert (await cache.get("k", fingerprint="fp", schema_version="v2")) is None
         finally:
             await cache.close()
 
@@ -150,12 +140,8 @@ class TestPurgeOtherSchemas:
             await cache.put("b", fingerprint="y", schema_version="old", value=b"2")
             removed = await cache.purge_other_schemas("cur")
             assert removed == 1
-            assert (
-                await cache.get("a", fingerprint="x", schema_version="cur")
-            ) == b"1"
-            assert (
-                await cache.get("b", fingerprint="y", schema_version="old")
-            ) is None
+            assert (await cache.get("a", fingerprint="x", schema_version="cur")) == b"1"
+            assert (await cache.get("b", fingerprint="y", schema_version="old")) is None
         finally:
             await cache.close()
 
@@ -166,9 +152,7 @@ class TestDelete:
         try:
             await cache.put("k", fingerprint="f", schema_version="s", value=b"v")
             await cache.delete("k")
-            assert (
-                await cache.get("k", fingerprint="f", schema_version="s")
-            ) is None
+            assert (await cache.get("k", fingerprint="f", schema_version="s")) is None
         finally:
             await cache.close()
 
@@ -197,9 +181,7 @@ class TestClosedSemantics:
     async def test_use_after_close_raises(self, cache: ScanCache) -> None:
         await cache.close()
         with pytest.raises(RuntimeError):
-            await cache.put(
-                "k", fingerprint="f", schema_version="s", value=b"v"
-            )
+            await cache.put("k", fingerprint="f", schema_version="s", value=b"v")
 
     @pytest.mark.asyncio
     async def test_double_close_is_noop(self, cache: ScanCache) -> None:
@@ -244,9 +226,7 @@ class TestSqlitePersistence:
         await first.close()
         second = await SqliteScanCache.open(path=path)
         try:
-            assert (
-                await second.get("k", fingerprint="f", schema_version="s")
-            ) == b"v"
+            assert (await second.get("k", fingerprint="f", schema_version="s")) == b"v"
         finally:
             await second.close()
 

--- a/packages/pii-scanner/tests/state/test_sqlite_store.py
+++ b/packages/pii-scanner/tests/state/test_sqlite_store.py
@@ -44,7 +44,15 @@ class TestDefaultStatePath:
         monkeypatch.delenv("XDG_STATE_HOME", raising=False)
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         path = default_state_path("scan-xyz")
-        assert path == tmp_path / ".local" / "state" / "pleno" / "scan-xyz" / "checkpoint.sqlite"
+        assert (
+            path
+            == tmp_path
+            / ".local"
+            / "state"
+            / "pleno"
+            / "scan-xyz"
+            / "checkpoint.sqlite"
+        )
 
     def test_empty_xdg_state_home_falls_back(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -53,7 +61,15 @@ class TestDefaultStatePath:
         monkeypatch.setenv("XDG_STATE_HOME", "")
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         path = default_state_path("scan-xyz")
-        assert path == tmp_path / ".local" / "state" / "pleno" / "scan-xyz" / "checkpoint.sqlite"
+        assert (
+            path
+            == tmp_path
+            / ".local"
+            / "state"
+            / "pleno"
+            / "scan-xyz"
+            / "checkpoint.sqlite"
+        )
 
 
 class TestSqliteOpen:
@@ -75,7 +91,9 @@ class TestSqliteOpen:
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
         store = await SqliteCheckpointStore.open("scan-default")
         try:
-            assert store.path == tmp_path / "pleno" / "scan-default" / "checkpoint.sqlite"
+            assert (
+                store.path == tmp_path / "pleno" / "scan-default" / "checkpoint.sqlite"
+            )
             assert store.path.exists()
         finally:
             await store.close()
@@ -158,13 +176,9 @@ class TestSqliteDurability:
 
         reopened = await SqliteCheckpointStore.open("scan-1", path=target)
         try:
-            collected = [
-                cp async for cp in reopened.list_for_scan("scan-1")
-            ]
+            collected = [cp async for cp in reopened.list_for_scan("scan-1")]
             assert len(collected) == 5
-            assert {cp.cursor for cp in collected} == {
-                f"v{i}" for i in range(5)
-            }
+            assert {cp.cursor for cp in collected} == {f"v{i}" for i in range(5)}
         finally:
             await reopened.close()
 
@@ -190,43 +204,31 @@ class TestSqliteDurability:
 class TestSqliteEdgeCases:
     @pytest.mark.asyncio
     async def test_close_is_idempotent(self, tmp_path: Path) -> None:
-        store = await SqliteCheckpointStore.open(
-            "scan-1", path=tmp_path / "ck.sqlite"
-        )
+        store = await SqliteCheckpointStore.open("scan-1", path=tmp_path / "ck.sqlite")
         await store.close()
         await store.close()
 
     @pytest.mark.asyncio
     async def test_async_context_manager(self, tmp_path: Path) -> None:
         target = tmp_path / "ck.sqlite"
-        async with await SqliteCheckpointStore.open(
-            "scan-1", path=target
-        ) as store:
+        async with await SqliteCheckpointStore.open("scan-1", path=target) as store:
             await store.save(_cp())
             assert await store.load("scan-1", "src-a") is not None
         # WHY: file remains on disk even after close, so a fresh open
         # can still read prior state.
-        async with await SqliteCheckpointStore.open(
-            "scan-1", path=target
-        ) as store2:
+        async with await SqliteCheckpointStore.open("scan-1", path=target) as store2:
             assert await store2.load("scan-1", "src-a") is not None
 
     @pytest.mark.asyncio
-    async def test_save_many_empty_short_circuits(
-        self, tmp_path: Path
-    ) -> None:
-        store = await SqliteCheckpointStore.open(
-            "scan-1", path=tmp_path / "ck.sqlite"
-        )
+    async def test_save_many_empty_short_circuits(self, tmp_path: Path) -> None:
+        store = await SqliteCheckpointStore.open("scan-1", path=tmp_path / "ck.sqlite")
         try:
             await store.save_many([])
         finally:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_naive_datetime_in_db_is_assumed_utc(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_naive_datetime_in_db_is_assumed_utc(self, tmp_path: Path) -> None:
         # WHY: covers the naive-datetime branch of _parse_iso. We can't
         # easily get a naive timestamp through save() (Checkpoint takes a
         # datetime; we always serialize via .isoformat()), so we manually
@@ -253,9 +255,7 @@ class TestSqliteEdgeCases:
     async def test_concurrent_distinct_keys_do_not_deadlock(
         self, tmp_path: Path
     ) -> None:
-        store = await SqliteCheckpointStore.open(
-            "scan-1", path=tmp_path / "ck.sqlite"
-        )
+        store = await SqliteCheckpointStore.open("scan-1", path=tmp_path / "ck.sqlite")
         try:
 
             async def write_and_read(i: int) -> None:
@@ -272,12 +272,8 @@ class TestSqliteEdgeCases:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_use_after_close_for_each_method(
-        self, tmp_path: Path
-    ) -> None:
-        store = await SqliteCheckpointStore.open(
-            "scan-1", path=tmp_path / "ck.sqlite"
-        )
+    async def test_use_after_close_for_each_method(self, tmp_path: Path) -> None:
+        store = await SqliteCheckpointStore.open("scan-1", path=tmp_path / "ck.sqlite")
         await store.close()
         with pytest.raises(RuntimeError, match="closed"):
             await store.save(_cp())
@@ -296,9 +292,7 @@ class TestSqliteEdgeCases:
             await store.list_shards("scan-1", "src-a")
 
     @pytest.mark.asyncio
-    async def test_path_property_matches_constructor(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_path_property_matches_constructor(self, tmp_path: Path) -> None:
         target = tmp_path / "ck.sqlite"
         store = await SqliteCheckpointStore.open("scan-1", path=target)
         try:
@@ -307,9 +301,7 @@ class TestSqliteEdgeCases:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_parent_directory_permission_700(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_parent_directory_permission_700(self, tmp_path: Path) -> None:
         # WHY: cursor strings can leak access patterns (Slack channel IDs,
         # Confluence space keys). On a multi-user host, the parent dir
         # must not be world-readable.

--- a/packages/pii-scanner/tests/test_cli_connectors.py
+++ b/packages/pii-scanner/tests/test_cli_connectors.py
@@ -41,9 +41,7 @@ class TestConnectorsList:
         assert "github" in result.output
 
     def test_json_format(self) -> None:
-        result = CliRunner().invoke(
-            main, ["connectors", "list", "--format", "json"]
-        )
+        result = CliRunner().invoke(main, ["connectors", "list", "--format", "json"])
         assert result.exit_code == 0
         payload = json.loads(result.output)
         kinds = {entry["kind"] for entry in payload}
@@ -69,8 +67,6 @@ class TestConnectorsDescribe:
         assert payload["config_schema"] is None
 
     def test_describe_unknown(self) -> None:
-        result = CliRunner().invoke(
-            main, ["connectors", "describe", "no-such-kind"]
-        )
+        result = CliRunner().invoke(main, ["connectors", "describe", "no-such-kind"])
         assert result.exit_code != 0
         assert "unknown connector" in result.output.lower()

--- a/packages/pii-scanner/tests/test_cli_dir.py
+++ b/packages/pii-scanner/tests/test_cli_dir.py
@@ -1,7 +1,6 @@
 """End-to-end-ish: invoke the CLI on the bundled fixtures dir."""
 
 import json
-import sys
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -15,7 +14,14 @@ def test_dir_finds_pii_in_positive_fixtures():
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["dir", str(FIXTURES / "positive"), "--report-format", "json", "--no-color", "--exit-zero"],
+        [
+            "dir",
+            str(FIXTURES / "positive"),
+            "--report-format",
+            "json",
+            "--no-color",
+            "--exit-zero",
+        ],
     )
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
@@ -30,7 +36,14 @@ def test_dir_inline_ignore_suppresses_negatives():
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["dir", str(FIXTURES / "negative"), "--report-format", "json", "--no-color", "--exit-zero"],
+        [
+            "dir",
+            str(FIXTURES / "negative"),
+            "--report-format",
+            "json",
+            "--no-color",
+            "--exit-zero",
+        ],
     )
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)

--- a/packages/pii-scanner/tests/test_cli_scan.py
+++ b/packages/pii-scanner/tests/test_cli_scan.py
@@ -65,9 +65,7 @@ class TestRun:
         # text output is on stderr; runner mixes them.
         assert "refs_seen=2" in result.output
 
-    def test_runs_dir_via_toml_config(
-        self, small_tree: Path, tmp_path: Path
-    ) -> None:
+    def test_runs_dir_via_toml_config(self, small_tree: Path, tmp_path: Path) -> None:
         cfg = tmp_path / "dir.toml"
         cfg.write_text(f'root = "{small_tree}"\n')
         result = CliRunner().invoke(
@@ -111,9 +109,7 @@ class TestRun:
     def test_toml_invalid_syntax(self, tmp_path: Path) -> None:
         cfg = tmp_path / "bad.toml"
         cfg.write_text("this is = = invalid")
-        result = CliRunner().invoke(
-            main, ["scan", "run", "dir", "--config", str(cfg)]
-        )
+        result = CliRunner().invoke(main, ["scan", "run", "dir", "--config", str(cfg)])
         assert result.exit_code != 0
         assert "not valid TOML" in result.output
 

--- a/packages/pii-scanner/tests/test_cli_schedule.py
+++ b/packages/pii-scanner/tests/test_cli_schedule.py
@@ -136,9 +136,7 @@ class TestRunOnce:
         import sqlite3
 
         with sqlite3.connect(reg_path) as conn:
-            conn.execute(
-                "UPDATE schedules SET next_run_at='2000-01-01T00:00:00+00:00'"
-            )
+            conn.execute("UPDATE schedules SET next_run_at='2000-01-01T00:00:00+00:00'")
             conn.commit()
 
         result = runner.invoke(

--- a/packages/pii-scanner/tests/test_cloud_pass.py
+++ b/packages/pii-scanner/tests/test_cloud_pass.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import httpx
-import pytest
 
 from pleno_pii_scanner.cloud_pass import CloudConfig, _chunk, scan_files_cloud
 
@@ -69,9 +68,7 @@ def test_scan_files_cloud_translates_offsets(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "__init__", fake_init)
 
     cfg = CloudConfig(base_url="https://example.invalid", concurrency=1)
-    findings = scan_files_cloud(
-        [(Path("x.txt"), file)], {"x.txt": text}, cfg
-    )
+    findings = scan_files_cloud([(Path("x.txt"), file)], {"x.txt": text}, cfg)
     assert len(findings) == 1
     f = findings[0]
     assert f.entity == "PHONE_NUMBER"
@@ -97,9 +94,7 @@ def test_scan_files_cloud_handles_http_error(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "__init__", fake_init)
 
     cfg = CloudConfig(base_url="https://example.invalid", concurrency=1)
-    findings = scan_files_cloud(
-        [(Path("x.txt"), file)], {"x.txt": "hello world"}, cfg
-    )
+    findings = scan_files_cloud([(Path("x.txt"), file)], {"x.txt": "hello world"}, cfg)
     # 500 errors are swallowed and produce no findings (per-file resilience).
     assert findings == []
 

--- a/packages/pii-scanner/tests/test_cluster.py
+++ b/packages/pii-scanner/tests/test_cluster.py
@@ -11,8 +11,14 @@ from pleno_pii_scanner.models import Finding
 
 def _f(entity, file, line=1, matched="x", verification="unverified", score=0.5):
     return Finding(
-        entity=entity, file=file, line=line, col=1, score=score,
-        snippet=matched, matched=matched, pattern_name="p",
+        entity=entity,
+        file=file,
+        line=line,
+        col=1,
+        score=score,
+        snippet=matched,
+        matched=matched,
+        pattern_name="p",
         verification=verification,
     )
 
@@ -39,10 +45,7 @@ def test_drops_same_email_repeated_in_one_file():
     """Six mentions of one support contact = one identifiable individual,
     not a DB. Distinct-value gating must drop this."""
     same = "support@example-corp.jp"
-    fs = [
-        _f("EMAIL_ADDRESS", "faq.md", line=i, matched=same)
-        for i in range(1, 7)
-    ]
+    fs = [_f("EMAIL_ADDRESS", "faq.md", line=i, matched=same) for i in range(1, 7)]
     assert keep_db_clusters(fs) == []
 
 
@@ -153,12 +156,27 @@ def test_failed_findings_do_not_count_toward_cluster():
     folder to DB-shaped. Otherwise an awesome-list of book links would
     look like a leaked DB."""
     fs = [
-        _f("MY_NUMBER_CORPORATE", "books.md", line=1, matched="9784911384039",
-           verification="failed"),
-        _f("MY_NUMBER_CORPORATE", "books.md", line=2, matched="9784000000000",
-           verification="failed"),
-        _f("MY_NUMBER_CORPORATE", "books.md", line=3, matched="9784912345678",
-           verification="failed"),
+        _f(
+            "MY_NUMBER_CORPORATE",
+            "books.md",
+            line=1,
+            matched="9784911384039",
+            verification="failed",
+        ),
+        _f(
+            "MY_NUMBER_CORPORATE",
+            "books.md",
+            line=2,
+            matched="9784000000000",
+            verification="failed",
+        ),
+        _f(
+            "MY_NUMBER_CORPORATE",
+            "books.md",
+            line=3,
+            matched="9784912345678",
+            verification="failed",
+        ),
     ]
     # No real PII finding → cluster computation excludes the failed ones,
     # nothing qualifies, all dropped.

--- a/packages/pii-scanner/tests/test_detector.py
+++ b/packages/pii-scanner/tests/test_detector.py
@@ -148,9 +148,7 @@ class TestRecognizerPackFingerprint:
         from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
 
         normal = recognizer_pack_fingerprint(ALL_JA_RECOGNIZERS)
-        reversed_ = recognizer_pack_fingerprint(
-            tuple(reversed(ALL_JA_RECOGNIZERS))
-        )
+        reversed_ = recognizer_pack_fingerprint(tuple(reversed(ALL_JA_RECOGNIZERS)))
         assert normal == reversed_
 
     def test_dropping_one_recognizer_changes_hash(self) -> None:
@@ -176,16 +174,14 @@ class TestRecognizerPackFingerprint:
                 entity="EMAIL",
                 language="en",
                 patterns=(
-                    PiiPattern(
-                        name="basic", regex=r"[A-Za-z0-9]+@\w+", score=0.5
-                    ),
+                    PiiPattern(name="basic", regex=r"[A-Za-z0-9]+@\w+", score=0.5),
                 ),
                 context=("email",),
             ),
         )
-        assert recognizer_pack_fingerprint(
-            original
-        ) != recognizer_pack_fingerprint(edited)
+        assert recognizer_pack_fingerprint(original) != recognizer_pack_fingerprint(
+            edited
+        )
 
 
 class TestSchemaComponents:
@@ -268,9 +264,7 @@ class TestMakeDetector:
     async def test_skip_verify_keeps_findings_unverified(self) -> None:
         from pleno_recognizers.ja import ALL_JA_RECOGNIZERS
 
-        detector = make_detector(
-            ALL_JA_RECOGNIZERS, skip_ner=True, skip_verify=True
-        )
+        detector = make_detector(ALL_JA_RECOGNIZERS, skip_ner=True, skip_verify=True)
         text = 'EMAIL = "alice@example.com"\n'
         _, payload = await detector(_ref("e.py"), _doc(text))
         findings = decode_findings(payload)
@@ -352,7 +346,9 @@ class TestRunnerReplay:
                 self, _filter: SourceFilter, _cursor: str | None
             ) -> AsyncIterator[DocumentRef]:
                 for path in ("a.py", "b.py"):
-                    yield DocumentRef(source_id=self.id, source_kind=self.kind, path=path)
+                    yield DocumentRef(
+                        source_id=self.id, source_kind=self.kind, path=path
+                    )
 
             async def fetch(
                 self, ref: DocumentRef

--- a/packages/pii-scanner/tests/test_hf_ner_pass.py
+++ b/packages/pii-scanner/tests/test_hf_ner_pass.py
@@ -19,7 +19,7 @@ from pleno_pii_scanner.hf_ner_pass import (
 
 def _id2label() -> dict[int, str]:
     labels = ["O", "B-ORGANIZATION", "I-ORGANIZATION", "B-PERSON", "I-PERSON"]
-    return {i: l for i, l in enumerate(labels)}
+    return dict(enumerate(labels))
 
 
 def test_parse_thresholds_defaults_match_v013_model_card():

--- a/packages/pii-scanner/tests/test_ignore.py
+++ b/packages/pii-scanner/tests/test_ignore.py
@@ -1,18 +1,32 @@
 from pathlib import Path
 
-from pleno_pii_scanner.ignore import IgnoreSet, _inline_ignored_entities, filter_findings, write_baseline, load_baseline
+from pleno_pii_scanner.ignore import (
+    IgnoreSet,
+    _inline_ignored_entities,
+    filter_findings,
+    write_baseline,
+    load_baseline,
+)
 from pleno_pii_scanner.models import Finding
 
 
 def _f(entity="EMAIL_ADDRESS", file="a.py", line=1, matched="x@y.com"):
     return Finding(
-        entity=entity, file=file, line=line, col=1, score=0.9,
-        snippet="snip", matched=matched, pattern_name="p",
+        entity=entity,
+        file=file,
+        line=line,
+        col=1,
+        score=0.9,
+        snippet="snip",
+        matched=matched,
+        pattern_name="p",
     )
 
 
 def test_inline_ignore_specific():
-    assert _inline_ignored_entities("x = 1  # pleno:ignore PHONE_NUMBER") == {"PHONE_NUMBER"}
+    assert _inline_ignored_entities("x = 1  # pleno:ignore PHONE_NUMBER") == {
+        "PHONE_NUMBER"
+    }
 
 
 def test_inline_ignore_all():
@@ -32,12 +46,7 @@ def test_inline_ignore_none():
 
 def test_ignoreset_loads(tmp_path: Path):
     p = tmp_path / ".plenoignore"
-    p.write_text(
-        "# comment\n"
-        "docs/**\n"
-        "PHONE_NUMBER\n"
-        "finding:abc123\n"
-    )
+    p.write_text("# comment\ndocs/**\nPHONE_NUMBER\nfinding:abc123\n")
     s = IgnoreSet.load(p)
     assert "PHONE_NUMBER" in s.entities
     assert "abc123" in s.fingerprints

--- a/packages/pii-scanner/tests/test_noise_filters.py
+++ b/packages/pii-scanner/tests/test_noise_filters.py
@@ -10,7 +10,9 @@ from pleno_pii_scanner.models import Finding
 from pleno_pii_scanner.noise_filters import filter_noise
 
 
-def _f(entity, matched, snippet, *, line=1, col=1, score=0.4, verification="unverified"):
+def _f(
+    entity, matched, snippet, *, line=1, col=1, score=0.4, verification="unverified"
+):
     return Finding(
         entity=entity,
         file="a.txt",
@@ -113,8 +115,11 @@ def test_drops_private_rfc1918():
 
 
 def test_drops_ipv4_in_v8_version_chatter():
-    f = _f("IP_ADDRESS", "4.2.77.18",
-           "* **V8**: upgrade V8 from 4.2.77.18 to 4.2.77.20 with minor fixes")
+    f = _f(
+        "IP_ADDRESS",
+        "4.2.77.18",
+        "* **V8**: upgrade V8 from 4.2.77.18 to 4.2.77.20 with minor fixes",
+    )
     assert _kept([f], f.snippet) == []
 
 
@@ -228,8 +233,12 @@ def test_drops_email_with_cli_prefix():
 
 def test_drops_email_with_url_path_prefix():
     line = "pip install git+https://github.com/suisya-systems/core-harness@v0.x.y"
-    f = _f("EMAIL_ADDRESS", "github.com/suisya-systems/core-harness@v0.x.y",
-           line, score=0.95)
+    f = _f(
+        "EMAIL_ADDRESS",
+        "github.com/suisya-systems/core-harness@v0.x.y",
+        line,
+        score=0.95,
+    )
     assert _kept([f], line) == []
 
 
@@ -260,8 +269,9 @@ def test_keeps_real_user_email():
 
 def test_drops_isbn13_my_number_corporate():
     line = "- [Textbook](https://www.books.or.jp/book-details/9784911384039)"
-    f = _f("MY_NUMBER_CORPORATE", "9784911384039", line, score=0.3,
-           verification="failed")
+    f = _f(
+        "MY_NUMBER_CORPORATE", "9784911384039", line, score=0.3, verification="failed"
+    )
     assert _kept([f], line) == []
 
 
@@ -330,7 +340,9 @@ def test_drops_organization_when_match_extends_into_url():
     # When the NER span keeps going past "](" into the URL itself, the match
     # contains an OPENING bracket "(" mid-span — drop, the boundary is wrong.
     line = "- [株式会社 LabBase ](https://labbase.co.jp/)"
-    f = _f("ORGANIZATION", "株式会社 LabBase ](https://labbase.co.jp/)", line, score=0.85)
+    f = _f(
+        "ORGANIZATION", "株式会社 LabBase ](https://labbase.co.jp/)", line, score=0.85
+    )
     assert _kept([f], line) == []
 
 

--- a/packages/pii-scanner/tests/test_verify.py
+++ b/packages/pii-scanner/tests/test_verify.py
@@ -6,8 +6,14 @@ from pleno_pii_scanner.verify import verify
 
 def _f(entity, matched, file="a.txt"):
     return Finding(
-        entity=entity, file=file, line=1, col=1, score=0.5,
-        snippet=matched, matched=matched, pattern_name="p",
+        entity=entity,
+        file=file,
+        line=1,
+        col=1,
+        score=0.5,
+        snippet=matched,
+        matched=matched,
+        pattern_name="p",
     )
 
 
@@ -50,7 +56,9 @@ def test_verify_person_email_proximity_boosts_score():
         matched="Guido van Rossum",
         pattern_name="person_latin_multi_word",
     )
-    text = {"pep.rst": "| PEP: 8\n| Title: Style\n| Author: Guido van Rossum <guido@python.org>,\n"}
+    text = {
+        "pep.rst": "| PEP: 8\n| Title: Style\n| Author: Guido van Rossum <guido@python.org>,\n"
+    }
     out = verify([f], [JA_PERSON_LATIN], file_text_for=text)
     assert out[0].verification == "passed"
     assert out[0].score >= 0.7, out[0].score


### PR DESCRIPTION
## Why

CI/CD has been red on every push to `main` since the connectors matrix
shipped. Every connector job runs `ruff check` + `ruff format --check`
against its package and 18+ packages had accumulated F401 / F841 / E402
/ E741 violations plus formatter drift.

Trusted-publishing still fires off tag push (so PyPI releases are fine),
but `deploy` is gated on `connectors` so the Fly app has not redeployed
for several cycles.

## What

- **pii-scanner core**: drop unused imports/locals; gate
  `CredentialProfile` under `TYPE_CHECKING` (it was an unresolved forward
  reference, not even a `noqa`); suppress E402 on the three intentionally-
  deferred CLI mounts that load *after* `_register_builtins()`; fix E741
  (`{i: l for i, l in ...}` -> `dict(enumerate(...))`).
- **17 connector packages**: auto-fixed F401/F841 plus 4 manual
  unused-local removals in gcs, oci, salesforce x2.
- **Repo-wide `ruff format`** pass — no logic changes, just whitespace
  and trailing-comma normalisation. Per-package `ruff format` (the same
  command CI runs) drove every formatting change.

## Verification

- `uvx ruff check $pkg/src $pkg/tests` clean for every package.
- `uvx ruff format --check $pkg/src $pkg/tests` clean for every package.
- `uv run pytest -q` (pii-scanner): 1266 passed, 8 skipped.
- `uv run pytest -q` (gcs / oci / salesforce — the packages with manual
  edits beyond auto-fix): all green.