### PR TITLE
chore: add pii-scanner-elasticsearch to uv workspace members

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ members = [
     "packages/pii-scanner-ci-logs",
     "packages/pii-scanner-confluence",
     "packages/pii-scanner-discord",
+    "packages/pii-scanner-elasticsearch",
     "packages/pii-scanner-gcs",
     "packages/pii-scanner-gdrive",
     "packages/pii-scanner-github",


### PR DESCRIPTION
Single-line workspace registration. The elasticsearch package was added but not registered in `[tool.uv.workspace.members]`, so `uv sync` from the repo root (run by every connector CI matrix shard) failed with:

```
× Failed to build pleno-pii-scanner-elasticsearch
╰─▶ pleno-pii-scanner references a workspace in tool.uv.sources, but is not a workspace member
```

Verified locally: `uv sync` from repo root completes cleanly after the addition.