### PR TITLE
feat(sdk-js): TypeScript SDK + npx pleno-anonymize CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,25 @@ jobs:
         working-directory: packages/recognizers
         run: uv run pytest -q
 
+  sdk-js:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/sdk-js
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: packages/sdk-js/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm test
+
   deploy:
     needs: [check, test, recognizers]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,92 @@
+name: Release npm packages
+
+# Trusted publishing for the JS SDK + CLI shipped from packages/sdk-js.
+#
+# Tag convention:
+#   sdk-js/vX.Y.Z   -> packages/sdk-js
+#
+# npm side: configure a Trusted Publisher for the package on npmjs.com so
+# this workflow can authenticate via OIDC (no NODE_AUTH_TOKEN secret needed).
+# Until that is configured, run with workflow_dispatch dry_run=true to verify
+# the build, then enable the publisher and re-tag.
+#
+# https://docs.npmjs.com/generating-provenance-statements
+
+on:
+  push:
+    tags:
+      - 'sdk-js/v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build but skip npm publish'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    concurrency:
+      group: release-npm-${{ github.ref_name }}
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: packages/sdk-js
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: packages/sdk-js/pnpm-lock.yaml
+
+      - name: Resolve dry-run flag
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "push" ]; then
+            dry_run="false"
+          else
+            dry_run="${INPUT_DRY_RUN:-true}"
+          fi
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches package version
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          tag_version="${TAG#sdk-js/v}"
+          pkg_version=$(node -p "require('./package.json').version")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::tag ${TAG} does not match package.json version ${pkg_version}"
+            exit 1
+          fi
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm test
+      - run: npm pack --dry-run
+
+      - name: Publish to npm
+        if: steps.resolve.outputs.dry_run != 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # pleno-anonymize
 
-Japanese-first PII analysis and redaction. The repository ships two artifacts that share a single recognizer registry and NER model:
+Japanese-first PII analysis and redaction. The repository ships three artifacts that share a single recognizer registry and NER model:
 
 - **`pleno-anonymize` server** — HTTP API exposing `/api/analyze`, `/api/redact`, and OpenAI / Anthropic / Gemini proxies that mask PII before forwarding upstream.
+- **`pleno-anonymize` npm package** — TypeScript SDK + CLI (`npx pleno-anonymize scan .`) wrapping the same API. See [`packages/sdk-js`](packages/sdk-js).
 - **`ja_ner_ja` / `en_ner_en` models** — spaCy NER models trained from this repository's training pipeline.
 
 Endpoint: https://pleno-anonymize.fly.dev (API reference at `/docs`).
@@ -38,6 +39,7 @@ Routing chat traffic through the LLM proxy masks PII before the request reaches 
 | Path | What it is |
 |---|---|
 | `server/` | FastAPI service — analyze / redact endpoints + LLM proxies |
+| `packages/sdk-js/` | TypeScript SDK + `npx pleno-anonymize` CLI (analyze / redact / scan) |
 | `packages/recognizers/` | Pure-Python Presidio recognizer registry (regex + checksum validators) |
 | `packages/training/` | spaCy / Hugging Face training pipeline for `ja_ner_ja` and `en_ner_en` |
 | `packages/models/` | Trained NER model artifacts |

--- a/packages/sdk-js/.gitignore
+++ b/packages/sdk-js/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.log

--- a/packages/sdk-js/.npmignore
+++ b/packages/sdk-js/.npmignore
@@ -1,0 +1,5 @@
+src/
+test/
+tsconfig.json
+.gitignore
+.npmignore

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -1,0 +1,120 @@
+# pleno-anonymize
+
+TypeScript SDK and CLI for the [pleno-anonymize](https://github.com/plenoai/pleno-anonymize) PII detection / redaction API.
+
+The same package ships:
+
+- A small `PlenoAnonymize` client for `analyze` / `redact`
+- A filesystem **scanner** that walks paths, reads text files, and reports PII per file
+- A CLI exposed as `pleno-anonymize` (run via `npx pleno-anonymize`)
+
+It targets the public endpoint at `https://pleno-anonymize.fly.dev` by default and works against any self-hosted deployment.
+
+## Install
+
+```bash
+# one-shot via npx (no install)
+npx pleno-anonymize scan .
+
+# or as a dependency
+npm i pleno-anonymize
+```
+
+Requires Node.js **18+** (uses native `fetch`).
+
+## CLI
+
+```text
+pleno-anonymize scan <path...>     # walk paths, detect PII per file
+pleno-anonymize analyze [text]     # detect entities in text / stdin / --file
+pleno-anonymize redact  [text]     # replace detected PII with <PLACEHOLDERS>
+pleno-anonymize health             # ping the API
+```
+
+Common flags:
+
+| Flag | Description |
+|---|---|
+| `--endpoint <url>` | API base URL (env: `PLENO_ANONYMIZE_ENDPOINT`) |
+| `--api-key <key>` | Bearer token (env: `PLENO_ANONYMIZE_API_KEY`) |
+| `--language ja\|en` | Detection language (default `ja`) |
+| `--entities A,B,C` | Restrict to specific entity types |
+| `--json` | Emit JSON |
+| `--fail-on-findings` | Exit `2` on `scan` when PII is found (CI gate) |
+| `--concurrency <n>` | Parallel scan requests (default `4`) |
+| `--max-bytes <n>` | Per-file byte cap for `scan` (default `262144`) |
+| `--ignore a,b` | Extra directory names to skip |
+| `--ext .md,.py` | Restrict scan to extensions |
+| `-f, --file <path>` | Read input text from file |
+
+### Examples
+
+```bash
+# scan the current repo, fail CI on any finding
+npx pleno-anonymize scan . --fail-on-findings
+
+# analyze a Japanese string
+echo "山田太郎 090-1234-5678 yamada@example.com" \
+  | npx pleno-anonymize analyze --language ja
+
+# redact and pipe to file
+npx pleno-anonymize redact -f notes.md > notes.redacted.md
+
+# JSON output for tooling
+npx pleno-anonymize scan src --json | jq '.byEntity'
+```
+
+## SDK
+
+```ts
+import { PlenoAnonymize, scanPaths } from "pleno-anonymize";
+
+const client = new PlenoAnonymize({
+  // endpoint: "https://pleno-anonymize.fly.dev",   // default
+  // apiKey: process.env.PLENO_ANONYMIZE_API_KEY,    // optional Bearer
+  defaultLanguage: "ja",
+});
+
+const findings = await client.analyze("山田太郎 090-1234-5678");
+// [{ entity_type: "PERSON", start: 0, end: 4, score: 0.9, text: "山田太郎" }, ...]
+
+const { text } = await client.redact("Contact john@example.com");
+// "Contact <EMAIL_ADDRESS>"
+
+const summary = await scanPaths(client, ["src", "docs"], {
+  language: "ja",
+  ignore: ["fixtures"],
+  onFile: (file) => {
+    if (file.findings.length > 0) console.log(file.path, file.findings.length);
+  },
+});
+console.log(summary.byEntity, summary.totalFindings);
+```
+
+### API surface
+
+| Export | Purpose |
+|---|---|
+| `PlenoAnonymize` | HTTP client (`analyze`, `redact`, `health`) |
+| `PlenoAnonymizeError` | Thrown on HTTP / timeout / abort failures |
+| `scanFile(client, path, opts)` | Analyze a single file |
+| `scanPaths(client, paths, opts)` | Walk paths with concurrency, return `ScanSummary` |
+| `Finding`, `FileScanResult`, `ScanSummary`, `Language` | Types |
+
+## Detected entities
+
+Free-text NER (`PERSON`, `ADDRESS`, `ORGANIZATION`, `DATE_OF_BIRTH`, `BANK_ACCOUNT`) and structured / regex+checksum classes (`PHONE_NUMBER`, `MY_NUMBER`, `MY_NUMBER_CORPORATE`, `CREDIT_CARD`, `PASSPORT`, `DRIVER_LICENSE`, `HEALTH_INSURANCE`, `RESIDENCE_CARD`, `POSTAL_CODE`, `EMAIL_ADDRESS`, `IP_ADDRESS`, `URL`).
+
+See the [server README](../../README.md) for the full list and language coverage.
+
+## Exit codes (CLI)
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Usage / runtime error |
+| `2` | `scan --fail-on-findings` and findings were detected |
+
+## License
+
+[AGPL-3.0](../../LICENSE)

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "pleno-anonymize",
+  "version": "0.1.0",
+  "description": "TypeScript SDK and CLI for the pleno-anonymize PII detection / redaction API.",
+  "license": "AGPL-3.0",
+  "homepage": "https://github.com/plenoai/pleno-anonymize",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/plenoai/pleno-anonymize.git",
+    "directory": "packages/sdk-js"
+  },
+  "bugs": {
+    "url": "https://github.com/plenoai/pleno-anonymize/issues"
+  },
+  "keywords": [
+    "pii",
+    "redaction",
+    "anonymize",
+    "presidio",
+    "japanese",
+    "ner",
+    "scanner",
+    "cli"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "pleno-anonymize": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run clean && npm run build",
+    "test": "node --test test/*.test.mjs",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/sdk-js/pnpm-lock.yaml
+++ b/packages/sdk-js/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.40
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
+packages:
+
+  '@types/node@20.19.40':
+    resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@20.19.40':
+    dependencies:
+      undici-types: 6.21.0
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/packages/sdk-js/src/cli.ts
+++ b/packages/sdk-js/src/cli.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+import { parseArgs } from "node:util";
+import { readFile } from "node:fs/promises";
+import { PlenoAnonymize, PlenoAnonymizeError } from "./client.js";
+import { scanPaths } from "./scanner.js";
+import type { Finding, Language, ScanSummary } from "./types.js";
+
+const HELP = `pleno-anonymize — PII detection / redaction CLI
+
+Usage:
+  pleno-anonymize scan <path...> [options]
+  pleno-anonymize analyze [text] [options]
+  pleno-anonymize redact  [text] [options]
+  pleno-anonymize health  [options]
+
+Options:
+  --endpoint <url>        API base URL (default: $PLENO_ANONYMIZE_ENDPOINT or https://pleno-anonymize.fly.dev)
+  --api-key <key>         Bearer token (default: $PLENO_ANONYMIZE_API_KEY)
+  --language <ja|en>      Detection language (default: ja)
+  --entities <list>       Comma-separated entity types to restrict to
+  --json                  Emit JSON output
+  --concurrency <n>       Parallel requests for scan (default: 4)
+  --max-bytes <n>         Per-file byte cap for scan (default: 262144)
+  --ignore <list>         Extra directory names to ignore (comma-separated)
+  --ext <list>            Restrict scan to extensions (comma-separated, e.g. ".md,.py")
+  --fail-on-findings      Exit non-zero (2) when scan finds PII
+  --no-color              Disable ANSI colors
+  -f, --file <path>       Read input text from file (analyze / redact)
+  -h, --help              Show this help
+
+Examples:
+  pleno-anonymize scan . --fail-on-findings
+  echo "山田太郎 090-1234-5678" | pleno-anonymize analyze --language ja
+  pleno-anonymize redact "Contact john@example.com" --json
+`;
+
+const COLOR = !process.env.NO_COLOR && process.stdout.isTTY;
+const c = {
+  red: (s: string) => (COLOR ? `\x1b[31m${s}\x1b[0m` : s),
+  yellow: (s: string) => (COLOR ? `\x1b[33m${s}\x1b[0m` : s),
+  green: (s: string) => (COLOR ? `\x1b[32m${s}\x1b[0m` : s),
+  cyan: (s: string) => (COLOR ? `\x1b[36m${s}\x1b[0m` : s),
+  dim: (s: string) => (COLOR ? `\x1b[2m${s}\x1b[0m` : s),
+  bold: (s: string) => (COLOR ? `\x1b[1m${s}\x1b[0m` : s),
+};
+
+interface CommonFlags {
+  endpoint?: string;
+  apiKey?: string;
+  language: Language;
+  entities?: string[];
+  json: boolean;
+}
+
+async function main(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const command = argv[0];
+  const rest = argv.slice(1);
+
+  try {
+    switch (command) {
+      case "scan":
+        return await runScan(rest);
+      case "analyze":
+        return await runAnalyze(rest);
+      case "redact":
+        return await runRedact(rest);
+      case "health":
+        return await runHealth(rest);
+      case "--version":
+      case "-v":
+      case "version": {
+        const pkg = await loadPackageJson();
+        process.stdout.write(`${pkg.name} ${pkg.version}\n`);
+        return 0;
+      }
+      default:
+        process.stderr.write(c.red(`unknown command: ${command}\n\n`));
+        process.stdout.write(HELP);
+        return 1;
+    }
+  } catch (err) {
+    if (err instanceof PlenoAnonymizeError) {
+      process.stderr.write(c.red(`error: ${err.message}\n`));
+      if (err.body) {
+        process.stderr.write(c.dim(`${JSON.stringify(err.body)}\n`));
+      }
+      return 1;
+    }
+    process.stderr.write(c.red(`error: ${(err as Error).message}\n`));
+    return 1;
+  }
+}
+
+type ParseArgsOption = { type: "string" | "boolean"; short?: string; multiple?: boolean };
+
+function parseCommon(
+  args: string[],
+  extra: Record<string, ParseArgsOption> = {},
+): { flags: CommonFlags; values: Record<string, unknown>; positionals: string[] } {
+  const options: Record<string, ParseArgsOption> = {
+    endpoint: { type: "string" },
+    "api-key": { type: "string" },
+    language: { type: "string" },
+    entities: { type: "string" },
+    json: { type: "boolean" },
+    help: { type: "boolean", short: "h" },
+    "no-color": { type: "boolean" },
+    ...extra,
+  };
+  const parsed = parseArgs({ args, allowPositionals: true, options });
+  const values = parsed.values as Record<string, unknown>;
+  const positionals = parsed.positionals;
+
+  if (values["no-color"]) {
+    for (const k of Object.keys(c)) {
+      (c as Record<string, (s: string) => string>)[k] = (s: string) => s;
+    }
+  }
+  const language = (values.language as string | undefined) ?? "ja";
+  if (language !== "ja" && language !== "en") {
+    throw new Error(`unsupported language: ${language} (must be ja or en)`);
+  }
+  const entitiesRaw = values.entities as string | undefined;
+  const flags: CommonFlags = {
+    endpoint: values.endpoint as string | undefined,
+    apiKey: values["api-key"] as string | undefined,
+    language,
+    entities: entitiesRaw
+      ? entitiesRaw.split(",").map((s) => s.trim()).filter(Boolean)
+      : undefined,
+    json: Boolean(values.json),
+  };
+  return { flags, values, positionals };
+}
+
+function makeClient(flags: CommonFlags): PlenoAnonymize {
+  return new PlenoAnonymize({
+    endpoint: flags.endpoint,
+    apiKey: flags.apiKey,
+    defaultLanguage: flags.language,
+  });
+}
+
+async function runScan(args: string[]): Promise<number> {
+  const { flags, values, positionals } = parseCommon(args, {
+    concurrency: { type: "string" },
+    "max-bytes": { type: "string" },
+    ignore: { type: "string" },
+    ext: { type: "string" },
+    "fail-on-findings": { type: "boolean" },
+  });
+  if (values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const targets = positionals.length > 0 ? positionals : ["."];
+  const client = makeClient(flags);
+  const concurrency = values.concurrency ? Number(values.concurrency as string) : undefined;
+  const maxBytes = values["max-bytes"] ? Number(values["max-bytes"] as string) : undefined;
+  const ignore = values.ignore
+    ? (values.ignore as string).split(",").map((s) => s.trim()).filter(Boolean)
+    : undefined;
+  const includeExtensions = values.ext
+    ? (values.ext as string).split(",").map((s) => s.trim()).filter(Boolean)
+    : undefined;
+
+  const summary = await scanPaths(client, targets, {
+    language: flags.language,
+    entities: flags.entities,
+    concurrency,
+    maxBytes,
+    ignore,
+    includeExtensions,
+    onFile: flags.json
+      ? undefined
+      : (file) => {
+          if (file.skipped === "binary") return;
+          if (file.error) {
+            process.stderr.write(c.yellow(`! ${file.path}: ${file.error}\n`));
+            return;
+          }
+          if (file.findings.length === 0) return;
+          process.stdout.write(c.bold(`${file.path}\n`));
+          for (const f of file.findings) {
+            process.stdout.write(
+              `  ${c.cyan(f.entity_type.padEnd(18))} ${c.dim(`@${f.start}-${f.end} score=${f.score.toFixed(2)}`)}  ${formatSnippet(f)}\n`,
+            );
+          }
+        },
+  });
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+  } else {
+    printScanFooter(summary);
+  }
+
+  if (Boolean(values["fail-on-findings"]) && summary.totalFindings > 0) return 2;
+  return 0;
+}
+
+function printScanFooter(summary: ScanSummary): void {
+  const entries = Object.entries(summary.byEntity).sort((a, b) => b[1] - a[1]);
+  process.stdout.write("\n");
+  process.stdout.write(
+    c.bold(
+      `scanned ${summary.scannedFiles} file(s), ${summary.totalFindings} finding(s)`,
+    ) + "\n",
+  );
+  if (summary.skippedFiles > 0) {
+    process.stdout.write(c.dim(`skipped ${summary.skippedFiles} file(s)`) + "\n");
+  }
+  for (const [entity, count] of entries) {
+    process.stdout.write(`  ${c.cyan(entity.padEnd(18))} ${count}\n`);
+  }
+}
+
+function formatSnippet(f: Finding): string {
+  const single = f.text.replace(/\s+/g, " ").trim();
+  return single.length > 60 ? `${single.slice(0, 57)}...` : single;
+}
+
+async function runAnalyze(args: string[]): Promise<number> {
+  const { flags, values, positionals } = parseCommon(args, {
+    file: { type: "string", short: "f" },
+  });
+  if (values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const text = await resolveText(positionals, values.file as string | undefined);
+  const client = makeClient(flags);
+  const findings = await client.analyze(text, {
+    language: flags.language,
+    entities: flags.entities,
+  });
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(findings, null, 2) + "\n");
+    return findings.length > 0 ? 0 : 0;
+  }
+  if (findings.length === 0) {
+    process.stdout.write(c.green("no PII detected\n"));
+    return 0;
+  }
+  for (const f of findings) {
+    process.stdout.write(
+      `${c.cyan(f.entity_type.padEnd(18))} ${c.dim(`@${f.start}-${f.end} score=${f.score.toFixed(2)}`)}  ${formatSnippet(f)}\n`,
+    );
+  }
+  return 0;
+}
+
+async function runRedact(args: string[]): Promise<number> {
+  const { flags, values, positionals } = parseCommon(args, {
+    file: { type: "string", short: "f" },
+  });
+  if (values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const text = await resolveText(positionals, values.file as string | undefined);
+  const client = makeClient(flags);
+  const result = await client.redact(text, {
+    language: flags.language,
+    entities: flags.entities,
+  });
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+    return 0;
+  }
+  process.stdout.write(`${result.text ?? ""}\n`);
+  return 0;
+}
+
+async function runHealth(args: string[]): Promise<number> {
+  const { flags } = parseCommon(args);
+  const client = makeClient(flags);
+  const result = await client.health();
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    process.stdout.write(`${result.status ?? "ok"}\n`);
+  }
+  return 0;
+}
+
+async function resolveText(positionals: string[], filePath?: string): Promise<string> {
+  if (filePath) return (await readFile(filePath, "utf8")).replace(/\r\n/g, "\n");
+  if (positionals.length > 0) return positionals.join(" ");
+  if (!process.stdin.isTTY) return await readStdin();
+  throw new Error("provide text as an argument, --file, or via stdin");
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function loadPackageJson(): Promise<{ name: string; version: string }> {
+  const url = new URL("../package.json", import.meta.url);
+  const data = JSON.parse(await readFile(url, "utf8"));
+  return { name: data.name, version: data.version };
+}
+
+main(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`fatal: ${(err as Error).stack ?? err}\n`);
+    process.exit(1);
+  },
+);

--- a/packages/sdk-js/src/client.ts
+++ b/packages/sdk-js/src/client.ts
@@ -1,0 +1,154 @@
+import type {
+  AnalyzeRequest,
+  Finding,
+  Language,
+  RedactRequest,
+  RedactResult,
+} from "./types.js";
+
+export const DEFAULT_ENDPOINT = "https://pleno-anonymize.fly.dev";
+
+export interface ClientOptions {
+  endpoint?: string;
+  apiKey?: string;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+  defaultLanguage?: Language;
+  userAgent?: string;
+}
+
+export class PlenoAnonymizeError extends Error {
+  readonly status?: number;
+  readonly body?: unknown;
+
+  constructor(message: string, opts: { status?: number; body?: unknown } = {}) {
+    super(message);
+    this.name = "PlenoAnonymizeError";
+    this.status = opts.status;
+    this.body = opts.body;
+  }
+}
+
+export class PlenoAnonymize {
+  readonly endpoint: string;
+  readonly defaultLanguage: Language;
+  private readonly fetchImpl: typeof fetch;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+  private readonly userAgent: string;
+
+  constructor(options: ClientOptions = {}) {
+    const endpoint =
+      options.endpoint ??
+      process.env.PLENO_ANONYMIZE_ENDPOINT ??
+      DEFAULT_ENDPOINT;
+    this.endpoint = endpoint.replace(/\/+$/, "");
+    this.apiKey = options.apiKey ?? process.env.PLENO_ANONYMIZE_API_KEY;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    this.timeoutMs = options.timeoutMs ?? 30_000;
+    this.defaultLanguage = options.defaultLanguage ?? "ja";
+    this.userAgent = options.userAgent ?? "pleno-anonymize-sdk-js";
+
+    if (!this.fetchImpl) {
+      throw new PlenoAnonymizeError(
+        "global fetch is not available; pass options.fetch or run on Node 18+",
+      );
+    }
+  }
+
+  async analyze(
+    text: string,
+    options: { language?: Language; entities?: string[] } = {},
+  ): Promise<Finding[]> {
+    const body: AnalyzeRequest = {
+      text,
+      language: options.language ?? this.defaultLanguage,
+      ...(options.entities ? { entities: options.entities } : {}),
+    };
+    return this.request<Finding[]>("/api/analyze", body);
+  }
+
+  async redact(
+    input: string | RedactRequest,
+    options: {
+      language?: Language;
+      entities?: string[];
+      operators?: Record<string, Record<string, unknown>>;
+    } = {},
+  ): Promise<RedactResult> {
+    const body: RedactRequest =
+      typeof input === "string"
+        ? {
+            text: input,
+            language: options.language ?? this.defaultLanguage,
+            ...(options.entities ? { entities: options.entities } : {}),
+            ...(options.operators ? { operators: options.operators } : {}),
+          }
+        : { language: this.defaultLanguage, ...input };
+
+    const payload: Record<string, unknown> = { ...body };
+    if (body.fillColor) {
+      payload.fill_color = body.fillColor;
+      delete (payload as { fillColor?: unknown }).fillColor;
+    }
+    return this.request<RedactResult>("/api/redact", payload);
+  }
+
+  async health(): Promise<{ status: string }> {
+    return this.request<{ status: string }>("/health", undefined, { method: "GET" });
+  }
+
+  private async request<T>(
+    path: string,
+    body?: unknown,
+    init: { method?: string } = {},
+  ): Promise<T> {
+    const url = `${this.endpoint}${path}`;
+    const method = init.method ?? (body === undefined ? "GET" : "POST");
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      "user-agent": this.userAgent,
+    };
+    if (body !== undefined) headers["content-type"] = "application/json";
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(url, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+      const raw = await res.text();
+      let parsed: unknown = undefined;
+      if (raw) {
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          parsed = raw;
+        }
+      }
+      if (!res.ok) {
+        throw new PlenoAnonymizeError(
+          `pleno-anonymize ${method} ${path} failed: ${res.status} ${res.statusText}`,
+          { status: res.status, body: parsed },
+        );
+      }
+      return parsed as T;
+    } catch (err) {
+      if (err instanceof PlenoAnonymizeError) throw err;
+      if ((err as { name?: string }).name === "AbortError") {
+        throw new PlenoAnonymizeError(
+          `pleno-anonymize ${method} ${path} timed out after ${this.timeoutMs}ms`,
+        );
+      }
+      throw new PlenoAnonymizeError(
+        `pleno-anonymize ${method} ${path} request failed: ${(err as Error).message}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  PlenoAnonymize,
+  PlenoAnonymizeError,
+  DEFAULT_ENDPOINT,
+  type ClientOptions,
+} from "./client.js";
+export { scanFile, scanPaths, type ScanOptions } from "./scanner.js";
+export type {
+  AnalyzeRequest,
+  Finding,
+  Language,
+  RedactRequest,
+  RedactResult,
+  FileScanResult,
+  ScanSummary,
+} from "./types.js";

--- a/packages/sdk-js/src/scanner.ts
+++ b/packages/sdk-js/src/scanner.ts
@@ -1,0 +1,256 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import type { PlenoAnonymize } from "./client.js";
+import type {
+  FileScanResult,
+  Finding,
+  Language,
+  ScanSummary,
+} from "./types.js";
+
+export interface ScanOptions {
+  language?: Language;
+  entities?: string[];
+  maxBytes?: number;
+  concurrency?: number;
+  ignore?: string[];
+  includeExtensions?: string[];
+  followSymlinks?: boolean;
+  onFile?: (result: FileScanResult) => void;
+}
+
+const DEFAULT_IGNORE = new Set([
+  ".git",
+  "node_modules",
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".ruff_cache",
+  "dist",
+  "build",
+  "target",
+  ".next",
+  ".turbo",
+  ".cache",
+]);
+
+const SCAN_EXTENSIONS = new Set([
+  ".txt", ".md", ".markdown", ".rst",
+  ".json", ".jsonl", ".ndjson", ".yaml", ".yml", ".toml", ".ini", ".env", ".cfg", ".conf",
+  ".csv", ".tsv",
+  ".log",
+  ".html", ".htm", ".xml", ".svg",
+  ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx",
+  ".py", ".rb", ".go", ".rs", ".java", ".kt", ".swift", ".php", ".cs", ".c", ".h", ".cpp", ".hpp",
+  ".sh", ".bash", ".zsh", ".fish",
+  ".sql",
+]);
+
+const DEFAULT_MAX_BYTES = 256 * 1024;
+
+export async function scanPaths(
+  client: PlenoAnonymize,
+  paths: string[],
+  options: ScanOptions = {},
+): Promise<ScanSummary> {
+  const ignore = new Set([...DEFAULT_IGNORE, ...(options.ignore ?? [])]);
+  const allow = options.includeExtensions
+    ? new Set(options.includeExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
+    : SCAN_EXTENSIONS;
+  const concurrency = Math.max(1, options.concurrency ?? 4);
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  const files: string[] = [];
+  for (const p of paths) {
+    await collectFiles(resolve(p), files, ignore, allow, options.followSymlinks ?? false);
+  }
+
+  const queue = [...files];
+  const results: FileScanResult[] = [];
+  const workers = Array.from({ length: Math.min(concurrency, queue.length) || 1 }, async () => {
+    while (queue.length > 0) {
+      const next = queue.shift();
+      if (!next) break;
+      const result = await scanSingleFile(client, next, {
+        language: options.language ?? client.defaultLanguage,
+        entities: options.entities,
+        maxBytes,
+      });
+      results.push(result);
+      options.onFile?.(result);
+    }
+  });
+  await Promise.all(workers);
+
+  results.sort((a, b) => a.path.localeCompare(b.path));
+
+  const byEntity: Record<string, number> = {};
+  let totalFindings = 0;
+  let scannedFiles = 0;
+  let skippedFiles = 0;
+  for (const r of results) {
+    if (r.skipped) {
+      skippedFiles += 1;
+      continue;
+    }
+    scannedFiles += 1;
+    for (const f of r.findings) {
+      totalFindings += 1;
+      byEntity[f.entity_type] = (byEntity[f.entity_type] ?? 0) + 1;
+    }
+  }
+
+  return { files: results, totalFindings, byEntity, scannedFiles, skippedFiles };
+}
+
+async function collectFiles(
+  abs: string,
+  out: string[],
+  ignore: Set<string>,
+  allow: Set<string>,
+  followSymlinks: boolean,
+): Promise<void> {
+  let info;
+  try {
+    info = await stat(abs);
+  } catch {
+    return;
+  }
+
+  if (info.isFile()) {
+    if (matchExtension(abs, allow)) out.push(abs);
+    return;
+  }
+  if (!info.isDirectory()) return;
+
+  let entries;
+  try {
+    entries = await readdir(abs, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (ignore.has(entry.name)) continue;
+    const child = join(abs, entry.name);
+    if (entry.isSymbolicLink() && !followSymlinks) continue;
+    if (entry.isDirectory()) {
+      await collectFiles(child, out, ignore, allow, followSymlinks);
+    } else if (entry.isFile() && matchExtension(child, allow)) {
+      out.push(child);
+    }
+  }
+}
+
+function matchExtension(path: string, allow: Set<string>): boolean {
+  const dot = path.lastIndexOf(".");
+  if (dot < 0) return false;
+  return allow.has(path.slice(dot).toLowerCase());
+}
+
+interface SingleFileOptions {
+  language: Language;
+  entities?: string[];
+  maxBytes: number;
+}
+
+async function scanSingleFile(
+  client: PlenoAnonymize,
+  abs: string,
+  options: SingleFileOptions,
+): Promise<FileScanResult> {
+  const display = relative(process.cwd(), abs) || abs;
+  let info;
+  try {
+    info = await stat(abs);
+  } catch (err) {
+    return errorResult(display, options.language, "read-error", (err as Error).message);
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = await readFile(abs);
+  } catch (err) {
+    return errorResult(display, options.language, "read-error", (err as Error).message);
+  }
+
+  if (looksBinary(buffer)) {
+    return {
+      path: display,
+      bytes: info.size,
+      language: options.language,
+      findings: [],
+      truncated: false,
+      skipped: "binary",
+    };
+  }
+
+  const truncated = buffer.length > options.maxBytes;
+  const slice = truncated ? buffer.subarray(0, options.maxBytes) : buffer;
+  const text = slice.toString("utf8");
+  if (!text.trim()) {
+    return {
+      path: display,
+      bytes: info.size,
+      language: options.language,
+      findings: [],
+      truncated,
+    };
+  }
+
+  let findings: Finding[];
+  try {
+    findings = await client.analyze(text, {
+      language: options.language,
+      entities: options.entities,
+    });
+  } catch (err) {
+    return errorResult(display, options.language, "read-error", (err as Error).message);
+  }
+
+  return {
+    path: display,
+    bytes: info.size,
+    language: options.language,
+    findings,
+    truncated,
+  };
+}
+
+function errorResult(
+  path: string,
+  language: Language,
+  reason: NonNullable<FileScanResult["skipped"]>,
+  message: string,
+): FileScanResult {
+  return {
+    path,
+    bytes: 0,
+    language,
+    findings: [],
+    truncated: false,
+    skipped: reason,
+    error: message,
+  };
+}
+
+function looksBinary(buf: Buffer): boolean {
+  const sample = buf.subarray(0, Math.min(buf.length, 8000));
+  for (let i = 0; i < sample.length; i += 1) {
+    if (sample[i] === 0) return true;
+  }
+  return false;
+}
+
+export async function scanFile(
+  client: PlenoAnonymize,
+  path: string,
+  options: Omit<ScanOptions, "onFile" | "concurrency" | "ignore" | "includeExtensions" | "followSymlinks"> = {},
+): Promise<FileScanResult> {
+  return scanSingleFile(client, resolve(path), {
+    language: options.language ?? client.defaultLanguage,
+    entities: options.entities,
+    maxBytes: options.maxBytes ?? DEFAULT_MAX_BYTES,
+  });
+}

--- a/packages/sdk-js/src/types.ts
+++ b/packages/sdk-js/src/types.ts
@@ -1,0 +1,48 @@
+export type Language = "ja" | "en";
+
+export interface AnalyzeRequest {
+  text: string;
+  language?: Language;
+  entities?: string[];
+}
+
+export interface Finding {
+  entity_type: string;
+  start: number;
+  end: number;
+  score: number;
+  text: string;
+}
+
+export interface RedactRequest {
+  text?: string;
+  image?: string;
+  language?: Language;
+  entities?: string[];
+  operators?: Record<string, Record<string, unknown>>;
+  fillColor?: [number, number, number];
+}
+
+export interface RedactResult {
+  text?: string;
+  items?: unknown[];
+  image?: string;
+}
+
+export interface FileScanResult {
+  path: string;
+  bytes: number;
+  language: Language;
+  findings: Finding[];
+  truncated: boolean;
+  skipped?: "binary" | "too-large" | "read-error";
+  error?: string;
+}
+
+export interface ScanSummary {
+  files: FileScanResult[];
+  totalFindings: number;
+  byEntity: Record<string, number>;
+  scannedFiles: number;
+  skippedFiles: number;
+}

--- a/packages/sdk-js/test/client.test.mjs
+++ b/packages/sdk-js/test/client.test.mjs
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PlenoAnonymize, PlenoAnonymizeError } from "../dist/index.js";
+
+function mockFetch(handler) {
+  return async (url, init) => {
+    const body = init && init.body ? JSON.parse(init.body) : undefined;
+    return handler(String(url), init?.method ?? "GET", body);
+  };
+}
+
+function jsonResponse(data, init = {}) {
+  return new Response(JSON.stringify(data), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("analyze posts to /api/analyze with language default", async () => {
+  let captured;
+  const client = new PlenoAnonymize({
+    endpoint: "https://example.test",
+    fetch: mockFetch((url, method, body) => {
+      captured = { url, method, body };
+      return jsonResponse([
+        { entity_type: "EMAIL_ADDRESS", start: 0, end: 16, score: 1, text: "a@b.co" },
+      ]);
+    }),
+  });
+  const findings = await client.analyze("a@b.co");
+  assert.equal(captured.url, "https://example.test/api/analyze");
+  assert.equal(captured.method, "POST");
+  assert.equal(captured.body.language, "ja");
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].entity_type, "EMAIL_ADDRESS");
+});
+
+test("redact accepts string shorthand", async () => {
+  const client = new PlenoAnonymize({
+    endpoint: "https://example.test",
+    fetch: mockFetch((url, _method, body) => {
+      assert.equal(body.text, "hello");
+      return jsonResponse({ text: "<X>", items: [] });
+    }),
+  });
+  const out = await client.redact("hello");
+  assert.equal(out.text, "<X>");
+});
+
+test("non-2xx becomes PlenoAnonymizeError with body", async () => {
+  const client = new PlenoAnonymize({
+    endpoint: "https://example.test",
+    fetch: mockFetch(() => jsonResponse({ detail: "bad" }, { status: 422 })),
+  });
+  await assert.rejects(
+    () => client.analyze("x"),
+    (err) => {
+      assert.ok(err instanceof PlenoAnonymizeError);
+      assert.equal(err.status, 422);
+      assert.deepEqual(err.body, { detail: "bad" });
+      return true;
+    },
+  );
+});
+
+test("endpoint trailing slash is normalized", async () => {
+  const client = new PlenoAnonymize({
+    endpoint: "https://example.test///",
+    fetch: mockFetch((url) => {
+      assert.equal(url, "https://example.test/api/analyze");
+      return jsonResponse([]);
+    }),
+  });
+  await client.analyze("hi");
+});

--- a/packages/sdk-js/test/scanner.test.mjs
+++ b/packages/sdk-js/test/scanner.test.mjs
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PlenoAnonymize, scanPaths } from "../dist/index.js";
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "pleno-scan-"));
+  await writeFile(join(root, "a.md"), "Contact john@example.com");
+  await writeFile(join(root, "b.md"), "no pii here");
+  await mkdir(join(root, "node_modules"));
+  await writeFile(join(root, "node_modules", "skip.md"), "ignored@example.com");
+  await mkdir(join(root, "nested"));
+  await writeFile(join(root, "nested", "c.txt"), "Email: alice@example.com");
+  return root;
+}
+
+test("scanPaths walks dirs, skips ignored, aggregates findings", async () => {
+  const root = await fixture();
+  const calls = [];
+  const fakeFetch = async (url, init) => {
+    const body = JSON.parse(init.body);
+    calls.push(body.text);
+    const findings = [];
+    const re = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+    let match;
+    while ((match = re.exec(body.text)) !== null) {
+      findings.push({
+        entity_type: "EMAIL_ADDRESS",
+        start: match.index,
+        end: match.index + match[0].length,
+        score: 1,
+        text: match[0],
+      });
+    }
+    return new Response(JSON.stringify(findings), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  const client = new PlenoAnonymize({ endpoint: "https://example.test", fetch: fakeFetch });
+  const summary = await scanPaths(client, [root]);
+  const scannedNames = summary.files.filter((f) => !f.skipped).map((f) => f.path);
+  assert.ok(scannedNames.some((p) => p.endsWith("a.md")));
+  assert.ok(scannedNames.some((p) => p.endsWith("c.txt")));
+  assert.ok(!scannedNames.some((p) => p.includes("node_modules")));
+  assert.equal(summary.totalFindings, 2);
+  assert.equal(summary.byEntity.EMAIL_ADDRESS, 2);
+});

--- a/packages/sdk-js/tsconfig.json
+++ b/packages/sdk-js/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Adds `packages/sdk-js`, a zero-dep Node 18+ npm package that wraps the existing `/api/analyze` and `/api/redact` endpoints. The same package powers programmatic use (`PlenoAnonymize`, `scanFile`, `scanPaths`) and the `npx pleno-anonymize` CLI.

## CLI

```text
pleno-anonymize scan <path...>     # walk paths, detect PII per file
pleno-anonymize analyze [text]     # inline / --file / stdin
pleno-anonymize redact  [text]     # replace detected PII with <PLACEHOLDERS>
pleno-anonymize health
```

- `scan` walks dirs (skipping `node_modules`, `.git`, `.venv`, etc.), caps per-file bytes, runs analyze concurrently, supports `--json` and `--fail-on-findings` (exit `2`) for CI gating
- `analyze` / `redact` accept inline text, `-f/--file`, or stdin
- `--endpoint` / `--api-key` fall back to `PLENO_ANONYMIZE_ENDPOINT` / `PLENO_ANONYMIZE_API_KEY`, defaulting to the public fly.dev deployment

## SDK

```ts
import { PlenoAnonymize, scanPaths } from "pleno-anonymize";

const client = new PlenoAnonymize({ defaultLanguage: "ja" });
const findings = await client.analyze("山田太郎 090-1234-5678");
const summary = await scanPaths(client, ["src", "docs"], { ignore: ["fixtures"] });
```

- `PlenoAnonymize` uses native `fetch` with `AbortController` timeouts and `PlenoAnonymizeError` carrying `status` + parsed body
- Strict TS, declaration maps shipped, `isolatedModules`

## CI / release

- New `ci.yml` job runs `pnpm install && pnpm build && pnpm test` for sdk-js
- `release-npm.yml` triggers on `sdk-js/vX.Y.Z` tag pushes (mirrors the recognizers convention), publishes with `--provenance`, and guards against tag/version mismatch
- `npm pack --dry-run` ships 22 files / ~14 kB (`dist/` + `README`)

## Verified

- `pnpm test` — 5/5 pass (mock-fetch client + scanner with tmp-dir fixture)
- `node dist/cli.js health/analyze/redact/scan` against `https://pleno-anonymize.fly.dev` returns expected output
- `pnpm run build` clean (`tsc` strict, `noUncheckedIndexedAccess`)