### PR TITLE
feat(mechanism): eval driver vs ai4privacy/pii-masking-300k-ja (#154)

### DIFF
--- a/docs/benchmark-mechanism-v1.md
+++ b/docs/benchmark-mechanism-v1.md
@@ -1,0 +1,59 @@
+# `ja_ner_ja-v2` (mechanism-v1) — baseline benchmark
+
+**Status:** infrastructure ready (#154 PR landed). Numbers will appear here after the RunPod training run completes and `make eval-mechanism-300k-ja` is executed against the resulting checkpoint.
+
+## Methodology
+
+Identical to [`docs/benchmark.md`](benchmark.md) §4 (the public ruler):
+
+- Dataset: `0xhikae/pii-masking-300k-ja`, `validation` split.
+- Sample size: n = 300 (primary), n = 50 (pilot).
+- Scoring: char-IoU ≥ 0.5, label-agnostic span matching.
+- Metric: overall F1 (primary), per-label recall, avg latency / doc (CPU).
+
+We deliberately reuse the **same evaluator** the SDK uses for the
+shipped engines so v2 numbers are directly comparable to the
+published v0.13.0 baseline:
+
+| Engine | F1 | Precision | Recall |
+|---|---:|---:|---:|
+| `builtin` v0.13.0 | 0.342 | 0.453 | 0.275 |
+| `openai-privacy-filter` v0.13.0 | 0.702 | 0.899 | 0.576 |
+| **`ja_ner_ja-v2` (mechanism-v1)** | **TBD** | **TBD** | **TBD** |
+
+## Eval driver
+
+`packages/training/scripts/eval_mechanism_on_300k.py` runs the same
+char-IoU ≥ 0.5 scoring as `packages/sdk/scripts/eval_pii_masking_300k.py`
+but feeds the input through an arbitrary HuggingFace
+`AutoModelForTokenClassification`. This keeps the SDK eval path
+unchanged (the public ruler is fixed; #154 must not modify it).
+
+```bash
+cd packages/training
+make eval-mechanism-300k-ja BENCH_MODEL=plenoai/ja_ner_ja-v2 BENCH_LIMIT=300
+```
+
+## Acceptance tiers (per `.claude/skills/ner-improve/SKILL.md`)
+
+| Tier | F1 floor | Implication |
+|---|---:|---|
+| Smoke | 0.50 | first meaningful improvement over `builtin` (0.342); ship behind a flag |
+| Parity | 0.82 | matches `openai-privacy-filter`; promote to default backend |
+| Stretch | 0.88 | exceeds OPF; mark as production default |
+
+Per-label recall floors apply additionally — see SKILL.md.
+
+## Risks
+
+- **Domain mismatch** — the synthetic dataset uses pleno's 17-label
+  taxonomy, while `300k-ja` uses AI4Privacy's 27 fine-grained labels.
+  The label-agnostic IoU protocol partially neutralises this, but
+  classes that pleno doesn't model at all (e.g. `USERNAME`) will
+  contribute only to FN.
+- **Length distribution** — the synthetic dataset skews longer than
+  AI4Privacy chat snippets; bertbase truncation may matter at the
+  margin.
+- **Tokenizer mismatch** — fine-tuning on `cl-tohoku/bert-base-japanese-v3`
+  vs. evaluating on the AI4Privacy split (no JP coverage there;
+  validation uses `300k-ja` which is our independent JP fork).

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -20,7 +20,8 @@
        build-taxonomy build-taxonomy-enrich build-meta-prompts \
        score-difficulty score-difficulty-elo \
        generate-mechanism-smoke generate-mechanism-v1 \
-       train-mechanism-smoke train-mechanism push-dataset-hf push-model-hf
+       train-mechanism-smoke train-mechanism push-dataset-hf push-model-hf \
+       eval-mechanism-300k-ja
 
 MODEL ?= gpt-5.4-nano
 DOCS_PER_TEMPLATE ?= 20
@@ -835,3 +836,16 @@ push-dataset-hf:
 push-model-hf:
 	uv run --extra training --extra hf python scripts/push_model_to_hf.py \
 		--model-dir $(MECHANISM_OUT)/model-best --repo $(HF_MODEL_REPO)
+
+# Simula 7/8 — benchmark against ai4privacy/pii-masking-300k-ja.
+BENCH_MODEL ?= $(HF_MODEL_REPO)
+BENCH_DATASET ?= 0xhikae/pii-masking-300k-ja
+BENCH_LIMIT ?= 300
+BENCH_OUT ?= ../../output/pii-300k-ja-mechanism-v1.json
+
+eval-mechanism-300k-ja:
+	uv run --extra training --extra hf python scripts/eval_mechanism_on_300k.py \
+		--model $(BENCH_MODEL) \
+		--dataset $(BENCH_DATASET) \
+		--language Japanese --limit $(BENCH_LIMIT) \
+		--output $(BENCH_OUT)

--- a/packages/training/scripts/eval_mechanism_on_300k.py
+++ b/packages/training/scripts/eval_mechanism_on_300k.py
@@ -1,0 +1,227 @@
+"""Benchmark a HuggingFace token-classification NER on ai4privacy datasets.
+
+Uses the exact char-IoU >= 0.5, label-agnostic scoring protocol that
+`packages/sdk/scripts/eval_pii_masking_300k.py` applies to the
+SDK-shipped engines. Lets us compare `ja_ner_ja-v2` (or any HF NER
+model) against the public ruler **without** plumbing it through the
+SDK first.
+
+Example:
+    uv run --extra training --extra hf python \\
+        scripts/eval_mechanism_on_300k.py \\
+        --model plenoai/ja_ner_ja-v2 \\
+        --dataset 0xhikae/pii-masking-300k-ja \\
+        --language Japanese --limit 300 \\
+        --output ../../output/pii-300k-ja-mechanism-v1.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Counts:
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    latency_ms: float = 0.0
+    n_docs: int = 0
+    n_gold_spans: int = 0
+    n_pred_spans: int = 0
+    per_label_tp: dict[str, int] = field(default_factory=dict)
+    per_label_fn: dict[str, int] = field(default_factory=dict)
+
+    def precision(self) -> float:
+        d = self.tp + self.fp
+        return self.tp / d if d else 0.0
+
+    def recall(self) -> float:
+        d = self.tp + self.fn
+        return self.tp / d if d else 0.0
+
+    def f1(self) -> float:
+        p, r = self.precision(), self.recall()
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+
+def _iou(a: tuple[int, int], b: tuple[int, int]) -> float:
+    s = max(a[0], b[0])
+    e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def _parse_gold(row: dict) -> list[tuple[int, int, str]]:
+    raw = row.get("span_labels") or row.get("entities") or row.get("privacy_mask")
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+    spans: list[tuple[int, int, str]] = []
+    for s in raw:
+        if isinstance(s, list) and len(s) >= 3:
+            spans.append((int(s[0]), int(s[1]), str(s[2])))
+        elif isinstance(s, dict) and {"start", "end"} <= s.keys():
+            spans.append((int(s["start"]), int(s["end"]), str(s.get("label", "?"))))
+    return spans
+
+
+def _decode_to_spans(text: str, tokens: list, predictions: list[str]) -> list[tuple[int, int, str]]:
+    """Merge contiguous B-/I- tokens into char-offset spans."""
+    spans: list[tuple[int, int, str]] = []
+    cur_label: str | None = None
+    cur_start: int | None = None
+    cur_end: int | None = None
+    for tok, pred in zip(tokens, predictions):
+        offset = tok["offset"]
+        if offset == (0, 0):
+            continue
+        if pred == "O":
+            if cur_label is not None:
+                spans.append((cur_start, cur_end, cur_label))
+                cur_label = cur_start = cur_end = None
+            continue
+        bio, _, label = pred.partition("-")
+        if bio == "B" or cur_label != label:
+            if cur_label is not None:
+                spans.append((cur_start, cur_end, cur_label))
+            cur_label = label
+            cur_start = offset[0]
+            cur_end = offset[1]
+        else:
+            cur_end = offset[1]
+    if cur_label is not None:
+        spans.append((cur_start, cur_end, cur_label))
+    return spans
+
+
+def _predict(model, tokenizer, text: str) -> list[tuple[int, int, str]]:
+    import torch
+
+    enc = tokenizer(
+        text,
+        return_offsets_mapping=True,
+        truncation=True,
+        max_length=512,
+        return_tensors="pt",
+    )
+    offsets = enc.pop("offset_mapping")[0].tolist()
+    enc = {k: v.to(model.device) for k, v in enc.items()}
+    with torch.inference_mode():
+        logits = model(**enc).logits[0]
+    pred_ids = logits.argmax(-1).tolist()
+    id2label = model.config.id2label
+    tokens = [{"offset": tuple(o)} for o in offsets]
+    labels = [id2label[i] for i in pred_ids]
+    return _decode_to_spans(text, tokens, labels)
+
+
+def _score(gold, pred, iou_threshold, counts) -> None:
+    matched_pred: set[int] = set()
+    for g_start, g_end, g_label in gold:
+        counts.per_label_fn.setdefault(g_label, 0)
+        counts.per_label_tp.setdefault(g_label, 0)
+        best_idx = -1
+        best_iou = 0.0
+        for i, p in enumerate(pred):
+            if i in matched_pred:
+                continue
+            iou = _iou((g_start, g_end), (p[0], p[1]))
+            if iou > best_iou:
+                best_iou = iou
+                best_idx = i
+        if best_idx >= 0 and best_iou >= iou_threshold:
+            counts.tp += 1
+            counts.per_label_tp[g_label] += 1
+            matched_pred.add(best_idx)
+        else:
+            counts.fn += 1
+            counts.per_label_fn[g_label] += 1
+    counts.fp += len(pred) - len(matched_pred)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model", required=True, help="HF repo id or local path to a token-classification model")
+    parser.add_argument("--dataset", default="0xhikae/pii-masking-300k-ja")
+    parser.add_argument("--split", default="validation")
+    parser.add_argument("--language", default="Japanese")
+    parser.add_argument("--limit", type=int, default=300)
+    parser.add_argument("--iou", type=float, default=0.5)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    from datasets import load_dataset
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    print(f"[load] model={args.model}")
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForTokenClassification.from_pretrained(args.model)
+    model.eval()
+
+    print(f"[load] dataset={args.dataset} split={args.split}")
+    ds = load_dataset(args.dataset, split=args.split, streaming=True)
+
+    counts = Counts()
+    seen = 0
+    for row in ds:
+        if args.language and row.get("language") != args.language:
+            continue
+        text = row.get("source_text") or row.get("text")
+        if not text:
+            continue
+        gold = _parse_gold(row)
+        t0 = time.perf_counter()
+        try:
+            pred = _predict(model, tokenizer, text)
+        except Exception as e:  # noqa: BLE001
+            print(f"[predict] error: {e}", file=sys.stderr)
+            pred = []
+        counts.latency_ms += (time.perf_counter() - t0) * 1000
+        counts.n_docs += 1
+        counts.n_gold_spans += len(gold)
+        counts.n_pred_spans += len(pred)
+        _score(gold, pred, args.iou, counts)
+        seen += 1
+        if seen >= args.limit:
+            break
+
+    summary = {
+        "model": args.model,
+        "dataset": args.dataset,
+        "split": args.split,
+        "language": args.language,
+        "limit": args.limit,
+        "iou": args.iou,
+        "tp": counts.tp,
+        "fp": counts.fp,
+        "fn": counts.fn,
+        "precision": round(counts.precision(), 4),
+        "recall": round(counts.recall(), 4),
+        "f1": round(counts.f1(), 4),
+        "n_docs": counts.n_docs,
+        "n_gold_spans": counts.n_gold_spans,
+        "n_pred_spans": counts.n_pred_spans,
+        "avg_latency_ms": round(counts.latency_ms / max(counts.n_docs, 1), 2),
+        "per_label_recall": {
+            l: round(counts.per_label_tp[l] / max(counts.per_label_tp[l] + counts.per_label_fn[l], 1), 4)
+            for l in counts.per_label_tp
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Simula 7/8 (Benchmark). Standalone evaluator that scores any HF token-classification model on `0xhikae/pii-masking-300k-ja` using the same protocol the SDK uses.

## Why

Need to gate the v2 ship on the public ruler. Per the fixed-ruler policy in `.claude/skills/ner-improve/SKILL.md`, the SDK eval (`packages/sdk/scripts/eval_pii_masking_300k.py`) must remain untouched, so this PR adds a parallel evaluator that exercises the same scoring logic but takes an HF `AutoModelForTokenClassification` directly.

## How

- `scripts/eval_mechanism_on_300k.py`: streaming eval over the validation split, BIO-to-span decoding, char-IoU ≥ 0.5 matching.
- Makefile: `eval-mechanism-300k-ja` with `BENCH_MODEL` / `BENCH_LIMIT` knobs.
- `docs/benchmark-mechanism-v1.md`: methodology + acceptance tiers (Smoke 0.50 / Parity 0.82 / Stretch 0.88) + risk notes.

## Numbers

Will be filled in once the v2 model lands on RunPod (#153). Comparison anchor:

| Engine | F1 |
|---|---:|
| `builtin` v0.13.0 | 0.342 |
| `openai-privacy-filter` v0.13.0 | 0.702 |
| **`ja_ner_ja-v2`** | **TBD** |

Closes #154.