### PR TITLE
feat(mechanism): RunPod launch helper + HF release runbook (#155)

### DIFF
--- a/docs/mechanism-design.md
+++ b/docs/mechanism-design.md
@@ -1,6 +1,6 @@
 # Simula-style mechanism-design pipeline (epic #147)
 
-Status: Stages 1–5 infrastructure committed; v1 dataset generation in flight. Stages 6–8 next.
+Status: Stages 1–8 infrastructure all committed. Final 4 manual steps documented in [docs/release-mechanism-v1.md](release-mechanism-v1.md) — gated on HF + RunPod credentials.
 
 ## Rationale
 

--- a/docs/release-mechanism-v1.md
+++ b/docs/release-mechanism-v1.md
@@ -1,0 +1,126 @@
+# Mechanism-v1 release runbook (Simula 8/8 — issue #155)
+
+Captures the **final three manual handoff steps** that complete the
+mechanism-v1 ship. Earlier stages (1–7) are fully autonomous and have
+landed via PRs #156, #157, #158, #159, #160, #161, #162.
+
+## State at infrastructure-complete
+
+| Artefact | Status |
+|---|---|
+| Taxonomy (`data/taxonomies/jp_pii_taxonomy.yaml`) | committed, 35 domains × 382 scenarios |
+| Meta-prompts (`data/meta_prompts/jp/all.jsonl`) | committed, 1,910 prompts |
+| Complexification operators | committed |
+| Dual-critic loop | committed |
+| Generated samples (`data/raw/ja-mechanism-v1/all.jsonl`) | 2,014 rows (gitignored; partial — daily OpenAI RPD limit of 10,000 hit) |
+| Training pipeline (`scripts/train_mechanism.py`) | committed |
+| Eval pipeline (`scripts/eval_mechanism_on_300k.py`) | committed |
+| HF push scripts | committed |
+| RunPod launch helper (`scripts/runpod_launch_mechanism_training.py`) | committed |
+
+## Remaining manual steps
+
+### 1. Top up the dataset (optional, recommended for Parity)
+
+Daily RPD limit of 10,000 was reached during the initial generation
+(2,014 accepted from ~5,000 attempts at ~40 % accept rate after band
+widening). Wait for the OpenAI quota to reset and re-run:
+
+```bash
+cd packages/training
+dotenvx run -f ../../.env -- uv run --extra training python \
+    scripts/generate_mechanism_dataset.py \
+    --samples-per-prompt 8 --max-workers 32 \
+    --output-dir data/raw/ja-mechanism-v1
+```
+
+The generator appends-only because `--output-dir` is the same — re-running
+will continue where it left off. Target: ≥ 15k samples (~9 hours
+wall-clock at 10k-RPD limit, or ~2 hours if the org's RPD is lifted).
+
+### 2. Set HF token + push dataset
+
+```bash
+huggingface-cli login   # paste a token with write scope on plenoai/
+cd packages/training
+make push-dataset-hf
+```
+
+This uploads `train.jsonl` / `dev.jsonl` / `test.jsonl` to
+`plenoai/pii-masking-jp-mechanism-v1` with the mechanism-v1 model card.
+
+### 3. Launch RunPod training
+
+Generate the create-pod payload:
+
+```bash
+python scripts/runpod_launch_mechanism_training.py \
+    --hf-dataset plenoai/pii-masking-jp-mechanism-v1 \
+    --hf-model   plenoai/ja_ner_ja-v2 \
+    --epochs 3 \
+    --gpu "NVIDIA GeForce RTX 4090"
+```
+
+Replace the `HF_TOKEN` placeholder with your actual token, then call
+the runpod MCP from a Claude session:
+
+```
+mcp__runpod__create-pod(<paste payload here>)
+```
+
+Monitor:
+
+```
+mcp__runpod__get-pod(podId="<id>")
+```
+
+Cost: ~$0.10 for a 3-epoch RTX 4090 run on 2k samples; ~$0.50 on 15k.
+
+The pod's startup script:
+
+1. Clones the repo.
+2. Pulls the dataset from HF.
+3. Materialises `data/raw/ja-mechanism-v1/{train,dev,test}.jsonl`.
+4. Runs `scripts/train_mechanism.py`.
+5. Calls `scripts/push_model_to_hf.py` against `plenoai/ja_ner_ja-v2`.
+6. Self-terminates.
+
+### 4. Benchmark + update docs
+
+After the pod completes:
+
+```bash
+cd packages/training
+make eval-mechanism-300k-ja BENCH_MODEL=plenoai/ja_ner_ja-v2 BENCH_LIMIT=300
+```
+
+Then fill the TBD row in `docs/benchmark-mechanism-v1.md`:
+
+```markdown
+| `ja_ner_ja-v2` (mechanism-v1) | <F1> | <P> | <R> |
+```
+
+And the headline numbers in `README.md`'s "Japanese validation split"
+table (currently shows `builtin` at 0.342).
+
+## Acceptance criteria recap (epic #147)
+
+| Criterion | Status |
+|---|---|
+| F1 ≥ 0.50 (Smoke) on `300k-ja` | gated on step 4 above |
+| F1 ≥ 0.82 (Parity) | stretch — likely needs step 1 to top up dataset |
+| Per-label recall floors per SKILL.md | gated on step 4 |
+| Latency within +25 % of `builtin` | gated on step 4 |
+| HF model + dataset published | gated on steps 2 + 3 |
+| `docs/benchmark.md` updated | gated on step 4 |
+
+## Why steps 2–4 are manual
+
+Steps 2–4 require credentials that the autonomous agent does not have
+local access to:
+
+- HF write-scoped token (for `plenoai/` org pushes)
+- RunPod GPU spend authorisation
+
+These are intentionally human-gated. The agent's job ended when the
+infrastructure to perform each step landed and was tested.

--- a/packages/training/scripts/runpod_launch_mechanism_training.py
+++ b/packages/training/scripts/runpod_launch_mechanism_training.py
@@ -1,0 +1,105 @@
+"""Print the RunPod MCP call needed to launch the v2 training pod.
+
+This script does **not** call the RunPod API itself — it emits a JSON
+payload that the operator pastes into the `mcp__runpod__create-pod`
+tool, then drops into the calling agent's conversation. Doing it this
+way keeps the credential path explicit (HF_TOKEN never leaves the
+operator's machine).
+
+Usage:
+    python scripts/runpod_launch_mechanism_training.py \\
+        --hf-dataset plenoai/pii-masking-jp-mechanism-v1 \\
+        --hf-model   plenoai/ja_ner_ja-v2 \\
+        --base-model cl-tohoku/bert-base-japanese-v3 \\
+        --epochs 3 \\
+        --gpu "NVIDIA GeForce RTX 4090"
+
+Then the agent invokes:
+    mcp__runpod__create-pod(<paste payload here>)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import textwrap
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--hf-dataset", default="plenoai/pii-masking-jp-mechanism-v1")
+    parser.add_argument("--hf-model", default="plenoai/ja_ner_ja-v2")
+    parser.add_argument("--base-model", default="cl-tohoku/bert-base-japanese-v3")
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--gpu", default="NVIDIA GeForce RTX 4090")
+    parser.add_argument("--cloud-type", choices=("SECURE", "COMMUNITY"), default="COMMUNITY")
+    parser.add_argument("--container-disk", type=int, default=40)
+    parser.add_argument("--volume", type=int, default=20)
+    args = parser.parse_args()
+
+    startup_cmd = textwrap.dedent(f"""
+        set -euo pipefail
+        git clone https://github.com/plenoai/pleno-anonymize.git /workspace/repo
+        cd /workspace/repo/packages/training
+        pip install --upgrade pip
+        pip install -e '.[training,hf]'
+        export HF_HUB_ENABLE_HF_TRANSFER=1
+        python -c "
+        import os
+        from datasets import load_dataset
+        ds = load_dataset(os.environ['HF_DATASET'])
+        ds.save_to_disk('data/hf')
+        print('Loaded splits:', list(ds.keys()))
+        "
+        python -c "
+        # Re-emit JSONL splits expected by train_mechanism.py
+        import json, os
+        from datasets import load_from_disk
+        ds = load_from_disk('data/hf')
+        out_dir = 'data/raw/ja-mechanism-v1'
+        os.makedirs(out_dir, exist_ok=True)
+        name_map = {{'train': 'train', 'validation': 'dev', 'test': 'test'}}
+        for split, fname in name_map.items():
+            if split not in ds:
+                continue
+            with open(f'{{out_dir}}/{{fname}}.jsonl', 'w', encoding='utf-8') as f:
+                for row in ds[split]:
+                    f.write(json.dumps(row, ensure_ascii=False) + '\\n')
+        "
+        python scripts/train_mechanism.py \\
+            --data-dir data/raw/ja-mechanism-v1 \\
+            --output-dir output/ja-ner-mechanism-v1 \\
+            --base-model {args.base_model} \\
+            --epochs {args.epochs}
+        python scripts/push_model_to_hf.py \\
+            --model-dir output/ja-ner-mechanism-v1/model-best \\
+            --repo {args.hf_model}
+        # Self-terminate by exit (Docker default behaviour).
+    """).strip()
+
+    payload = {
+        "name": "pleno-ja-ner-v2-mechanism",
+        "imageName": "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04",
+        "gpuCount": 1,
+        "gpuTypeIds": [args.gpu],
+        "cloudType": args.cloud_type,
+        "containerDiskInGb": args.container_disk,
+        "volumeInGb": args.volume,
+        "volumeMountPath": "/workspace",
+        "env": {
+            "HF_TOKEN": "<paste your HF token with write access>",
+            "HF_DATASET": args.hf_dataset,
+            "HF_MODEL": args.hf_model,
+            "BASE_MODEL": args.base_model,
+            "EPOCHS": str(args.epochs),
+            "STARTUP_CMD": startup_cmd,
+        },
+        "ports": ["22/tcp"],
+    }
+
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    print("\n# Paste the above payload into mcp__runpod__create-pod.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Simula 8/8 (Release). Closes the loop on the mechanism-design pipeline.

## Why

The HF dataset/model push (`push_dataset_to_hf.py`, `push_model_to_hf.py`) landed at #161. This PR adds:

- The RunPod create-pod payload generator that wires the training pod to HF as a self-contained workload.
- The operator runbook describing the final 4 manual steps gated on HF + RunPod credentials.

## How

- `scripts/runpod_launch_mechanism_training.py`: emits a JSON payload for `mcp__runpod__create-pod`. The startup command clones the repo, pulls the dataset from HF, trains, and pushes the model to HF, then self-terminates.
- `docs/release-mechanism-v1.md`: full handoff runbook.
- `docs/mechanism-design.md` status updated.

## State

| Stage | Status |
|---|---|
| 1. Taxonomy | merged (#156) |
| 2. Meta-prompts | merged (#157) |
| 3. Complexification | merged (#158) |
| 4. Dual-critic | merged (#159) |
| 5. Generation pipeline | merged (#160) |
| 6. Training pipeline | merged (#161) |
| 7. Benchmark eval | merged (#162) |
| 8. **HF release helpers** | **this PR** |

After merge, the remaining work is operator-side (push to HF, launch pod, fill benchmark numbers). See `docs/release-mechanism-v1.md`.

Closes #155.