### PR TITLE
docs(v2): add OOD eval for honest generalisation estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Japanese validation split (`0xhikae/pii-masking-300k-ja`), 50 docs.
 |---|---|---|---|---|
 | `builtin` | 0.453 | 0.275 | 0.342 | 55 ms |
 | `openai-privacy-filter` | **0.899** | **0.576** | **0.702** | 2.3 s |
-| **[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised)** (300 docs) | **0.931** | **0.982** | **0.956** | **43 ms** |
+| **[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised)** (300 docs, in-dist) | **0.931** | **0.982** | **0.956** | **43 ms** |
+| **[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised)** (67 docs, OOD synthetic) | 0.710 | 0.823 | 0.762 | 41 ms |
 
-The supervised v2 model clears all three acceptance tiers (Smoke 0.50 / Parity 0.82 / Stretch 0.88) and outperforms `openai-privacy-filter` while running ~50× faster on CPU. v1 baseline `ja_ner_ja-v2-mechanism` (synthetic-only, F1 0.352) is kept for methodology comparison — see [`docs/benchmark-mechanism-v1.md`](docs/benchmark-mechanism-v1.md).
+The supervised v2 model was trained on the train split of `0xhikae/pii-masking-300k-ja`, so the 0.956 figure on its validation split is an in-distribution upper bound (treat with appropriate skepticism — splits are disjoint by construction but share generation methodology). The OOD row evaluates against a completely separate synthetic test set the model has never seen, with a different label schema, and is the more honest generalisation estimate. v1 baseline `ja_ner_ja-v2-mechanism` (synthetic-only, F1 0.352) is kept for methodology comparison — see [`docs/benchmark-mechanism-v1.md`](docs/benchmark-mechanism-v1.md) and [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md).
 
 ```bash
 uv run --with datasets --package pleno-anonymize --extra openai \

--- a/README.md
+++ b/README.md
@@ -71,11 +71,22 @@ Japanese validation split (`0xhikae/pii-masking-300k-ja`), 50 docs.
 | Engine | Precision | Recall | F1 | Latency/doc (CPU) |
 |---|---|---|---|---|
 | `builtin` | 0.453 | 0.275 | 0.342 | 55 ms |
-| `openai-privacy-filter` | **0.899** | **0.576** | **0.702** | 2.3 s |
-| **[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised)** (300 docs, in-dist) | **0.931** | **0.982** | **0.956** | **43 ms** |
-| **[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised)** (67 docs, OOD synthetic) | 0.710 | 0.823 | 0.762 | 41 ms |
+| `openai-privacy-filter` | 0.899 | 0.576 | 0.702 | 2.3 s |
 
-The supervised v2 model was trained on the train split of `0xhikae/pii-masking-300k-ja`, so the 0.956 figure on its validation split is an in-distribution upper bound (treat with appropriate skepticism — splits are disjoint by construction but share generation methodology). The OOD row evaluates against a completely separate synthetic test set the model has never seen, with a different label schema, and is the more honest generalisation estimate. v1 baseline `ja_ner_ja-v2-mechanism` (synthetic-only, F1 0.352) is kept for methodology comparison — see [`docs/benchmark-mechanism-v1.md`](docs/benchmark-mechanism-v1.md) and [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md).
+[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised) numbers below.
+Read [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md) for full methodology, CIs, and caveats.
+
+| Eval set | F1 | 95% CI | P | R | Latency |
+|---|---:|---|---:|---:|---:|
+| In-dist (300k-ja validation, 300 docs)\* | 0.957 | [0.935, 0.973] | 0.933 | 0.983 | 43 ms |
+| OOD synthetic v1 test (134 docs, strict scoring) | 0.770 | [0.745, 0.797] | 0.718 | 0.829 | 41 ms |
+| OOD synthetic v1 test (134 docs, **span-merged**)† | **0.862** | [0.841, 0.881] | 0.888 | 0.837 | 41 ms |
+| spaCy `ja_core_news_lg` OOD baseline | 0.855 | [0.832, 0.878] | 0.787 | 0.937 | 26 ms |
+
+\* Trained on `0xhikae/pii-masking-300k-ja` train split. Use OOD numbers for production expectations.
+† Adjacent v2 sub-spans are merged before scoring, neutralising a label-granularity artifact (gold uses coarse `PERSON`/`ADDRESS`; v2 emits fine-grained `LASTNAME1`+`GIVENNAME1` / `STREET`+`CITY`+`STREET`). See benchmark doc for the artifact diagnosis.
+
+v1 baseline `ja_ner_ja-v2-mechanism` (synthetic-only, F1 0.352) is kept for methodology comparison — see [`docs/benchmark-mechanism-v1.md`](docs/benchmark-mechanism-v1.md).
 
 ```bash
 uv run --with datasets --package pleno-anonymize --extra openai \

--- a/README.md
+++ b/README.md
@@ -73,18 +73,21 @@ Japanese validation split (`0xhikae/pii-masking-300k-ja`), 50 docs.
 | `builtin` | 0.453 | 0.275 | 0.342 | 55 ms |
 | `openai-privacy-filter` | 0.899 | 0.576 | 0.702 | 2.3 s |
 
-[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised) numbers below.
-Read [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md) for full methodology, CIs, and caveats.
+[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised) numbers below — 3-seed mean ± std (seeds 42 / 7 / 1337), 1000-iter bootstrap CIs on the seed-42 run. See [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md) for the full methodology, span-merge derivation, real-text caveats, and open gaps.
 
-| Eval set | F1 | 95% CI | P | R | Latency |
+| Eval set | F1 | F1 95% CI | P | R | Latency |
 |---|---:|---|---:|---:|---:|
-| In-dist (300k-ja validation, 300 docs)\* | 0.957 | [0.935, 0.973] | 0.933 | 0.983 | 43 ms |
-| OOD synthetic v1 test (134 docs, strict scoring) | 0.770 | [0.745, 0.797] | 0.718 | 0.829 | 41 ms |
-| OOD synthetic v1 test (134 docs, **span-merged**)† | **0.862** | [0.841, 0.881] | 0.888 | 0.837 | 41 ms |
-| spaCy `ja_core_news_lg` OOD baseline | 0.855 | [0.832, 0.878] | 0.787 | 0.937 | 26 ms |
+| In-dist (300k-ja validation, 300 docs)\* | **0.955 ± 0.002** | [0.935, 0.973] | 0.929 ± 0.004 | 0.983 ± 0.001 | 43 ms |
+| OOD synthetic (v1 test+dev, 134 docs, strict) | 0.773 ± 0.004 | [0.745, 0.797] | 0.718 | 0.829 | 41 ms |
+| OOD synthetic (label-aware merged)† | **0.852 ± 0.014** | [0.846, 0.885] | 0.867 | 0.838 | 41 ms |
+| Real text (stockmark JP Wikipedia, PII subset 人名/地名, 147 docs)‡ | **0.467 ± 0.010** | [0.393, 0.520] | 0.486 | 0.436 | 43 ms |
+| spaCy `ja_core_news_lg` (same real-text, PII subset) | 0.571 | [0.533, 0.608] | 0.425 | 0.871 | 22 ms |
 
-\* Trained on `0xhikae/pii-masking-300k-ja` train split. Use OOD numbers for production expectations.
-† Adjacent v2 sub-spans are merged before scoring, neutralising a label-granularity artifact (gold uses coarse `PERSON`/`ADDRESS`; v2 emits fine-grained `LASTNAME1`+`GIVENNAME1` / `STREET`+`CITY`+`STREET`). See benchmark doc for the artifact diagnosis.
+\* Trained on `0xhikae/pii-masking-300k-ja` train split. Treat as upper bound, not production estimate.
+† Adjacent v2 sub-spans are merged before scoring **only when their labels map to the same coarse equivalence class** (e.g., `LASTNAME1`+`GIVENNAME1` → PERSON, `STREET`+`CITY` → ADDRESS). Cross-class adjacency is not merged. Neutralises a label-granularity artifact in the eval protocol.
+‡ **First real-text eval.** v2 trails spaCy by 0.10 F1 on Wikipedia. Reflects domain mismatch (v2 trained on form-/record-style PII text, Wikipedia is narrative prose). A real-text PII-context eval (chat/form/email JP) is the highest-priority follow-up.
+
+**Acceptance tier read:** Smoke (≥0.50) and Parity (≥0.82, vs OPF 0.702) met on synthetic eval. Real-text Parity is **not** claimed. Production expectations should be calibrated near 0.47, not 0.85.
 
 v1 baseline `ja_ner_ja-v2-mechanism` (synthetic-only, F1 0.352) is kept for methodology comparison — see [`docs/benchmark-mechanism-v1.md`](docs/benchmark-mechanism-v1.md).
 

--- a/docs/benchmark-supervised-v2.md
+++ b/docs/benchmark-supervised-v2.md
@@ -1,115 +1,202 @@
-# `ja_ner_ja-v2-supervised` — Smoke / Parity / Stretch all cleared
+# `ja_ner_ja-v2-supervised` — benchmark + methodological accounting
 
-**Status:** released publicly at
-[`0xhikae/ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised).
-Closes the Smoke goal opened by issue #168 (proposed after v1 fell short).
+Released at [`0xhikae/ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised).
+Closes the goal opened by [#168](https://github.com/plenoai/pleno-anonymize/issues/168).
+
+This document reports both the optimistic in-distribution number and
+the more honest out-of-distribution numbers, surfaces a non-obvious
+eval-protocol artifact, and lists the methodological limitations a
+peer reviewer would (and did) flag.
+
+## TL;DR
+
+- **In-distribution F1: 0.957** [0.935, 0.973] — on the validation
+  split of the same dataset whose train split was used to train v2.
+  Treat as an upper bound, **not** a generalisation estimate.
+- **OOD F1 (strict): 0.770** [0.745, 0.797] — on the Simula v1
+  synthetic test set (separate generator, different label schema, never
+  seen at training). Penalised by label granularity (see below).
+- **OOD F1 (schema-intersection): 0.807** [0.782, 0.834] — restricting
+  gold to labels with a v2 vocabulary analogue.
+- **OOD F1 (span-merged): 0.862** [0.841, 0.881] — collapses contiguous
+  v2 sub-spans, neutralising the label-granularity artifact. This is
+  the most defensible single number.
+- **Classic baseline (spaCy `ja_core_news_lg`) OOD: 0.855** [0.832,
+  0.878]. v2 (merged) edges it, but the bootstrap CIs overlap.
 
 ## Methodology
 
 Identical to [`docs/benchmark.md`](benchmark.md) §4 (the public ruler):
 
-- Dataset: `0xhikae/pii-masking-300k-ja`, `validation` split.
-- Sample size: n = 300.
 - Scoring: char-IoU ≥ 0.5, label-agnostic span matching.
-- Driver: `packages/training/scripts/eval_mechanism_on_300k.py` —
-  same script used for v1.
+- Driver: `packages/training/scripts/eval_mechanism_on_300k.py` and
+  `packages/training/scripts/eval_ood_jsonl.py`.
+- 1000-iteration document-level bootstrap, seed 42, for 95% CIs.
 
-## Headline (in-distribution)
+## In-distribution evaluation
 
-| Engine | F1 | Precision | Recall | Latency/doc (CPU) |
-|---|---:|---:|---:|---:|
-| `builtin` v0.13.0 | 0.342 | 0.453 | 0.275 | 55 ms |
-| `ja_ner_ja-v2-mechanism` (v1, synthetic only) | 0.352 | 0.612 | 0.247 | 37 ms |
-| `openai-privacy-filter` v0.13.0 | 0.702 | 0.899 | 0.576 | 2.3 s |
-| **`ja_ner_ja-v2-supervised`** | **0.956** | **0.931** | **0.982** | **43 ms** |
+Validation split of `0xhikae/pii-masking-300k-ja`, 300 docs.
+
+| Engine | F1 | F1 95% CI | Precision | Recall | Latency/doc (CPU) |
+|---|---:|---|---:|---:|---:|
+| `builtin` v0.13.0 | 0.342 | — | 0.453 | 0.275 | 55 ms |
+| `ja_ner_ja-v2-mechanism` (v1, synthetic only) | 0.352 | — | 0.612 | 0.247 | 37 ms |
+| spaCy `ja_core_news_lg` | 0.274 | [0.250, 0.297] | 0.205 | 0.411 | 22 ms |
+| `openai-privacy-filter` v0.13.0 | 0.702 | — | 0.899 | 0.576 | 2.3 s |
+| **`ja_ner_ja-v2-supervised`** | **0.957** | **[0.935, 0.973]** | **0.933** | **0.983** | 43 ms |
 
 **Caveat:** v2 was trained on the **train split** of the same
-dataset used for this evaluation (validation split). The splits
-are disjoint by construction but share generation methodology, so
-0.956 measures supervised fit on the methodology, not the model's
-ability to handle truly novel text.
+dataset. Per template-overlap analysis (below) the splits are
+0.4% surface-overlapping but cannot be assumed fully independent.
+Use OOD numbers for production expectations.
 
-## Out-of-distribution check (Simula synthetic v1 test, 67 docs)
+## Train/val template overlap (reviewer concern: split leakage)
 
-To estimate the real-world generalisation gap, v2 is also evaluated
-against a completely separate test set: the 67-doc test split from
-the v1 (mechanism / Simula) synthetic dataset. That dataset was
-generated through a different pipeline (different scenarios, lenses,
-operators, label schema — 17 pleno labels vs the 28 ai4privacy
-labels v2 emits). v2 has never seen any of these texts.
+`0xhikae/pii-masking-300k-ja` is a JP-translated fork of
+`ai4privacy/pii-masking-300k`. A common failure mode is that train
+and validation share generation templates, so a model can memorise
+the template skeleton and predict spans by position rather than
+context. Two probes on a 20k-row train / 1.5k-row val sample:
 
-| Engine | F1 | Precision | Recall | Latency/doc (CPU) |
-|---|---:|---:|---:|---:|
-| **`ja_ner_ja-v2-supervised` (OOD)** | **0.762** | **0.710** | **0.823** | **41 ms** |
+| Signature | Distinct in train | Distinct in val | Train-val overlap |
+|---|---:|---:|---:|
+| Char-level skeleton (first 150 chars with PII tags replaced by labels) | 19,961 / 20,000 | 1,497 / 1,500 | 0.4 % (6 of 1,500 val rows) |
+| Label-sequence only (tuple of label types per row) | 13,952 | 1,223 | 36.1 % |
 
-OOD F1 0.762 vs in-distribution F1 0.956 → ≈0.19 generalisation gap.
-Still clears Smoke (0.50) and matches Parity (vs OPF in-dist 0.702),
-but lands below Stretch (0.88).
+Char-level: surface forms in train and val are essentially disjoint;
+template memorisation is not a credible explanation for the 0.957
+in-dist F1. Label-sequence overlap of 36% is expected for any
+fixed-vocabulary NER task and does not by itself imply leakage —
+distinct documents can share label sequences without sharing text.
 
-Per-label OOD recall: `PHONE_NUMBER`, `EMAIL_ADDRESS`, `POSTAL_CODE`,
-`CREDIT_CARD` all 1.0; `PERSON` 0.96; `BANK_ACCOUNT` 0.88; `ADDRESS`
-0.86; `DATE_OF_BIRTH` 0.82. Structural PII generalises well.
+This does not prove zero leakage. AI4Privacy could have shared
+*scenario seeds* across splits before instantiation. But the
+character-level evidence makes wholesale template memorisation
+unlikely.
 
-Two zeros (`HEALTH_INSURANCE` 0.05, `ORGANIZATION` 0.00) are **schema
-mismatch, not generalisation failure**: those labels don't exist in
-v2's 28-label output vocabulary so v2 cannot emit them. Production
-deployments needing these labels stack Presidio pattern recognizers
-on top.
+## Out-of-distribution evaluation
+
+Combined dev+test from the v1 (Simula / synthetic) dataset:
+`packages/training/data/raw/ja-mechanism-v1/{dev,test}.jsonl`,
+n=134 docs. Different generator pipeline (Simula meta-prompts,
+complexification operators, dual-critic loop), different label
+schema (17 pleno labels vs 28 ai4privacy v2 emits), zero overlap
+with v2 training data.
+
+| Engine | F1 | F1 95% CI | Precision | Recall | Latency/doc (CPU) |
+|---|---:|---|---:|---:|---:|
+| spaCy `ja_core_news_lg` | 0.855 | [0.832, 0.878] | 0.787 | 0.937 | 26 ms |
+| **v2-supervised (strict)** | 0.770 | [0.745, 0.797] | 0.718 | 0.829 | 41 ms |
+| v2-supervised (schema-intersection) | 0.807 | [0.782, 0.834] | 0.708 | 0.940 | 41 ms |
+| **v2-supervised (span-merged)** | **0.862** | **[0.841, 0.881]** | 0.888 | 0.837 | 41 ms |
+
+### Why v2 (strict) < spaCy on OOD — the label-granularity artifact
+
+The v1 OOD set uses **coarse** labels (e.g., `PERSON` covering an
+entire 「山田太郎」 span). v2 was trained on **fine-grained**
+ai4privacy labels and emits `LASTNAME1` + `GIVENNAME1` as two
+adjacent narrow spans. With char-IoU ≥ 0.5, neither narrow
+prediction reaches the threshold against the wide gold span; both
+become FP and the gold becomes FN.
+
+Concrete example from `/tmp/v2-ood-extended.jsonl[1]`:
+
+- Gold `ADDRESS` (33, 48) — 15 chars
+- v2 predicts: `STREET` (33, 36), `CITY` (36, 40), `STREET` (40, 48) — three fragments
+- IoU values: 0.20, 0.27, 0.53 → only the last one barely matches
+
+`eval_ood_span_merged.py` re-runs the same eval after merging any
+contiguous non-O v2 spans into one. F1 climbs from 0.770 to 0.862.
+The model's underlying span predictions are correct; the strict
+scoring penalises the schema mismatch.
+
+**The 0.862 (merged) number is the most defensible OOD figure.**
+
+### Why this isn't a real "OOD" test
+
+Both training data and "OOD" data are LLM-synthesised. A genuine
+out-of-distribution test would be hand-annotated real Japanese text
+(chat logs, scanned forms, call-centre transcripts). We do not
+have one yet, so all reported OOD numbers should be read as
+"synthetic-to-synthetic generalisation upper bound for the
+production target". Production expectations should be calibrated
+below 0.862, not at it.
+
+### Schema-intersection per-label recall (OOD, strict)
+
+`PHONE_NUMBER` 1.00 · `EMAIL_ADDRESS` 1.00 · `POSTAL_CODE` 1.00 ·
+`CREDIT_CARD` 1.00 · `PERSON` 0.96 · `BANK_ACCOUNT` 0.94 · `ADDRESS`
+0.87 · `DATE_OF_BIRTH` 0.82.
+
+`HEALTH_INSURANCE` (0.05) and `ORGANIZATION` (0.00) are excluded —
+those labels have no analogue in v2's 28-label ai4privacy output
+vocabulary, so v2 structurally cannot emit them. Production
+deployments needing these classes should stack Presidio pattern
+recognizers on top.
 
 ## Acceptance tiers from [`SKILL.md`](../.claude/skills/ner-improve/SKILL.md)
 
-| Tier | F1 floor | In-dist | OOD |
-|---|---:|:---:|:---:|
-| Smoke | 0.50 | ✅ 0.956 | ✅ 0.762 |
-| Parity | 0.82 | ✅ | ❌ (below 0.82, but above OPF in-dist 0.702) |
-| Stretch | 0.88 | ✅ | ❌ |
+| Tier | F1 floor | In-dist | OOD (strict) | OOD (merged) |
+|---|---:|:---:|:---:|:---:|
+| Smoke | 0.50 | ✅ | ✅ | ✅ |
+| Parity | 0.82 | ✅ | ❌ (0.770) | ✅ (0.862) |
+| Stretch | 0.88 | ✅ | ❌ | ❌ (CI upper 0.881) |
 
-The **OOD number is the honest one**. Use 0.762 for production
-expectations, not 0.956.
+Honest reading: **Smoke and Parity are met under the merged OOD
+protocol; Stretch is not.**
 
-## Why v2 worked when v1 didn't
-
-v1 trained on 2,014 synthetic samples and hit F1 0.352 — recall-limited
-by domain shift (in-dataset test F1 was 0.975, but only 40 % of
-validation spans were predicted). The diagnosis in [#168](https://github.com/plenoai/pleno-anonymize/issues/168)
-was correct: it was a data-distribution problem, not a model-capacity
-problem. Training on the train split of the eval dataset — the
-standard supervised baseline — closes the gap entirely.
-
-The synthetic / Simula pipeline is still useful (zero data licensing,
-fine-grained taxonomy control, label-agnostic eval lets us mix it in
-later) but as a sole data source against an in-distribution validation
-set it loses to direct supervised training.
-
-## Training
+## Training recipe
 
 - Base: `FacebookAI/xlm-roberta-base` (270M params)
 - Data: 25,082 Japanese rows from `0xhikae/pii-masking-300k-ja` train
   split (dumped locally then scp'd to RunPod since the dataset is
   private; no token leaves the operator's machine)
-- 2 epochs, batch size 16, lr 5e-5, fp16
+- 2 epochs, batch size 16, lr 5e-5, fp16, **seed 42**
 - ~5 min on a single RTX A6000 (RunPod), ~$0.05 compute
+- Reproducibility caveats below
 
-## Per-label recall
+## Reproducibility
 
-All 27 labels ≥ 0.89, most at 1.0. Full list in the
-[HF model card](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised).
+- Training script `packages/training/scripts/train_supervised_300k_ja.py`
+  pins seed via `--seed`, `TrainingArguments(seed=, data_seed=)`,
+  `random.seed`, `numpy.random.seed`, `torch.manual_seed`,
+  `PYTHONHASHSEED`.
+- 1000-iter bootstrap CIs use seed 42.
+- The training dataset is private (`0xhikae/pii-masking-300k-ja`).
+  Third-party reproduction requires the dataset owner granting
+  access. The training script reads from a local JSONL dump.
+- Library versions: not pinned in `pyproject.toml`. Recorded only
+  loosely in CLAUDE.md as "transformers>=4.45,<5". Pinning is a
+  follow-up.
+- Replicate runs across multiple seeds: not done. Reported numbers
+  are from a single training run.
 
-## What v1 also produced
+## Open methodological gaps (reviewer feedback, R1 round)
 
-- `0xhikae/ja_ner_ja-v2-mechanism` — the baseline checkpoint (public,
-  F1 0.352, kept for comparison)
-- Simula-style synthetic dataset generator under
-  `packages/training/src/pleno_ner_training/mechanism/` — taxonomy,
-  meta-prompts, complexification operators, dual-critic gate
-- Full ablation infrastructure (`eval_mechanism_on_300k.py`,
-  `runpod_launch_mechanism_training.py`)
+Resolved in this revision:
+- ✅ Train/val template overlap quantified (R1)
+- ✅ Bootstrap 95% CIs on every reported number (R3)
+- ✅ Schema-intersection OOD F1 reported (R3)
+- ✅ Span-merged OOD F1 reported, label-granularity artifact called out (R3)
+- ✅ Classic baseline added (spaCy `ja_core_news_lg`) (R4)
+- ✅ Seed pinned in training script (R5)
+- ✅ Headline tables include CIs and avoid bold-comparing in-dist to OPF (R2)
 
-## Risks / honest caveats
-
-- Trained and evaluated on the same dataset (different splits). The
-  splits are disjoint by construction but share generation methodology.
-  On truly out-of-distribution Japanese text (real chat logs, scanned
-  forms) numbers will be lower.
-- Single base-model size — large/multilingual ablations (#171) were
-  not run since v2 already passed Stretch.
+Still outstanding (would block top-venue Accept):
+- ❌ **No real Japanese text in evaluation.** Both training and OOD
+  are LLM-synthesised. Adding ≥100 hand-annotated real-text samples
+  is the highest-priority follow-up.
+- ❌ **No multi-seed replicate runs.** Single training run, single
+  bootstrap of that run. Variance across seeds unknown.
+- ❌ **No v1↔v2 ablation isolating base model from data.** v1 used
+  `xlm-roberta-base` after a switch from `cl-tohoku/bert-base-japanese-v3`
+  (which lacked a fast tokenizer); v2 also uses `xlm-roberta-base`,
+  so the v1→v2 jump is attributable to data only. But the v1
+  config used 3 epochs, v2 uses 2 epochs — minor confound.
+- ❌ **AI4Privacy split-protocol still partially opaque.** The
+  template-overlap probe is necessary but not sufficient; dataset
+  card does not document the splitting strategy at the scenario or
+  seed level.
+- ❌ **Library versions not pinned in package manifests.**
+- ❌ **Only one classic baseline (spaCy).** GiNZA would be a natural
+  second.

--- a/docs/benchmark-supervised-v2.md
+++ b/docs/benchmark-supervised-v2.md
@@ -14,7 +14,7 @@ Identical to [`docs/benchmark.md`](benchmark.md) §4 (the public ruler):
 - Driver: `packages/training/scripts/eval_mechanism_on_300k.py` —
   same script used for v1.
 
-## Headline
+## Headline (in-distribution)
 
 | Engine | F1 | Precision | Recall | Latency/doc (CPU) |
 |---|---:|---:|---:|---:|
@@ -23,8 +23,49 @@ Identical to [`docs/benchmark.md`](benchmark.md) §4 (the public ruler):
 | `openai-privacy-filter` v0.13.0 | 0.702 | 0.899 | 0.576 | 2.3 s |
 | **`ja_ner_ja-v2-supervised`** | **0.956** | **0.931** | **0.982** | **43 ms** |
 
-Acceptance tiers from [`SKILL.md`](../.claude/skills/ner-improve/SKILL.md):
-Smoke 0.50 ✅ · Parity 0.82 ✅ · Stretch 0.88 ✅.
+**Caveat:** v2 was trained on the **train split** of the same
+dataset used for this evaluation (validation split). The splits
+are disjoint by construction but share generation methodology, so
+0.956 measures supervised fit on the methodology, not the model's
+ability to handle truly novel text.
+
+## Out-of-distribution check (Simula synthetic v1 test, 67 docs)
+
+To estimate the real-world generalisation gap, v2 is also evaluated
+against a completely separate test set: the 67-doc test split from
+the v1 (mechanism / Simula) synthetic dataset. That dataset was
+generated through a different pipeline (different scenarios, lenses,
+operators, label schema — 17 pleno labels vs the 28 ai4privacy
+labels v2 emits). v2 has never seen any of these texts.
+
+| Engine | F1 | Precision | Recall | Latency/doc (CPU) |
+|---|---:|---:|---:|---:|
+| **`ja_ner_ja-v2-supervised` (OOD)** | **0.762** | **0.710** | **0.823** | **41 ms** |
+
+OOD F1 0.762 vs in-distribution F1 0.956 → ≈0.19 generalisation gap.
+Still clears Smoke (0.50) and matches Parity (vs OPF in-dist 0.702),
+but lands below Stretch (0.88).
+
+Per-label OOD recall: `PHONE_NUMBER`, `EMAIL_ADDRESS`, `POSTAL_CODE`,
+`CREDIT_CARD` all 1.0; `PERSON` 0.96; `BANK_ACCOUNT` 0.88; `ADDRESS`
+0.86; `DATE_OF_BIRTH` 0.82. Structural PII generalises well.
+
+Two zeros (`HEALTH_INSURANCE` 0.05, `ORGANIZATION` 0.00) are **schema
+mismatch, not generalisation failure**: those labels don't exist in
+v2's 28-label output vocabulary so v2 cannot emit them. Production
+deployments needing these labels stack Presidio pattern recognizers
+on top.
+
+## Acceptance tiers from [`SKILL.md`](../.claude/skills/ner-improve/SKILL.md)
+
+| Tier | F1 floor | In-dist | OOD |
+|---|---:|:---:|:---:|
+| Smoke | 0.50 | ✅ 0.956 | ✅ 0.762 |
+| Parity | 0.82 | ✅ | ❌ (below 0.82, but above OPF in-dist 0.702) |
+| Stretch | 0.88 | ✅ | ❌ |
+
+The **OOD number is the honest one**. Use 0.762 for production
+expectations, not 0.956.
 
 ## Why v2 worked when v1 didn't
 

--- a/docs/benchmark-supervised-v2.md
+++ b/docs/benchmark-supervised-v2.md
@@ -1,202 +1,233 @@
 # `ja_ner_ja-v2-supervised` — benchmark + methodological accounting
 
 Released at [`0xhikae/ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised).
-Closes the goal opened by [#168](https://github.com/plenoai/pleno-anonymize/issues/168).
 
-This document reports both the optimistic in-distribution number and
-the more honest out-of-distribution numbers, surfaces a non-obvious
-eval-protocol artifact, and lists the methodological limitations a
-peer reviewer would (and did) flag.
+This is the **R2 revision** of the benchmark doc. The previous
+revision passed Smoke and (synthetic-OOD) Parity but the peer
+reviewer flagged three blocking concerns:
 
-## TL;DR
+- (R1-C1) Label-blind span merging inflated the OOD number
+- (R1-C2) No real-text Japanese in the eval suite
+- (R1-C3) Single training run — no variance estimate
 
-- **In-distribution F1: 0.957** [0.935, 0.973] — on the validation
-  split of the same dataset whose train split was used to train v2.
-  Treat as an upper bound, **not** a generalisation estimate.
-- **OOD F1 (strict): 0.770** [0.745, 0.797] — on the Simula v1
-  synthetic test set (separate generator, different label schema, never
-  seen at training). Penalised by label granularity (see below).
-- **OOD F1 (schema-intersection): 0.807** [0.782, 0.834] — restricting
-  gold to labels with a v2 vocabulary analogue.
-- **OOD F1 (span-merged): 0.862** [0.841, 0.881] — collapses contiguous
-  v2 sub-spans, neutralising the label-granularity artifact. This is
-  the most defensible single number.
-- **Classic baseline (spaCy `ja_core_news_lg`) OOD: 0.855** [0.832,
-  0.878]. v2 (merged) edges it, but the bootstrap CIs overlap.
+This revision addresses all three. Real-text performance is **worse
+than v2's synthetic OOD numbers suggested**, and the reviewer's
+caveat ("calibrate below 0.862, not at it") was correct.
+
+## TL;DR with 3-seed mean ± std
+
+3 training seeds (42, 7, 1337), identical recipe; 1000-iter
+document-level bootstrap CIs on the seed-42 run for the ranges.
+
+| Eval set | Mean F1 | Std | Seed-42 CI 95% | Smoke ≥ 0.50 | Parity ≥ 0.82 |
+|---|---:|---:|---|:---:|:---:|
+| In-dist (300k-ja val, 300 docs) | **0.955** | 0.002 | [0.935, 0.973] | ✅ | ✅ |
+| OOD synthetic (v1 test+dev, 134 docs, strict) | **0.773** | 0.004 | [0.745, 0.797] | ✅ | ❌ |
+| OOD synthetic (label-aware merged) | **0.852** | 0.014 | [0.846, 0.885] | ✅ | ✅ (with span-class merging) |
+| **Real text (stockmark JP Wikipedia, PII subset, 147 docs)** | **0.467** | 0.010 | [0.393, 0.520] | ❌ | ❌ |
+| Real text (stockmark, all 8 categories, 276 docs) | 0.395 | 0.009 | [0.343, 0.430] | ❌ | ❌ |
+
+**Honest reading:** v2 dominates in-distribution. On synthetic OOD
+it matches Parity under label-aware merging. **On real Japanese
+text (Wikipedia), v2 falls below Smoke.** spaCy `ja_core_news_lg`
+beats v2 on the same real-text set (see baselines below).
 
 ## Methodology
 
-Identical to [`docs/benchmark.md`](benchmark.md) §4 (the public ruler):
+Char-IoU ≥ 0.5, label-agnostic. 1000-iter document-level bootstrap
+with fixed seed=42 for CIs.
 
-- Scoring: char-IoU ≥ 0.5, label-agnostic span matching.
-- Driver: `packages/training/scripts/eval_mechanism_on_300k.py` and
-  `packages/training/scripts/eval_ood_jsonl.py`.
-- 1000-iteration document-level bootstrap, seed 42, for 95% CIs.
+Training: same recipe across all 3 seeds: `FacebookAI/xlm-roberta-base`,
+25,082 JP rows from `0xhikae/pii-masking-300k-ja` train split, 2 epochs,
+batch 16, lr 5e-5, fp16. Per-seed evaluation runs use the seed's own
+checkpoint.
 
 ## In-distribution evaluation
 
 Validation split of `0xhikae/pii-masking-300k-ja`, 300 docs.
 
-| Engine | F1 | F1 95% CI | Precision | Recall | Latency/doc (CPU) |
+| Model | F1 | F1 95% CI | P | R | Latency |
 |---|---:|---|---:|---:|---:|
 | `builtin` v0.13.0 | 0.342 | — | 0.453 | 0.275 | 55 ms |
 | `ja_ner_ja-v2-mechanism` (v1, synthetic only) | 0.352 | — | 0.612 | 0.247 | 37 ms |
 | spaCy `ja_core_news_lg` | 0.274 | [0.250, 0.297] | 0.205 | 0.411 | 22 ms |
 | `openai-privacy-filter` v0.13.0 | 0.702 | — | 0.899 | 0.576 | 2.3 s |
-| **`ja_ner_ja-v2-supervised`** | **0.957** | **[0.935, 0.973]** | **0.933** | **0.983** | 43 ms |
+| **`ja_ner_ja-v2-supervised` (seed 42)** | **0.957** | [0.935, 0.973] | 0.933 | 0.983 | 43 ms |
+| `ja_ner_ja-v2-supervised` (seed 7) | 0.954 | — | 0.927 | 0.982 | — |
+| `ja_ner_ja-v2-supervised` (seed 1337) | 0.954 | — | 0.926 | 0.983 | — |
+| **3-seed mean ± std** | **0.955 ± 0.002** | | | | |
 
-**Caveat:** v2 was trained on the **train split** of the same
-dataset. Per template-overlap analysis (below) the splits are
-0.4% surface-overlapping but cannot be assumed fully independent.
-Use OOD numbers for production expectations.
+**Caveat unchanged from R1:** v2 was trained on the **train split**
+of the same dataset. Per template-overlap analysis (below) the
+splits share only 0.4 % of char-level surface skeletons, so this is
+not pure template memorisation — but template-disjoint does not
+imply pipeline-disjoint. Read this as "supervised fit on the
+methodology", not production performance.
 
-## Train/val template overlap (reviewer concern: split leakage)
+## Train/val template overlap (split-leakage probe)
 
-`0xhikae/pii-masking-300k-ja` is a JP-translated fork of
-`ai4privacy/pii-masking-300k`. A common failure mode is that train
-and validation share generation templates, so a model can memorise
-the template skeleton and predict spans by position rather than
-context. Two probes on a 20k-row train / 1.5k-row val sample:
+`0xhikae/pii-masking-300k-ja` is a JP fork of
+`ai4privacy/pii-masking-300k`. Two probes on 20k train / 1.5k val
+rows:
 
-| Signature | Distinct in train | Distinct in val | Train-val overlap |
+| Signature | Train distinct | Val distinct | Train-val overlap |
 |---|---:|---:|---:|
-| Char-level skeleton (first 150 chars with PII tags replaced by labels) | 19,961 / 20,000 | 1,497 / 1,500 | 0.4 % (6 of 1,500 val rows) |
-| Label-sequence only (tuple of label types per row) | 13,952 | 1,223 | 36.1 % |
+| Char-level (150 char skeleton, labels in place of PII surface) | 19,961 / 20,000 | 1,497 / 1,500 | **0.4 %** (6 / 1,500) |
+| Label-sequence only (tuple of label types) | 13,952 | 1,223 | 36.1 % |
 
-Char-level: surface forms in train and val are essentially disjoint;
-template memorisation is not a credible explanation for the 0.957
-in-dist F1. Label-sequence overlap of 36% is expected for any
-fixed-vocabulary NER task and does not by itself imply leakage —
-distinct documents can share label sequences without sharing text.
+The char-level result rules out wholesale surface-form memorisation;
+label-sequence overlap of 36 % is expected for any fixed-vocabulary
+NER and does not by itself imply leakage.
 
-This does not prove zero leakage. AI4Privacy could have shared
-*scenario seeds* across splits before instantiation. But the
-character-level evidence makes wholesale template memorisation
-unlikely.
+## Out-of-distribution evaluation — Simula synthetic v1, 134 docs
 
-## Out-of-distribution evaluation
+Combined dev+test of the v1 (Simula) synthetic dataset:
+`packages/training/data/raw/ja-mechanism-v1/{dev,test}.jsonl`.
+Different pipeline, different label schema (17 pleno vs 28
+ai4privacy v2 emits), zero overlap with v2 training data.
 
-Combined dev+test from the v1 (Simula / synthetic) dataset:
-`packages/training/data/raw/ja-mechanism-v1/{dev,test}.jsonl`,
-n=134 docs. Different generator pipeline (Simula meta-prompts,
-complexification operators, dual-critic loop), different label
-schema (17 pleno labels vs 28 ai4privacy v2 emits), zero overlap
-with v2 training data.
+### Strict char-IoU ≥ 0.5 (no merging)
 
-| Engine | F1 | F1 95% CI | Precision | Recall | Latency/doc (CPU) |
-|---|---:|---|---:|---:|---:|
-| spaCy `ja_core_news_lg` | 0.855 | [0.832, 0.878] | 0.787 | 0.937 | 26 ms |
-| **v2-supervised (strict)** | 0.770 | [0.745, 0.797] | 0.718 | 0.829 | 41 ms |
-| v2-supervised (schema-intersection) | 0.807 | [0.782, 0.834] | 0.708 | 0.940 | 41 ms |
-| **v2-supervised (span-merged)** | **0.862** | **[0.841, 0.881]** | 0.888 | 0.837 | 41 ms |
+| Model | F1 | F1 95% CI | P | R |
+|---|---:|---|---:|---:|
+| spaCy `ja_core_news_lg` | 0.855 | [0.832, 0.878] | 0.787 | 0.937 |
+| **v2-supervised (seed 42)** | 0.770 | [0.745, 0.797] | 0.718 | 0.829 |
+| v2-supervised (seed 7) | 0.778 | — | — | — |
+| v2-supervised (seed 1337) | 0.771 | — | — | — |
+| **3-seed mean ± std** | **0.773 ± 0.004** | | | |
 
-### Why v2 (strict) < spaCy on OOD — the label-granularity artifact
+### Label-aware merged (R1-C1 fix)
 
-The v1 OOD set uses **coarse** labels (e.g., `PERSON` covering an
-entire 「山田太郎」 span). v2 was trained on **fine-grained**
-ai4privacy labels and emits `LASTNAME1` + `GIVENNAME1` as two
-adjacent narrow spans. With char-IoU ≥ 0.5, neither narrow
-prediction reaches the threshold against the wide gold span; both
-become FP and the gold becomes FN.
+v2 emits fine-grained ai4privacy labels (`LASTNAME1`, `GIVENNAME1`,
+`STREET`, `CITY`, ...) while the v1 OOD set uses coarse pleno
+labels (`PERSON`, `ADDRESS`, ...). `eval_ood_span_merged.py`
+defines explicit equivalence classes:
 
-Concrete example from `/tmp/v2-ood-extended.jsonl[1]`:
+- `PERSON` ← `{LASTNAME1/2/3, GIVENNAME1/2, TITLE, USERNAME}`
+- `ADDRESS` ← `{STREET, CITY, STATE, POSTCODE, BUILDING, SECADDRESS, COUNTRY, GEOCOORD}`
+- `DATE_OF_BIRTH` ← `{BOD, DATE, TIME}`
+- `PHONE` ← `{TEL}`, `EMAIL` ← `{EMAIL}`, `IP` ← `{IP}`, `SEX` ← `{SEX}`
+- `ID_CARD` ← `{IDCARD, DRIVERLICENSE, PASSPORT, PASS, SOCIALNUMBER}`
 
-- Gold `ADDRESS` (33, 48) — 15 chars
-- v2 predicts: `STREET` (33, 36), `CITY` (36, 40), `STREET` (40, 48) — three fragments
-- IoU values: 0.20, 0.27, 0.53 → only the last one barely matches
+Adjacent v2 sub-spans are merged into one super-span **only when
+both labels map to the same coarse class**. Cross-class adjacency
+(e.g., `LASTNAME1` next to `TEL` in form text) is NOT collapsed.
 
-`eval_ood_span_merged.py` re-runs the same eval after merging any
-contiguous non-O v2 spans into one. F1 climbs from 0.770 to 0.862.
-The model's underlying span predictions are correct; the strict
-scoring penalises the schema mismatch.
+| Model | F1 | F1 95% CI | P | R |
+|---|---:|---|---:|---:|
+| **v2-supervised (seed 42)** | **0.867** | [0.846, 0.885] | 0.883 | 0.851 |
+| v2-supervised (seed 7) | 0.857 | — | 0.860 | 0.853 |
+| v2-supervised (seed 1337) | 0.833 | — | 0.858 | 0.810 |
+| **3-seed mean ± std** | **0.852 ± 0.014** | | | |
+| spaCy `ja_core_news_lg` (no merge applicable) | 0.855 | [0.832, 0.878] | 0.787 | 0.937 |
 
-**The 0.862 (merged) number is the most defensible OOD figure.**
+Mean OOD-merged 0.852 is statistically indistinguishable from
+spaCy's 0.855 — overlapping CIs and seed std 0.014 dominates the
+difference.
 
-### Why this isn't a real "OOD" test
+## Real-text evaluation (R1-C2 fix) — stockmark JP Wikipedia NER
 
-Both training data and "OOD" data are LLM-synthesised. A genuine
-out-of-distribution test would be hand-annotated real Japanese text
-(chat logs, scanned forms, call-centre transcripts). We do not
-have one yet, so all reported OOD numbers should be read as
-"synthetic-to-synthetic generalisation upper bound for the
-production target". Production expectations should be calibrated
-below 0.862, not at it.
+Real Japanese Wikipedia sentences with 8 entity categories:
+人名, 法人名, 政治的組織名, その他の組織名, 地名, 施設名, 製品名, イベント名.
+Sourced from `stockmark/ner-wikipedia-dataset`, n=300 sampled rows.
 
-### Schema-intersection per-label recall (OOD, strict)
+Reported two ways: (a) all 8 categories, and (b) restricted to the
+**PII-relevant subset** `{人名, 地名}` since the other six categories
+(corporations, products, events, facilities) are out-of-scope for
+a PII NER like v2 by design.
 
-`PHONE_NUMBER` 1.00 · `EMAIL_ADDRESS` 1.00 · `POSTAL_CODE` 1.00 ·
-`CREDIT_CARD` 1.00 · `PERSON` 0.96 · `BANK_ACCOUNT` 0.94 · `ADDRESS`
-0.87 · `DATE_OF_BIRTH` 0.82.
+| Model | Subset | F1 | F1 95% CI | P | R |
+|---|---|---:|---|---:|---:|
+| **spaCy `ja_core_news_lg`** | All 8 | **0.709** | [0.679, 0.736] | 0.642 | 0.792 |
+| spaCy `ja_core_news_lg` | PII-subset | 0.571 | [0.533, 0.608] | 0.425 | 0.871 |
+| **v2-supervised (3-seed mean)** | PII-subset | **0.467 ± 0.010** | [0.393, 0.520] | 0.486 | 0.436 |
+| v2-supervised (3-seed mean) | All 8 | 0.395 ± 0.009 | [0.343, 0.430] | 0.616 | 0.281 |
 
-`HEALTH_INSURANCE` (0.05) and `ORGANIZATION` (0.00) are excluded —
-those labels have no analogue in v2's 28-label ai4privacy output
-vocabulary, so v2 structurally cannot emit them. Production
-deployments needing these classes should stack Presidio pattern
-recognizers on top.
+**v2 loses to spaCy by 0.10 F1 on real-text PII subset.** This is
+the honest result, and it reflects:
 
-## Acceptance tiers from [`SKILL.md`](../.claude/skills/ner-improve/SKILL.md)
+1. **Domain mismatch.** v2 was trained on form-/record-/chat-style
+   PII text (ai4privacy generation methodology). Wikipedia narrative
+   prose is a very different distribution.
+2. **Schema mismatch.** v2 is trained to find specific PII categories
+   (phones, emails, postcodes, ID numbers). Wikipedia entities are
+   often legal entities (`法人名`) and facilities that v2 was never
+   trained to recognise.
+3. **spaCy's home turf.** `ja_core_news_lg` was trained on Wikipedia-
+   derived data and benefits structurally.
 
-| Tier | F1 floor | In-dist | OOD (strict) | OOD (merged) |
-|---|---:|:---:|:---:|:---:|
-| Smoke | 0.50 | ✅ | ✅ | ✅ |
-| Parity | 0.82 | ✅ | ❌ (0.770) | ✅ (0.862) |
-| Stretch | 0.88 | ✅ | ❌ | ❌ (CI upper 0.881) |
+**A truly fair real-text PII eval would use hand-annotated
+chat/form/email Japanese.** That dataset does not exist publicly.
+Building one (~50–100 samples) is the highest-priority follow-up.
 
-Honest reading: **Smoke and Parity are met under the merged OOD
-protocol; Stretch is not.**
+The stockmark result should be read as: "on this kind of text,
+in this kind of context, with this kind of schema, v2 trails
+spaCy". It is not a verdict on v2's PII performance in production
+PII contexts.
 
-## Training recipe
+## Seed variance summary
 
-- Base: `FacebookAI/xlm-roberta-base` (270M params)
-- Data: 25,082 Japanese rows from `0xhikae/pii-masking-300k-ja` train
-  split (dumped locally then scp'd to RunPod since the dataset is
-  private; no token leaves the operator's machine)
-- 2 epochs, batch size 16, lr 5e-5, fp16, **seed 42**
-- ~5 min on a single RTX A6000 (RunPod), ~$0.05 compute
-- Reproducibility caveats below
+3 seeds × 4 eval sets:
+
+| Eval | seed 42 | seed 7 | seed 1337 | Mean | Std |
+|---|---:|---:|---:|---:|---:|
+| In-dist | 0.957 | 0.954 | 0.954 | 0.955 | 0.002 |
+| OOD strict | 0.770 | 0.778 | 0.771 | 0.773 | 0.004 |
+| OOD merged | 0.867 | 0.857 | 0.833 | 0.852 | 0.014 |
+| Real (PII) | 0.460 | 0.460 | 0.482 | 0.467 | 0.010 |
+| Real (full) | 0.386 | 0.392 | 0.407 | 0.395 | 0.009 |
+
+Variance is consistent across eval sets — small and well below the
+CI widths of the eval-set-side bootstrap.
+
+## Acceptance tiers — final read
+
+| Tier | F1 floor | In-dist | OOD strict | OOD merged | Real (PII) | Real (full) |
+|---|---:|:---:|:---:|:---:|:---:|:---:|
+| Smoke | 0.50 | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Parity | 0.82 | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Stretch | 0.88 | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+The honest read: **Smoke and Parity are met on synthetic eval. Real-
+text performance is below Smoke even on PII-relevant categories**, so
+real-text Parity is not claimed.
+
+Production deployment expectations should be calibrated to the
+real-text number (~0.47), not the synthetic OOD number (~0.85).
 
 ## Reproducibility
 
-- Training script `packages/training/scripts/train_supervised_300k_ja.py`
-  pins seed via `--seed`, `TrainingArguments(seed=, data_seed=)`,
-  `random.seed`, `numpy.random.seed`, `torch.manual_seed`,
-  `PYTHONHASHSEED`.
-- 1000-iter bootstrap CIs use seed 42.
-- The training dataset is private (`0xhikae/pii-masking-300k-ja`).
-  Third-party reproduction requires the dataset owner granting
-  access. The training script reads from a local JSONL dump.
-- Library versions: not pinned in `pyproject.toml`. Recorded only
-  loosely in CLAUDE.md as "transformers>=4.45,<5". Pinning is a
-  follow-up.
-- Replicate runs across multiple seeds: not done. Reported numbers
-  are from a single training run.
+- All scripts in `packages/training/scripts/`:
+  - `train_supervised_300k_ja.py` (seed pinned)
+  - `eval_mechanism_on_300k.py` (in-dist, char-IoU ≥ 0.5)
+  - `eval_ood_jsonl.py` (OOD strict)
+  - `eval_ood_span_merged.py` (OOD label-aware merge)
+  - `eval_stockmark_jp_real.py` (real-text)
+  - `eval_classic_baseline.py` (spaCy / GiNZA)
+  - `compute_ci_bootstrap.py` (1000-iter bootstrap CIs)
+- Seed pinning: python/numpy/torch/`PYTHONHASHSEED`/HF `TrainingArguments(seed, data_seed)`
+- Library versions: ranged in `pyproject.toml` extras; not fully pinned (Minor open item)
+- Training dataset is private; the script reads from a local JSONL
+  dump, scp'd to RunPod. Third-party reproduction needs dataset access.
 
-## Open methodological gaps (reviewer feedback, R1 round)
+## What's still open (would block top-venue Accept)
 
 Resolved in this revision:
-- ✅ Train/val template overlap quantified (R1)
-- ✅ Bootstrap 95% CIs on every reported number (R3)
-- ✅ Schema-intersection OOD F1 reported (R3)
-- ✅ Span-merged OOD F1 reported, label-granularity artifact called out (R3)
-- ✅ Classic baseline added (spaCy `ja_core_news_lg`) (R4)
-- ✅ Seed pinned in training script (R5)
-- ✅ Headline tables include CIs and avoid bold-comparing in-dist to OPF (R2)
+- ✅ R1-C1: label-aware span merge (replaces label-blind merge)
+- ✅ R1-C2: real-text eval added (stockmark Wikipedia)
+- ✅ R1-C3: 3-seed variance reported (std on every cell)
+- ✅ Reviewer's R0 #1–10 either resolved or downgraded to Minor
 
-Still outstanding (would block top-venue Accept):
-- ❌ **No real Japanese text in evaluation.** Both training and OOD
-  are LLM-synthesised. Adding ≥100 hand-annotated real-text samples
-  is the highest-priority follow-up.
-- ❌ **No multi-seed replicate runs.** Single training run, single
-  bootstrap of that run. Variance across seeds unknown.
-- ❌ **No v1↔v2 ablation isolating base model from data.** v1 used
-  `xlm-roberta-base` after a switch from `cl-tohoku/bert-base-japanese-v3`
-  (which lacked a fast tokenizer); v2 also uses `xlm-roberta-base`,
-  so the v1→v2 jump is attributable to data only. But the v1
-  config used 3 epochs, v2 uses 2 epochs — minor confound.
-- ❌ **AI4Privacy split-protocol still partially opaque.** The
-  template-overlap probe is necessary but not sufficient; dataset
-  card does not document the splitting strategy at the scenario or
-  seed level.
-- ❌ **Library versions not pinned in package manifests.**
-- ❌ **Only one classic baseline (spaCy).** GiNZA would be a natural
-  second.
+Still open:
+- ❌ **No PII-context real-text eval.** Wikipedia is real but
+  off-domain. ≥50 hand-annotated JP chat/form/email samples would
+  resolve this. Highest-priority follow-up.
+- ❌ Library versions not pinned in `pyproject.toml`.
+- ❌ Only one classic baseline (spaCy). GiNZA would be natural #2.
+- ❌ AI4Privacy upstream split-protocol still not fully documented.
+- ❌ v1→v2 epoch confound (2 vs 3 epochs).
+
+The single highest-impact follow-up is hand-annotating ≥50 real
+JP PII samples. Until then, real-text production performance is
+estimated from the stockmark Wikipedia result with the caveat that
+PII-context is a different distribution.

--- a/packages/training/docs/peer-review-v2-r2.md
+++ b/packages/training/docs/peer-review-v2-r2.md
@@ -1,0 +1,25 @@
+# Peer Review (R2)
+
+Verdict: Accept
+Confidence: 4
+Decision driver: All three R1 blocking concerns are resolved cleanly (label-aware merge with documented equivalence classes, 3-seed variance reported with std on every cell, real-text eval added on stockmark Wikipedia), and the doc now states an unfavourable real-text result against its own headline. The remaining gaps are explicitly enumerated and downgrade-to-Minor.
+
+## Resolved blocking items
+
+1. R1-C1 (label-blind merge): Fixed. `eval_ood_span_merged.py` lines 26-46 implement explicit equivalence classes; lines 86-100 enforce same-coarse-class merging only; the post-merge re-lookup bug (already-promoted coarse names) is handled at line 41. Cross-class adjacency is preserved as distinct spans. Methodologically defensible.
+
+2. R1-C2 (no real text): Resolved as "real but off-domain". The stockmark Wikipedia eval is real Japanese text, and the doc reports v2 losing to spaCy by 0.10 F1 on the PII subset without spin. Hand-annotated PII-context data would be better, and the doc names this as the top open follow-up; the unfavourable Wikipedia result combined with explicit production-expectation calibration ("~0.47, not ~0.85") is sufficient honesty for a venue acceptance.
+
+3. R1-C3 (single training run): Resolved. 3 seeds × 4 eval sets; std reported on every cell; std is small (0.002-0.014) and well below bootstrap CI widths. The seed=1337 OOD-merged drop to 0.833 is shown rather than hidden.
+
+## Remaining open items (Minor, acceptable with current disclosure)
+
+- No PII-context real-text eval (hand-annotated chat/form/email JP). Acknowledged as top follow-up; production-expectation calibration in the doc is appropriately conservative.
+- Library versions not pinned in pyproject.toml.
+- Only one classic baseline (spaCy); GiNZA natural second.
+- AI4Privacy upstream split-protocol still partially opaque (mitigated by the 0.4 % char-level overlap probe).
+- v1↔v2 epoch confound (2 vs 3 epochs).
+
+## Answer to the explicit R2 question
+
+The stockmark Wikipedia eval is sufficient as "real-text" for Accept, specifically because the doc reports an unfavourable result and calibrates production expectations to the real-text number rather than the synthetic OOD number. If the doc had concealed or spin-corrected the stockmark loss, it would not be sufficient. Hand-annotated PII-context samples remain the highest-priority follow-up but do not block this revision.

--- a/packages/training/scripts/compute_ci_bootstrap.py
+++ b/packages/training/scripts/compute_ci_bootstrap.py
@@ -1,0 +1,153 @@
+"""Bootstrap 95% CI for char-IoU label-agnostic F1/P/R.
+
+Reads per-document TP/FP/FN counts (or re-derives them from cached
+predictions + gold) and resamples with replacement at the document
+level to produce 95% confidence intervals.
+
+Usage:
+    python scripts/compute_ci_bootstrap.py \\
+        --model packages/training/output/ja-ner-supervised-v2/model-best \\
+        --data packages/training/data/raw/ja-300k-supervised/dev.jsonl \\
+        --limit 300 --bootstrap 1000 \\
+        --output output/v2-indist-ci.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+def iou(a, b):
+    s = max(a[0], b[0]); e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def decode(offsets, labels):
+    spans = []
+    cur_l = cur_s = cur_e = None
+    for off, pred in zip(offsets, labels):
+        if tuple(off) == (0, 0):
+            continue
+        if pred == "O":
+            if cur_l is not None:
+                spans.append((cur_s, cur_e, cur_l)); cur_l = cur_s = cur_e = None
+            continue
+        bio, _, lab = pred.partition("-")
+        if bio == "B" or cur_l != lab:
+            if cur_l is not None:
+                spans.append((cur_s, cur_e, cur_l))
+            cur_l = lab; cur_s = off[0]; cur_e = off[1]
+        else:
+            cur_e = off[1]
+    if cur_l is not None:
+        spans.append((cur_s, cur_e, cur_l))
+    return spans
+
+
+def score_doc(gold, pred, iou_thr):
+    matched = set(); tp = fn = 0
+    for g_s, g_e, g_l in gold:
+        best_i, best_iou = -1, 0.0
+        for i, p in enumerate(pred):
+            if i in matched: continue
+            v = iou((g_s, g_e), (p[0], p[1]))
+            if v > best_iou: best_iou = v; best_i = i
+        if best_i >= 0 and best_iou >= iou_thr:
+            tp += 1; matched.add(best_i)
+        else:
+            fn += 1
+    fp = len(pred) - len(matched)
+    return tp, fp, fn
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--iou", type=float, default=0.5)
+    parser.add_argument("--bootstrap", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import torch
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    mdl = AutoModelForTokenClassification.from_pretrained(args.model).eval()
+    id2lab = mdl.config.id2label
+
+    per_doc = []  # list of (tp, fp, fn)
+    t0 = time.perf_counter()
+    rows = []
+    for line in args.data.read_text(encoding="utf-8").splitlines():
+        if not line.strip(): continue
+        rows.append(json.loads(line))
+        if args.limit and len(rows) >= args.limit: break
+
+    for row in rows:
+        text = row["text"]
+        gold = [(int(e["start"]), int(e["end"]), str(e["label"])) for e in row["entities"]]
+        enc = tok(text, return_offsets_mapping=True, truncation=True, max_length=512, return_tensors="pt")
+        offs = enc.pop("offset_mapping")[0].tolist()
+        with torch.inference_mode():
+            logits = mdl(**{k: v.to(mdl.device) for k, v in enc.items()}).logits[0]
+        labs = [id2lab[i] for i in logits.argmax(-1).tolist()]
+        pred = decode(offs, labs)
+        per_doc.append(score_doc(gold, pred, args.iou))
+
+    arr = np.array(per_doc)  # (n_docs, 3) -- [tp, fp, fn]
+
+    def metrics(idx):
+        s = arr[idx].sum(axis=0)
+        tp, fp, fn = s
+        p = tp / (tp + fp) if (tp + fp) else 0.0
+        r = tp / (tp + fn) if (tp + fn) else 0.0
+        f = 2 * p * r / (p + r) if (p + r) else 0.0
+        return p, r, f
+
+    n = len(arr)
+    rng = np.random.default_rng(args.seed)
+    boot = []
+    for _ in range(args.bootstrap):
+        idx = rng.integers(0, n, size=n)
+        boot.append(metrics(idx))
+    boot = np.array(boot)  # (B, 3) -- [P, R, F1]
+
+    point = metrics(np.arange(n))
+    pct = lambda col: (float(np.percentile(boot[:, col], 2.5)), float(np.percentile(boot[:, col], 97.5)))
+
+    summary = {
+        "model": args.model,
+        "data": str(args.data),
+        "n_docs": int(n),
+        "iou": args.iou,
+        "bootstrap_iters": args.bootstrap,
+        "seed": args.seed,
+        "elapsed_sec": round(time.perf_counter() - t0, 1),
+        "point_estimate": {
+            "precision": round(point[0], 4),
+            "recall":    round(point[1], 4),
+            "f1":        round(point[2], 4),
+        },
+        "ci_95": {
+            "precision": [round(x, 4) for x in pct(0)],
+            "recall":    [round(x, 4) for x in pct(1)],
+            "f1":        [round(x, 4) for x in pct(2)],
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/scripts/eval_classic_baseline.py
+++ b/packages/training/scripts/eval_classic_baseline.py
@@ -1,0 +1,105 @@
+"""Run a classic JP NER (spaCy / GiNZA) against a JSONL test set.
+
+Same char-IoU >= 0.5 label-agnostic protocol as eval_ood_jsonl.py.
+Reviewer asked for >=1 non-PII-specific JP NER baseline to widen the
+comparison set.
+
+Usage:
+    python scripts/eval_classic_baseline.py \\
+        --model ja_core_news_lg \\
+        --data /tmp/v2-ood-extended.jsonl \\
+        --output output/spacy-ja-ood-extended.json
+"""
+from __future__ import annotations
+import argparse, json, time
+from dataclasses import dataclass, field
+from pathlib import Path
+import numpy as np
+
+
+def iou(a, b):
+    s = max(a[0], b[0]); e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True, help="spaCy model name (ja_core_news_lg, ja_ginza, etc.)")
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--iou", type=float, default=0.5)
+    parser.add_argument("--bootstrap", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import spacy
+    nlp = spacy.load(args.model)
+
+    rows = []
+    for line in args.data.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        rows.append(json.loads(line))
+        if args.limit and len(rows) >= args.limit:
+            break
+
+    per_doc = []
+    latencies = []
+    for r in rows:
+        text = r["text"]
+        gold = [(int(e["start"]), int(e["end"]), str(e["label"])) for e in r["entities"]]
+        t0 = time.perf_counter()
+        doc = nlp(text)
+        latencies.append((time.perf_counter() - t0) * 1000)
+        pred = [(ent.start_char, ent.end_char, ent.label_) for ent in doc.ents]
+        matched = set(); tp = fn = 0
+        for g_s, g_e, _g_l in gold:
+            best_i, best_iou = -1, 0.0
+            for i, p in enumerate(pred):
+                if i in matched: continue
+                v = iou((g_s, g_e), (p[0], p[1]))
+                if v > best_iou:
+                    best_iou = v; best_i = i
+            if best_i >= 0 and best_iou >= args.iou:
+                tp += 1; matched.add(best_i)
+            else:
+                fn += 1
+        fp = len(pred) - len(matched)
+        per_doc.append((tp, fp, fn))
+
+    arr = np.array(per_doc); n = len(arr)
+    s = arr.sum(axis=0); tp, fp, fn = s
+    P = tp / (tp + fp) if tp + fp else 0
+    R = tp / (tp + fn) if tp + fn else 0
+    F = 2 * P * R / (P + R) if P + R else 0
+
+    rng = np.random.default_rng(args.seed); boot = []
+    for _ in range(args.bootstrap):
+        idx = rng.integers(0, n, size=n)
+        ss = arr[idx].sum(axis=0); t, f, fn2 = ss
+        p = t / (t + f) if t + f else 0
+        r = t / (t + fn2) if t + fn2 else 0
+        boot.append(2 * p * r / (p + r) if p + r else 0)
+    boot = np.array(boot)
+
+    summary = {
+        "model": args.model,
+        "data": str(args.data),
+        "n_docs": int(n),
+        "iou": args.iou,
+        "bootstrap_iters": args.bootstrap,
+        "point": {"P": round(P, 4), "R": round(R, 4), "F1": round(F, 4)},
+        "f1_ci_95": [round(float(np.percentile(boot, 2.5)), 4),
+                     round(float(np.percentile(boot, 97.5)), 4)],
+        "avg_latency_ms": round(sum(latencies) / max(len(latencies), 1), 2),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/scripts/eval_ood_jsonl.py
+++ b/packages/training/scripts/eval_ood_jsonl.py
@@ -1,0 +1,136 @@
+"""OOD eval: run a HF token-classification model against a local JSONL.
+
+Same char-IoU >= 0.5, label-agnostic protocol as eval_mechanism_on_300k.py,
+but reads gold spans from a JSONL file the model never saw at training.
+Used to stress-test v2 against the synthetic v1 test split.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Counts:
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    latency_ms: float = 0.0
+    n_docs: int = 0
+    n_gold: int = 0
+    n_pred: int = 0
+    per_label_tp: dict = field(default_factory=dict)
+    per_label_fn: dict = field(default_factory=dict)
+
+    def p(self): d = self.tp + self.fp; return self.tp / d if d else 0.0
+    def r(self): d = self.tp + self.fn; return self.tp / d if d else 0.0
+    def f1(self):
+        p, r = self.p(), self.r()
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+
+def iou(a, b):
+    s = max(a[0], b[0]); e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def decode(text, offsets, labels):
+    spans = []
+    cur_l = cur_s = cur_e = None
+    for off, pred in zip(offsets, labels):
+        if tuple(off) == (0, 0):
+            continue
+        if pred == "O":
+            if cur_l is not None:
+                spans.append((cur_s, cur_e, cur_l)); cur_l = cur_s = cur_e = None
+            continue
+        bio, _, lab = pred.partition("-")
+        if bio == "B" or cur_l != lab:
+            if cur_l is not None:
+                spans.append((cur_s, cur_e, cur_l))
+            cur_l = lab; cur_s = off[0]; cur_e = off[1]
+        else:
+            cur_e = off[1]
+    if cur_l is not None:
+        spans.append((cur_s, cur_e, cur_l))
+    return spans
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--data", type=Path, required=True, help="JSONL of {text, entities}")
+    parser.add_argument("--iou", type=float, default=0.5)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import torch
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    mdl = AutoModelForTokenClassification.from_pretrained(args.model).eval()
+    id2lab = mdl.config.id2label
+
+    c = Counts()
+    for line in args.data.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        text = row["text"]
+        gold = [(int(e["start"]), int(e["end"]), str(e["label"])) for e in row["entities"]]
+
+        enc = tok(text, return_offsets_mapping=True, truncation=True, max_length=512, return_tensors="pt")
+        offs = enc.pop("offset_mapping")[0].tolist()
+        t0 = time.perf_counter()
+        with torch.inference_mode():
+            logits = mdl(**{k: v.to(mdl.device) for k, v in enc.items()}).logits[0]
+        c.latency_ms += (time.perf_counter() - t0) * 1000
+        labs = [id2lab[i] for i in logits.argmax(-1).tolist()]
+        pred = decode(text, offs, labs)
+
+        matched = set()
+        for g_s, g_e, g_l in gold:
+            c.per_label_fn.setdefault(g_l, 0); c.per_label_tp.setdefault(g_l, 0)
+            best_i, best_iou = -1, 0.0
+            for i, p in enumerate(pred):
+                if i in matched:
+                    continue
+                v = iou((g_s, g_e), (p[0], p[1]))
+                if v > best_iou:
+                    best_iou = v; best_i = i
+            if best_i >= 0 and best_iou >= args.iou:
+                c.tp += 1; c.per_label_tp[g_l] += 1; matched.add(best_i)
+            else:
+                c.fn += 1; c.per_label_fn[g_l] += 1
+        c.fp += len(pred) - len(matched)
+        c.n_docs += 1; c.n_gold += len(gold); c.n_pred += len(pred)
+
+    summary = {
+        "model": args.model,
+        "data": str(args.data),
+        "n_docs": c.n_docs,
+        "n_gold": c.n_gold,
+        "n_pred": c.n_pred,
+        "tp": c.tp, "fp": c.fp, "fn": c.fn,
+        "precision": round(c.p(), 4),
+        "recall": round(c.r(), 4),
+        "f1": round(c.f1(), 4),
+        "avg_latency_ms": round(c.latency_ms / max(c.n_docs, 1), 2),
+        "per_label_recall": {
+            l: round(c.per_label_tp[l] / max(c.per_label_tp[l] + c.per_label_fn[l], 1), 4)
+            for l in c.per_label_tp
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/scripts/eval_ood_schema_intersection.py
+++ b/packages/training/scripts/eval_ood_schema_intersection.py
@@ -1,0 +1,84 @@
+"""OOD eval restricted to gold labels that v2's 28-label vocab can semantically reach.
+
+Excludes HEALTH_INSURANCE and ORGANIZATION from gold (no analogue in v2's
+output vocabulary). Eval is still label-agnostic IoU >= 0.5.
+"""
+from __future__ import annotations
+import json, time, sys
+from pathlib import Path
+import numpy as np
+
+DATA = Path("/tmp/v2-ood-extended.jsonl")
+MODEL = "packages/training/output/ja-ner-supervised-v2/model-best"
+# Labels in v1 (pleno) test set that have NO semantic analogue in v2's schema
+EXCLUDED = {"HEALTH_INSURANCE", "ORGANIZATION", "MY_NUMBER", "MY_NUMBER_CORPORATE", "RESIDENCE_CARD", "URL", "IP_ADDRESS"}
+
+def iou(a,b):
+    s=max(a[0],b[0]); e=min(a[1],b[1])
+    inter=max(0,e-s); union=(a[1]-a[0])+(b[1]-b[0])-inter
+    return inter/union if union else 0.0
+
+def decode(offs, labs):
+    spans=[]; cur_l=cur_s=cur_e=None
+    for off,p in zip(offs,labs):
+        if tuple(off)==(0,0): continue
+        if p=="O":
+            if cur_l is not None: spans.append((cur_s,cur_e,cur_l)); cur_l=cur_s=cur_e=None
+            continue
+        bio,_,lab=p.partition("-")
+        if bio=="B" or cur_l!=lab:
+            if cur_l is not None: spans.append((cur_s,cur_e,cur_l))
+            cur_l=lab; cur_s=off[0]; cur_e=off[1]
+        else: cur_e=off[1]
+    if cur_l is not None: spans.append((cur_s,cur_e,cur_l))
+    return spans
+
+import torch
+from transformers import AutoModelForTokenClassification, AutoTokenizer
+tok=AutoTokenizer.from_pretrained(MODEL); mdl=AutoModelForTokenClassification.from_pretrained(MODEL).eval()
+id2lab=mdl.config.id2label
+
+per_doc=[]; per_label_tp={}; per_label_fn={}
+for line in DATA.read_text(encoding="utf-8").splitlines():
+    if not line.strip(): continue
+    r=json.loads(line)
+    text=r["text"]
+    gold=[(int(e["start"]),int(e["end"]),str(e["label"])) for e in r["entities"] if str(e["label"]) not in EXCLUDED]
+    enc=tok(text, return_offsets_mapping=True, truncation=True, max_length=512, return_tensors="pt")
+    offs=enc.pop("offset_mapping")[0].tolist()
+    with torch.inference_mode():
+        logits=mdl(**{k:v.to(mdl.device) for k,v in enc.items()}).logits[0]
+    labs=[id2lab[i] for i in logits.argmax(-1).tolist()]
+    pred=decode(offs, labs)
+    matched=set(); tp=fn=0
+    for g_s,g_e,g_l in gold:
+        per_label_tp.setdefault(g_l,0); per_label_fn.setdefault(g_l,0)
+        best_i,best_iou=-1,0.0
+        for i,p in enumerate(pred):
+            if i in matched: continue
+            v=iou((g_s,g_e),(p[0],p[1]))
+            if v>best_iou: best_iou=v; best_i=i
+        if best_i>=0 and best_iou>=0.5:
+            tp+=1; per_label_tp[g_l]+=1; matched.add(best_i)
+        else:
+            fn+=1; per_label_fn[g_l]+=1
+    fp=len(pred)-len(matched)
+    per_doc.append((tp,fp,fn))
+
+arr=np.array(per_doc); n=len(arr)
+s=arr.sum(axis=0); tp,fp,fn=s
+P=tp/(tp+fp) if tp+fp else 0; R=tp/(tp+fn) if tp+fn else 0; F=2*P*R/(P+R) if P+R else 0
+
+rng=np.random.default_rng(42); boot=[]
+for _ in range(1000):
+    idx=rng.integers(0,n,size=n)
+    ss=arr[idx].sum(axis=0); t,f,fn2=ss
+    p=t/(t+f) if t+f else 0; r=t/(t+fn2) if t+fn2 else 0
+    boot.append(2*p*r/(p+r) if p+r else 0)
+boot=np.array(boot)
+print(json.dumps({
+    "n_docs": int(n), "n_gold": int(tp+fn), "excluded_labels": sorted(EXCLUDED),
+    "point": {"P": round(P,4), "R": round(R,4), "F1": round(F,4)},
+    "f1_ci_95": [round(float(np.percentile(boot,2.5)),4), round(float(np.percentile(boot,97.5)),4)],
+    "per_label_recall": {l: round(per_label_tp[l]/max(per_label_tp[l]+per_label_fn[l],1),4) for l in per_label_tp},
+}, ensure_ascii=False, indent=2))

--- a/packages/training/scripts/eval_ood_span_merged.py
+++ b/packages/training/scripts/eval_ood_span_merged.py
@@ -1,78 +1,178 @@
-"""OOD eval with adjacent-span merging — fairer comparison when gold uses coarser labels."""
+"""OOD eval with **label-aware** span merging.
+
+Only adjacent v2 predictions whose labels belong to the same coarse
+equivalence class are merged. Adjacent predictions with semantically
+unrelated labels stay separate.
+
+This replaces an earlier label-blind implementation that merged any
+contiguous run of non-O tokens regardless of label — peer reviewer
+correctly flagged that as inflating F1 by collapsing distinct
+entities (e.g. PERSON,PHONE adjacent in form text).
+
+Equivalence classes are documented in `COARSE_CLASSES` below and
+reflect how the v1 (pleno) OOD set's coarse labels relate to v2's
+fine-grained ai4privacy labels.
+"""
 from __future__ import annotations
-import json, time
+
+import argparse
+import json
+import time
 from pathlib import Path
+
 import numpy as np
-import torch
-from transformers import AutoModelForTokenClassification, AutoTokenizer
 
-DATA = Path("/tmp/v2-ood-extended.jsonl")
-MODEL = "packages/training/output/ja-ner-supervised-v2/model-best"
 
-def iou(a,b):
-    s=max(a[0],b[0]); e=min(a[1],b[1])
-    inter=max(0,e-s); union=(a[1]-a[0])+(b[1]-b[0])-inter
-    return inter/union if union else 0.0
+COARSE_CLASSES: dict[str, set[str]] = {
+    "PERSON":        {"LASTNAME1", "LASTNAME2", "LASTNAME3", "GIVENNAME1", "GIVENNAME2", "TITLE", "USERNAME"},
+    "ADDRESS":       {"STREET", "CITY", "STATE", "POSTCODE", "BUILDING", "SECADDRESS", "COUNTRY", "GEOCOORD"},
+    "DATE_OF_BIRTH": {"BOD", "DATE", "TIME"},
+    "PHONE":         {"TEL"},
+    "EMAIL":         {"EMAIL"},
+    "ID_CARD":       {"IDCARD", "DRIVERLICENSE", "PASSPORT", "PASS", "SOCIALNUMBER"},
+    "CARD":          {"CARDISSUER"},
+    "IP":            {"IP"},
+    "SEX":           {"SEX"},
+}
 
-tok=AutoTokenizer.from_pretrained(MODEL); mdl=AutoModelForTokenClassification.from_pretrained(MODEL).eval()
-id2l=mdl.config.id2label
 
-def predict_merged(text, gap_chars=2):
-    enc=tok(text, return_offsets_mapping=True, truncation=True, max_length=512, return_tensors='pt')
-    offs=enc.pop('offset_mapping')[0].tolist()
+def _label_to_class(label: str) -> str | None:
+    # Already a coarse class name (post-merge): return as-is.
+    if label in COARSE_CLASSES:
+        return label
+    for cls, members in COARSE_CLASSES.items():
+        if label in members:
+            return cls
+    return None
+
+
+def iou(a, b):
+    s = max(a[0], b[0]); e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def predict_label_aware_merged(text, tok, mdl, id2lab, gap_chars=2):
+    enc = tok(text, return_offsets_mapping=True, truncation=True,
+              max_length=512, return_tensors="pt")
+    offs = enc.pop("offset_mapping")[0].tolist()
+    import torch
     with torch.inference_mode():
-        logits=mdl(**{k:v.to(mdl.device) for k,v in enc.items()}).logits[0]
-    labs=[id2l[i] for i in logits.argmax(-1).tolist()]
-    spans=[]; cur=None
-    for o,p in zip(offs,labs):
-        if tuple(o)==(0,0): continue
-        if p=='O':
-            if cur: spans.append(cur); cur=None
+        logits = mdl(**{k: v.to(mdl.device) for k, v in enc.items()}).logits[0]
+    labs = [id2lab[i] for i in logits.argmax(-1).tolist()]
+
+    # Step 1: BIO decode preserving fine labels
+    typed: list[tuple[int, int, str]] = []
+    cur_l = cur_s = cur_e = None
+    for off, p in zip(offs, labs):
+        if tuple(off) == (0, 0):
             continue
-        if cur is None: cur=[o[0], o[1]]
-        else: cur[1]=o[1]  # always extend regardless of label
-    if cur: spans.append(cur)
-    # Optionally merge spans separated by <= gap_chars whitespace
-    merged=[]
-    for s in spans:
-        if merged and s[0]-merged[-1][1] <= gap_chars:
-            merged[-1][1]=s[1]
+        if p == "O":
+            if cur_l is not None:
+                typed.append((cur_s, cur_e, cur_l))
+                cur_l = cur_s = cur_e = None
+            continue
+        bio, _, lab = p.partition("-")
+        if bio == "B" or cur_l != lab:
+            if cur_l is not None:
+                typed.append((cur_s, cur_e, cur_l))
+            cur_l = lab; cur_s = off[0]; cur_e = off[1]
         else:
-            merged.append(list(s))
-    return [(s[0], s[1], "X") for s in merged]
+            cur_e = off[1]
+    if cur_l is not None:
+        typed.append((cur_s, cur_e, cur_l))
 
-per_doc=[]
-for line in DATA.read_text(encoding='utf-8').splitlines():
-    if not line.strip(): continue
-    r=json.loads(line)
-    gold=[(int(e['start']),int(e['end']),str(e['label'])) for e in r['entities']]
-    pred=predict_merged(r['text'])
-    matched=set(); tp=fn=0
-    for g_s,g_e,_ in gold:
-        best_i,best_iou=-1,0.0
-        for i,p in enumerate(pred):
-            if i in matched: continue
-            v=iou((g_s,g_e),(p[0],p[1]))
-            if v>best_iou: best_iou=v; best_i=i
-        if best_i>=0 and best_iou>=0.5:
-            tp+=1; matched.add(best_i)
-        else:
-            fn+=1
-    fp=len(pred)-len(matched)
-    per_doc.append((tp,fp,fn))
+    # Step 2: label-aware merge — only collapse within same coarse class
+    merged: list[list] = []
+    for s, e, lab in typed:
+        cls = _label_to_class(lab)
+        if cls is None:
+            merged.append([s, e, lab])
+            continue
+        if merged:
+            prev = merged[-1]
+            prev_cls = _label_to_class(prev[2])
+            if prev_cls == cls and (s - prev[1]) <= gap_chars:
+                prev[1] = e
+                prev[2] = cls
+                continue
+        merged.append([s, e, cls])
 
-arr=np.array(per_doc); n=len(arr)
-s=arr.sum(axis=0); tp,fp,fn=s
-P=tp/(tp+fp) if tp+fp else 0; R=tp/(tp+fn) if tp+fn else 0; F=2*P*R/(P+R) if P+R else 0
-rng=np.random.default_rng(42); boot=[]
-for _ in range(1000):
-    idx=rng.integers(0,n,size=n)
-    ss=arr[idx].sum(axis=0); t,f,fn2=ss
-    p=t/(t+f) if t+f else 0; r=t/(t+fn2) if t+fn2 else 0
-    boot.append(2*p*r/(p+r) if p+r else 0)
-boot=np.array(boot)
-print(json.dumps({
-    "n_docs": int(n),
-    "point": {"P": round(P,4), "R": round(R,4), "F1": round(F,4)},
-    "f1_ci_95": [round(float(np.percentile(boot,2.5)),4), round(float(np.percentile(boot,97.5)),4)],
-}, ensure_ascii=False, indent=2))
+    return [(m[0], m[1], m[2]) for m in merged]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--data", type=Path, required=True)
+    parser.add_argument("--iou", type=float, default=0.5)
+    parser.add_argument("--bootstrap", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+    tok = AutoTokenizer.from_pretrained(args.model)
+    mdl = AutoModelForTokenClassification.from_pretrained(args.model).eval()
+    id2lab = mdl.config.id2label
+
+    per_doc = []
+    t0 = time.perf_counter()
+    for line in args.data.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        gold = [(int(e["start"]), int(e["end"]), str(e["label"])) for e in r["entities"]]
+        pred = predict_label_aware_merged(r["text"], tok, mdl, id2lab)
+        matched = set()
+        tp = fn = 0
+        for g_s, g_e, _g_l in gold:
+            best_i, best_iou = -1, 0.0
+            for i, p in enumerate(pred):
+                if i in matched:
+                    continue
+                v = iou((g_s, g_e), (p[0], p[1]))
+                if v > best_iou:
+                    best_iou = v; best_i = i
+            if best_i >= 0 and best_iou >= args.iou:
+                tp += 1; matched.add(best_i)
+            else:
+                fn += 1
+        fp = len(pred) - len(matched)
+        per_doc.append((tp, fp, fn))
+
+    arr = np.array(per_doc)
+    n = len(arr)
+    s = arr.sum(axis=0); tp, fp, fn = s
+    P = tp / (tp + fp) if tp + fp else 0
+    R = tp / (tp + fn) if tp + fn else 0
+    F = 2 * P * R / (P + R) if P + R else 0
+
+    rng = np.random.default_rng(args.seed); boot = []
+    for _ in range(args.bootstrap):
+        idx = rng.integers(0, n, size=n)
+        ss = arr[idx].sum(axis=0); t, f, fn2 = ss
+        p = t / (t + f) if t + f else 0
+        r = t / (t + fn2) if t + fn2 else 0
+        boot.append(2 * p * r / (p + r) if p + r else 0)
+    boot = np.array(boot)
+
+    summary = {
+        "model": args.model,
+        "data": str(args.data),
+        "n_docs": int(n),
+        "coarse_classes": {k: sorted(v) for k, v in COARSE_CLASSES.items()},
+        "merge_rule": "Adjacent v2 sub-spans merged only when both labels map to the same coarse equivalence class.",
+        "point": {"P": round(P, 4), "R": round(R, 4), "F1": round(F, 4)},
+        "f1_ci_95": [round(float(np.percentile(boot, 2.5)), 4),
+                     round(float(np.percentile(boot, 97.5)), 4)],
+        "elapsed_sec": round(time.perf_counter() - t0, 1),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/scripts/eval_ood_span_merged.py
+++ b/packages/training/scripts/eval_ood_span_merged.py
@@ -1,0 +1,78 @@
+"""OOD eval with adjacent-span merging — fairer comparison when gold uses coarser labels."""
+from __future__ import annotations
+import json, time
+from pathlib import Path
+import numpy as np
+import torch
+from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+DATA = Path("/tmp/v2-ood-extended.jsonl")
+MODEL = "packages/training/output/ja-ner-supervised-v2/model-best"
+
+def iou(a,b):
+    s=max(a[0],b[0]); e=min(a[1],b[1])
+    inter=max(0,e-s); union=(a[1]-a[0])+(b[1]-b[0])-inter
+    return inter/union if union else 0.0
+
+tok=AutoTokenizer.from_pretrained(MODEL); mdl=AutoModelForTokenClassification.from_pretrained(MODEL).eval()
+id2l=mdl.config.id2label
+
+def predict_merged(text, gap_chars=2):
+    enc=tok(text, return_offsets_mapping=True, truncation=True, max_length=512, return_tensors='pt')
+    offs=enc.pop('offset_mapping')[0].tolist()
+    with torch.inference_mode():
+        logits=mdl(**{k:v.to(mdl.device) for k,v in enc.items()}).logits[0]
+    labs=[id2l[i] for i in logits.argmax(-1).tolist()]
+    spans=[]; cur=None
+    for o,p in zip(offs,labs):
+        if tuple(o)==(0,0): continue
+        if p=='O':
+            if cur: spans.append(cur); cur=None
+            continue
+        if cur is None: cur=[o[0], o[1]]
+        else: cur[1]=o[1]  # always extend regardless of label
+    if cur: spans.append(cur)
+    # Optionally merge spans separated by <= gap_chars whitespace
+    merged=[]
+    for s in spans:
+        if merged and s[0]-merged[-1][1] <= gap_chars:
+            merged[-1][1]=s[1]
+        else:
+            merged.append(list(s))
+    return [(s[0], s[1], "X") for s in merged]
+
+per_doc=[]
+for line in DATA.read_text(encoding='utf-8').splitlines():
+    if not line.strip(): continue
+    r=json.loads(line)
+    gold=[(int(e['start']),int(e['end']),str(e['label'])) for e in r['entities']]
+    pred=predict_merged(r['text'])
+    matched=set(); tp=fn=0
+    for g_s,g_e,_ in gold:
+        best_i,best_iou=-1,0.0
+        for i,p in enumerate(pred):
+            if i in matched: continue
+            v=iou((g_s,g_e),(p[0],p[1]))
+            if v>best_iou: best_iou=v; best_i=i
+        if best_i>=0 and best_iou>=0.5:
+            tp+=1; matched.add(best_i)
+        else:
+            fn+=1
+    fp=len(pred)-len(matched)
+    per_doc.append((tp,fp,fn))
+
+arr=np.array(per_doc); n=len(arr)
+s=arr.sum(axis=0); tp,fp,fn=s
+P=tp/(tp+fp) if tp+fp else 0; R=tp/(tp+fn) if tp+fn else 0; F=2*P*R/(P+R) if P+R else 0
+rng=np.random.default_rng(42); boot=[]
+for _ in range(1000):
+    idx=rng.integers(0,n,size=n)
+    ss=arr[idx].sum(axis=0); t,f,fn2=ss
+    p=t/(t+f) if t+f else 0; r=t/(t+fn2) if t+fn2 else 0
+    boot.append(2*p*r/(p+r) if p+r else 0)
+boot=np.array(boot)
+print(json.dumps({
+    "n_docs": int(n),
+    "point": {"P": round(P,4), "R": round(R,4), "F1": round(F,4)},
+    "f1_ci_95": [round(float(np.percentile(boot,2.5)),4), round(float(np.percentile(boot,97.5)),4)],
+}, ensure_ascii=False, indent=2))

--- a/packages/training/scripts/eval_stockmark_jp_real.py
+++ b/packages/training/scripts/eval_stockmark_jp_real.py
@@ -1,0 +1,189 @@
+"""Real-text JP OOD eval against stockmark/ner-wikipedia-dataset.
+
+Real Japanese Wikipedia sentences with 8 entity categories:
+人名, 法人名, 政治的組織名, その他の組織名, 地名, 施設名, 製品名, イベント名.
+
+Only 人名 and 地名 are clean PII targets. The rest (corporations, products,
+events, facilities) are out-of-scope for a PII NER like v2 by design.
+
+We report two numbers:
+- full: char-IoU >= 0.5, label-agnostic over all 8 stockmark categories
+- pii-subset: same, but restricting gold to {人名, 地名}
+
+This is the first **real Japanese text** in the v2 eval suite. The
+peer reviewer flagged the absence of real-text eval as the structural
+Accept blocker; this addresses it (Wikipedia text is not full
+production "chat / form / scanned" coverage, but it is genuine non-
+LLM-synthesised JP).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+PII_RELEVANT = {"人名", "地名"}
+
+
+def iou(a, b):
+    s = max(a[0], b[0]); e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def decode_label_aware(text, tok, mdl, id2lab, COARSE_CLASSES):
+    enc = tok(text, return_offsets_mapping=True, truncation=True,
+              max_length=512, return_tensors="pt")
+    offs = enc.pop("offset_mapping")[0].tolist()
+    import torch
+    with torch.inference_mode():
+        logits = mdl(**{k: v.to(mdl.device) for k, v in enc.items()}).logits[0]
+    labs = [id2lab[i] for i in logits.argmax(-1).tolist()]
+
+    typed: list[tuple[int, int, str]] = []
+    cur_l = cur_s = cur_e = None
+    for off, p in zip(offs, labs):
+        if tuple(off) == (0, 0):
+            continue
+        if p == "O":
+            if cur_l is not None:
+                typed.append((cur_s, cur_e, cur_l))
+                cur_l = cur_s = cur_e = None
+            continue
+        bio, _, lab = p.partition("-")
+        if bio == "B" or cur_l != lab:
+            if cur_l is not None:
+                typed.append((cur_s, cur_e, cur_l))
+            cur_l = lab; cur_s = off[0]; cur_e = off[1]
+        else:
+            cur_e = off[1]
+    if cur_l is not None:
+        typed.append((cur_s, cur_e, cur_l))
+
+    def label_class(lbl):
+        if lbl in COARSE_CLASSES: return lbl
+        for cls, mem in COARSE_CLASSES.items():
+            if lbl in mem: return cls
+        return None
+
+    merged: list[list] = []
+    for s, e, lab in typed:
+        cls = label_class(lab)
+        if cls is None:
+            merged.append([s, e, lab])
+            continue
+        if merged:
+            prev = merged[-1]
+            if label_class(prev[2]) == cls and (s - prev[1]) <= 2:
+                prev[1] = e; prev[2] = cls
+                continue
+        merged.append([s, e, cls])
+    return [(m[0], m[1], m[2]) for m in merged]
+
+
+def score(rows, pred_fn, iou_thr, gold_filter=None):
+    per_doc = []
+    for r in rows:
+        gold = [(int(s[0]), int(s[1]), str(s[2])) for s in r["gold"]
+                if gold_filter is None or s[2] in gold_filter]
+        if not gold:
+            continue
+        pred = r["pred"]
+        matched = set()
+        tp = fn = 0
+        for g_s, g_e, _ in gold:
+            best_i, best_iou = -1, 0.0
+            for i, p in enumerate(pred):
+                if i in matched: continue
+                v = iou((g_s, g_e), (p[0], p[1]))
+                if v > best_iou: best_iou = v; best_i = i
+            if best_i >= 0 and best_iou >= iou_thr:
+                tp += 1; matched.add(best_i)
+            else:
+                fn += 1
+        fp = len(pred) - len(matched)
+        per_doc.append((tp, fp, fn))
+    arr = np.array(per_doc) if per_doc else np.zeros((0, 3), dtype=int)
+    return arr
+
+
+def bootstrap_ci(arr, iters=1000, seed=42):
+    if len(arr) == 0:
+        return {"P": 0, "R": 0, "F1": 0, "f1_ci": [0, 0], "n": 0}
+    s = arr.sum(axis=0); tp, fp, fn = s
+    P = tp / (tp + fp) if tp + fp else 0
+    R = tp / (tp + fn) if tp + fn else 0
+    F = 2 * P * R / (P + R) if P + R else 0
+    n = len(arr)
+    rng = np.random.default_rng(seed); boot = []
+    for _ in range(iters):
+        idx = rng.integers(0, n, size=n)
+        ss = arr[idx].sum(axis=0); t, f, fn2 = ss
+        p = t / (t + f) if t + f else 0
+        r = t / (t + fn2) if t + fn2 else 0
+        boot.append(2 * p * r / (p + r) if p + r else 0)
+    boot = np.array(boot)
+    return {
+        "P": round(P, 4), "R": round(R, 4), "F1": round(F, 4),
+        "f1_ci_95": [round(float(np.percentile(boot, 2.5)), 4),
+                     round(float(np.percentile(boot, 97.5)), 4)],
+        "n_docs": int(n),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--dataset", default="stockmark/ner-wikipedia-dataset")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--limit", type=int, default=300)
+    parser.add_argument("--iou", type=float, default=0.5)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    from datasets import load_dataset
+    from transformers import AutoModelForTokenClassification, AutoTokenizer
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from eval_ood_span_merged import COARSE_CLASSES
+
+    tok = AutoTokenizer.from_pretrained(args.model)
+    mdl = AutoModelForTokenClassification.from_pretrained(args.model).eval()
+    id2lab = mdl.config.id2label
+
+    rows_data = []
+    t0 = time.perf_counter()
+    for i, row in enumerate(load_dataset(args.dataset, split=args.split, streaming=True)):
+        if i >= args.limit: break
+        text = row["text"]
+        gold = [(e["span"][0], e["span"][1], e["type"]) for e in row["entities"]]
+        pred = decode_label_aware(text, tok, mdl, id2lab, COARSE_CLASSES)
+        rows_data.append({"gold": gold, "pred": pred})
+
+    arr_full = score(rows_data, None, args.iou, gold_filter=None)
+    arr_pii  = score(rows_data, None, args.iou, gold_filter=PII_RELEVANT)
+    full_metrics = bootstrap_ci(arr_full)
+    pii_metrics  = bootstrap_ci(arr_pii)
+
+    summary = {
+        "model": args.model,
+        "dataset": args.dataset,
+        "split": args.split,
+        "limit": args.limit,
+        "iou": args.iou,
+        "elapsed_sec": round(time.perf_counter() - t0, 1),
+        "full_protocol": full_metrics,
+        "pii_relevant_subset": {**pii_metrics, "categories": sorted(PII_RELEVANT)},
+        "all_stockmark_categories": sorted({g[2] for r in rows_data for g in r["gold"]}),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/scripts/eval_stockmark_spacy.py
+++ b/packages/training/scripts/eval_stockmark_spacy.py
@@ -1,0 +1,99 @@
+"""Run spaCy ja_core_news_lg on stockmark Wikipedia NER for baseline."""
+from __future__ import annotations
+import argparse, json, time
+from pathlib import Path
+import numpy as np
+
+PII_RELEVANT = {"人名", "地名"}
+
+
+def iou(a, b):
+    s = max(a[0], b[0]); e = min(a[1], b[1])
+    inter = max(0, e - s)
+    union = (a[1] - a[0]) + (b[1] - b[0]) - inter
+    return inter / union if union else 0.0
+
+
+def score(rows, iou_thr, gold_filter=None):
+    per_doc = []
+    for r in rows:
+        gold = [(s[0], s[1], s[2]) for s in r["gold"]
+                if gold_filter is None or s[2] in gold_filter]
+        if not gold: continue
+        pred = r["pred"]
+        matched = set(); tp = fn = 0
+        for g_s, g_e, _ in gold:
+            best_i, best_iou = -1, 0.0
+            for i, p in enumerate(pred):
+                if i in matched: continue
+                v = iou((g_s, g_e), (p[0], p[1]))
+                if v > best_iou: best_iou = v; best_i = i
+            if best_i >= 0 and best_iou >= iou_thr:
+                tp += 1; matched.add(best_i)
+            else:
+                fn += 1
+        fp = len(pred) - len(matched)
+        per_doc.append((tp, fp, fn))
+    return np.array(per_doc) if per_doc else np.zeros((0, 3), dtype=int)
+
+
+def boot(arr, iters=1000, seed=42):
+    if not len(arr): return {"P": 0, "R": 0, "F1": 0, "f1_ci_95": [0, 0], "n": 0}
+    s = arr.sum(axis=0); tp, fp, fn = s
+    P = tp / (tp + fp) if tp + fp else 0
+    R = tp / (tp + fn) if tp + fn else 0
+    F = 2 * P * R / (P + R) if P + R else 0
+    n = len(arr)
+    rng = np.random.default_rng(seed); bs = []
+    for _ in range(iters):
+        idx = rng.integers(0, n, size=n)
+        ss = arr[idx].sum(axis=0); t, f, fn2 = ss
+        p = t / (t + f) if t + f else 0
+        r = t / (t + fn2) if t + fn2 else 0
+        bs.append(2 * p * r / (p + r) if p + r else 0)
+    bs = np.array(bs)
+    return {
+        "P": round(P, 4), "R": round(R, 4), "F1": round(F, 4),
+        "f1_ci_95": [round(float(np.percentile(bs, 2.5)), 4),
+                     round(float(np.percentile(bs, 97.5)), 4)],
+        "n_docs": int(n),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="ja_core_news_lg")
+    parser.add_argument("--limit", type=int, default=300)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    from datasets import load_dataset
+    import spacy
+    nlp = spacy.load(args.model)
+
+    rows_data = []
+    t0 = time.perf_counter()
+    for i, row in enumerate(load_dataset("stockmark/ner-wikipedia-dataset", split="train", streaming=True)):
+        if i >= args.limit: break
+        text = row["text"]
+        gold = [(e["span"][0], e["span"][1], e["type"]) for e in row["entities"]]
+        doc = nlp(text)
+        pred = [(ent.start_char, ent.end_char, ent.label_) for ent in doc.ents]
+        rows_data.append({"gold": gold, "pred": pred})
+
+    summary = {
+        "model": args.model,
+        "dataset": "stockmark/ner-wikipedia-dataset",
+        "limit": args.limit,
+        "elapsed_sec": round(time.perf_counter() - t0, 1),
+        "full_protocol": boot(score(rows_data, 0.5)),
+        "pii_relevant_subset": {**boot(score(rows_data, 0.5, PII_RELEVANT)),
+                                "categories": sorted(PII_RELEVANT)},
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/training/scripts/train_supervised_300k_ja.py
+++ b/packages/training/scripts/train_supervised_300k_ja.py
@@ -73,7 +73,21 @@ def main() -> None:
     parser.add_argument("--epochs", type=int, default=2)
     parser.add_argument("--batch-size", type=int, default=16)
     parser.add_argument("--lr", type=float, default=5e-5)
+    parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
+
+    # Reproducibility: fix all RNGs we touch.
+    import os, random
+    import numpy as _np
+    random.seed(args.seed); _np.random.seed(args.seed)
+    os.environ["PYTHONHASHSEED"] = str(args.seed)
+    try:
+        import torch as _torch
+        _torch.manual_seed(args.seed)
+        if _torch.cuda.is_available():
+            _torch.cuda.manual_seed_all(args.seed)
+    except ImportError:
+        pass
 
     from datasets import Dataset
     from transformers import (
@@ -157,6 +171,8 @@ def main() -> None:
         save_total_limit=2,
         report_to=[],
         fp16=True,
+        seed=args.seed,
+        data_seed=args.seed,
     )
 
     def compute_metrics(eval_preds):


### PR DESCRIPTION
## Status: peer-reviewed (Accept)

Adversarial document reviewer (ce-adversarial-document-reviewer) rendered **Accept** (confidence 4) after R2.

Saved verdict: `packages/training/docs/peer-review-v2-r2.md`

## Two iterations, three reviewer rounds

| Round | Verdict | Driver |
|---|---|---|
| R0 (initial) | Major Revision | Train/eval leakage probe missing, no CIs, in-dist 0.957 bolded vs OPF 0.702 |
| R1 (CIs + baselines + headline reframe) | Major Revision | Span-merge bug, no real text, single seed |
| R2 (this) | **Accept** | All three R1 blockers resolved |

## Final 3-seed numbers (mean ± std)

| Eval set | F1 |
|---|---:|
| In-dist (300k-ja val, 300 docs) | **0.955 ± 0.002** |
| OOD synthetic strict | 0.773 ± 0.004 |
| OOD synthetic label-aware merged | **0.852 ± 0.014** |
| Real text (stockmark Wikipedia, PII subset) | 0.467 ± 0.010 |
| Real text (full 8 categories) | 0.395 ± 0.009 |

**Acceptance tiers (final read):** Smoke + Parity met on synthetic eval. Real-text below Smoke; spaCy beats v2 on Wikipedia by 0.10 F1 in the PII subset, honestly reported. Production deployment expectations calibrated to ~0.47, not ~0.85.

Released: https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised (public).

Reviewer's R3 follow-up items (not blocking): hand-annotated PII-context JP samples, GiNZA baseline, pyproject version pinning, AI4Privacy upstream split-protocol documentation.