### PR TITLE
chore: rename HF model to 0xhikae/pleno_anonymize_ja

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Japanese validation split (`0xhikae/pii-masking-300k-ja`), 50 docs.
 | `builtin` | 0.453 | 0.275 | 0.342 | 55 ms |
 | `openai-privacy-filter` | 0.899 | 0.576 | 0.702 | 2.3 s |
 
-[`ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised) numbers below — 3-seed mean ± std (seeds 42 / 7 / 1337), 1000-iter bootstrap CIs on the seed-42 run. See [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md) for the full methodology, span-merge derivation, real-text caveats, and open gaps.
+[`pleno_anonymize_ja`](https://huggingface.co/0xhikae/pleno_anonymize_ja) numbers below — 3-seed mean ± std (seeds 42 / 7 / 1337), 1000-iter bootstrap CIs on the seed-42 run. See [`docs/benchmark-supervised-v2.md`](docs/benchmark-supervised-v2.md) for the full methodology, span-merge derivation, real-text caveats, and open gaps.
 
 | Eval set | F1 | F1 95% CI | P | R | Latency |
 |---|---:|---|---:|---:|---:|

--- a/docs/benchmark-supervised-v2.md
+++ b/docs/benchmark-supervised-v2.md
@@ -1,6 +1,6 @@
-# `ja_ner_ja-v2-supervised` — benchmark + methodological accounting
+# `pleno_anonymize_ja` — benchmark + methodological accounting
 
-Released at [`0xhikae/ja_ner_ja-v2-supervised`](https://huggingface.co/0xhikae/ja_ner_ja-v2-supervised).
+Released at [`0xhikae/pleno_anonymize_ja`](https://huggingface.co/0xhikae/pleno_anonymize_ja).
 
 This is the **R2 revision** of the benchmark doc. The previous
 revision passed Smoke and (synthetic-OOD) Parity but the peer
@@ -52,9 +52,9 @@ Validation split of `0xhikae/pii-masking-300k-ja`, 300 docs.
 | `ja_ner_ja-v2-mechanism` (v1, synthetic only) | 0.352 | — | 0.612 | 0.247 | 37 ms |
 | spaCy `ja_core_news_lg` | 0.274 | [0.250, 0.297] | 0.205 | 0.411 | 22 ms |
 | `openai-privacy-filter` v0.13.0 | 0.702 | — | 0.899 | 0.576 | 2.3 s |
-| **`ja_ner_ja-v2-supervised` (seed 42)** | **0.957** | [0.935, 0.973] | 0.933 | 0.983 | 43 ms |
-| `ja_ner_ja-v2-supervised` (seed 7) | 0.954 | — | 0.927 | 0.982 | — |
-| `ja_ner_ja-v2-supervised` (seed 1337) | 0.954 | — | 0.926 | 0.983 | — |
+| **`pleno_anonymize_ja` (seed 42)** | **0.957** | [0.935, 0.973] | 0.933 | 0.983 | 43 ms |
+| `pleno_anonymize_ja` (seed 7) | 0.954 | — | 0.927 | 0.982 | — |
+| `pleno_anonymize_ja` (seed 1337) | 0.954 | — | 0.926 | 0.983 | — |
 | **3-seed mean ± std** | **0.955 ± 0.002** | | | | |
 
 **Caveat unchanged from R1:** v2 was trained on the **train split**


### PR DESCRIPTION
Per user request — simpler model name. Was `0xhikae/ja_ner_ja-v2-supervised`, now `0xhikae/pleno_anonymize_ja`. Same checkpoint, public, model card already updated on HF. This PR updates the in-repo references (README + benchmark doc).