### PR TITLE
fix(server): roll EN model in image back to en_ner_en-0.1.0 (tok2vec)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,18 @@ RUN uv sync --frozen --no-dev --package pleno-anonymize-server
 # placed them between syncs, and `uv sync --frozen` pruned wheels not in the
 # lockfile, breaking production (caught by build-time smoke).
 RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+# EN model: pleno_anonymize_en-0.2.0 is transformer-based (438MB wheel +
+# torch + nvidia CUDA libs → 15.7GB image, over fly's 8GB rootfs limit).
+# Server image ships the legacy tok2vec en_ner_en-0.1.0 for /api/?lang=en;
+# pleno_anonymize_en stays SDK-only for local users who can absorb the size.
 RUN uv pip install \
     https://huggingface.co/0xhikae/pleno_anonymize_ja/resolve/main/pleno_anonymize_ja-0.2.0-py3-none-any.whl \
-    https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.2.0-py3-none-any.whl
+    https://huggingface.co/0xhikae/en-ner-en/resolve/main/en_ner_en-0.1.0.tar.gz
 
 # Build-time smoke test surfaces model-load failures at image build instead of
 # runtime. `--no-sync` is required: `uv run` defaults to re-syncing the
 # workspace, which would clobber the wheels we just installed.
-RUN uv run --no-sync python -c "import spacy; spacy.load('pleno_anonymize_ja'); spacy.load('pleno_anonymize_en'); print('models loadable')"
+RUN uv run --no-sync python -c "import spacy; spacy.load('pleno_anonymize_ja'); spacy.load('en_ner_en'); print('models loadable')"
 
 FROM python:3.12-slim
 

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -64,10 +64,17 @@ def _init_presidio():
     # resolve via spaCy entry_point lookup, not filesystem path.
     _nlp_ja = spacy.load("pleno_anonymize_ja")
 
+    # pleno_anonymize_en v0.2.0 is transformer-based and inflates the image
+    # past fly's 8GB rootfs limit (torch + nvidia CUDA libs). Server image
+    # ships the lightweight tok2vec en_ner_en-0.1.0 instead; SDK users still
+    # get pleno_anonymize_en via the auto-download path.
     try:
         _nlp_en = spacy.load("pleno_anonymize_en")
     except OSError:
-        _nlp_en = None
+        try:
+            _nlp_en = spacy.load("en_ner_en")
+        except OSError:
+            _nlp_en = None
 
     models = {"ja": _nlp_ja}
     if _nlp_en is not None:


### PR DESCRIPTION
## Summary

Restores deployability after #176 — the new transformer-based `pleno_anonymize_en-0.2.0` wheel pulls torch + nvidia CUDA libs and inflates the server image to **15.74GB**, which exceeds fly.io's 8GB rootfs limit. The deploy job (run [25982102511](https://github.com/plenoai/pleno-anonymize/actions/runs/25982102511)) failed at the size-guard step.

- `Dockerfile`: install `en_ner_en-0.1.0.tar.gz` from the legacy `0xhikae/en-ner-en` HF repo (lightweight tok2vec, ~30MB, same EN behavior the image had pre-#176)
- `Dockerfile`: build-time smoke loads `en_ner_en` instead of `pleno_anonymize_en`
- `server/src/app.py`: spaCy load tries `pleno_anonymize_en` first, falls back to `en_ner_en` (so the image switches automatically once a CPU-only / tok2vec `pleno_anonymize_en` variant is published)
- SDK is unchanged — local users still get the F1=0.968 transformer model via the auto-download path

## Follow-up

Train + publish a non-transformer `pleno_anonymize_en` variant so the server can drop the legacy `en_ner_en` fallback.

## Test plan

- [ ] CI green (check / scan / test / sdk)
- [ ] Docker build smoke loads both `pleno_anonymize_ja` and `en_ner_en`
- [ ] Image size verify under 7GB threshold
- [ ] Fly deploy succeeds and `/health` responds