### PR TITLE
fix(sdk): probe pip with --version; bump to 0.2.1 for renamed HF URLs

### DIFF
--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pleno-anonymize"
-version = "0.2.0"
+version = "0.2.1"
 description = "Local-first Japanese PII detection and redaction. SDK + `pleno-anonymize` CLI sharing the same recognizer registry and NER pipeline as the pleno-anonymize server."
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/sdk/src/pleno_anonymize/_models.py
+++ b/packages/sdk/src/pleno_anonymize/_models.py
@@ -44,8 +44,23 @@ def is_installed(model_name: str) -> bool:
     return importlib.util.find_spec(model_name) is not None
 
 
+def _pip_works() -> bool:
+    # `find_spec("pip")` lies inside uvx-managed envs: a stale `pip*.dist-info`
+    # makes the spec discoverable even though the module fails to import
+    # (`No module named pip`). Actually invoke pip to confirm.
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            check=True,
+            capture_output=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
 def _install_command(url: str, *, quiet: bool = False) -> list[str]:
-    if importlib.util.find_spec("pip") is not None:
+    if _pip_works():
         cmd = [sys.executable, "-m", "pip", "install", "--no-cache-dir"]
         if quiet:
             cmd.append("--quiet")

--- a/uv.lock
+++ b/uv.lock
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "pleno-anonymize"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "presidio-analyzer" },


### PR DESCRIPTION
## Summary

Two bugs surfaced by \`uvx pleno-anonymize redact --language ja\`:

1. **\`No module named pip\` inside uvx envs.** \`_install_command\` chose the pip branch because \`importlib.util.find_spec(\"pip\")\` returned a non-None spec, then \`python -m pip install\` died because pip itself isn't actually importable in the uvx-managed interpreter. Replace the spec check with a \`pip --version\` subprocess probe — we only commit to pip when it actually loads, otherwise fall through to the existing \`uv pip install\` branch.

2. **Renamed HF URLs aren't on PyPI yet.** \`MODEL_WHEELS\` was repointed at \`0xhikae/pleno_anonymize_{ja,en}\` in #176, but published 0.2.0 still references the legacy \`0xhikae/ja-ner-ja\` URL. Bump to 0.2.1 so a \`sdk/v0.2.1\` tag push propagates the new URLs via trusted publishing.

## Test plan

- [ ] CI green
- [ ] Tag \`sdk/v0.2.1\` after merge → PyPI publish succeeds
- [ ] \`uvx --refresh pleno-anonymize redact --language ja\` succeeds end-to-end