### PR TITLE
fix(sdk): drop [openai] extra (PyPI rejects git deps); bump to 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Full API surface: [`packages/sdk`](packages/sdk).
 | Engine | Install | Speed | When |
 |---|---|---|---|
 | `builtin` (default) | `pip install pleno-anonymize` | ~50 ms/doc CPU | Japanese-first, regex + checksum for structured IDs, slim deps |
-| `openai-privacy-filter` | `pip install "pleno-anonymize[openai]"` | ~2 s/doc CPU, ~30 ms GPU | English-heavy text, secret detection, higher recall |
+| `openai-privacy-filter` | `pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main'` | ~2 s/doc CPU, ~30 ms GPU | English-heavy text, secret detection, higher recall |
 
 ```bash
 # default — builtin Presidio + pleno_anonymize_ja

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pleno-anonymize"
-version = "0.2.1"
+version = "0.2.2"
 description = "Local-first Japanese PII detection and redaction. SDK + `pleno-anonymize` CLI sharing the same recognizer registry and NER pipeline as the pleno-anonymize server."
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }
@@ -25,11 +25,13 @@ dependencies = [
 
 [project.optional-dependencies]
 remote = ["httpx>=0.27"]
-# OpenAI Privacy Filter (openai/privacy-filter, Apache 2.0). Not on PyPI
-# yet, so install direct from GitHub. Adds torch (~2GB) plus a
-# ~1.5B-parameter checkpoint download on first use; kept out of the
-# default install to preserve the slim local-first footprint.
-openai = ["opf @ git+https://github.com/openai/privacy-filter@main"]
+# OPF (openai/privacy-filter) isn't on PyPI yet — and PyPI rejects wheels
+# whose extras carry direct URL deps (`Can't have direct dependency: opf @
+# git+...`, 400 from upload.pypi.org). Users who want the OPF engine install
+# it themselves alongside this package:
+#   pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main'
+# Once OPF ships to PyPI we can restore an `openai` extra. The engine code
+# in src/pleno_anonymize/engines/opf.py stays — it just imports opf lazily.
 
 [project.scripts]
 pleno-anonymize = "pleno_anonymize._cli:main"
@@ -51,10 +53,6 @@ testpaths = ["tests"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.metadata]
-# `openai` extra references a git URL until OpenAI publishes `opf` to PyPI.
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pleno_anonymize"]

--- a/uv.lock
+++ b/uv.lock
@@ -2258,19 +2258,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opf"
-version = "0.1.0"
-source = { git = "https://github.com/openai/privacy-filter?rev=main#f7f00ca7fb869683eb732c010299d901457f19c3" }
-dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "safetensors" },
-    { name = "tiktoken" },
-    { name = "torch" },
-]
-
-[[package]]
 name = "optimum"
 version = "2.1.0"
 source = { registry = "https://pypi.flatt.tech/simple/" }
@@ -2552,7 +2539,7 @@ wheels = [
 
 [[package]]
 name = "pleno-anonymize"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "presidio-analyzer" },
@@ -2561,9 +2548,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-openai = [
-    { name = "opf" },
-]
 remote = [
     { name = "httpx" },
 ]
@@ -2577,12 +2561,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", marker = "extra == 'remote'", specifier = ">=0.27" },
-    { name = "opf", marker = "extra == 'openai'", git = "https://github.com/openai/privacy-filter?rev=main" },
     { name = "presidio-analyzer", specifier = ">=2.2" },
     { name = "presidio-anonymizer", specifier = ">=2.2" },
     { name = "spacy", extras = ["ja"], specifier = ">=3.8" },
 ]
-provides-extras = ["remote", "openai"]
+provides-extras = ["remote"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

\`sdk/v0.2.1\` publish failed at upload time:

\`\`\`
400 Bad Request
Can't have direct dependency: opf @ git+https://github.com/openai/privacy-filter@main ; extra == \"openai\"
\`\`\`

PyPI rejects wheels whose extras declare direct URL deps. The \`[openai]\` extra was added in #140; v0.2.0 predated it so the rule never bit until now.

- Remove \`[project.optional-dependencies].openai\` from \`packages/sdk/pyproject.toml\` and the \`tool.hatch.metadata.allow-direct-references\` opt-in it required
- README: replace \`pip install \"pleno-anonymize[openai]\"\` with the explicit co-install \`pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main'\`
- \`engines/opf.py\` is untouched — it already imports \`opf\` lazily, so users who follow the new install line keep the engine
- Version bump to 0.2.2 (0.2.1 was tagged but never reached PyPI)

## Follow-up

When \`opf\` ships to PyPI we can restore the \`[openai]\` extra (no git URL needed) and add a one-line note pointing users at the cleaner install path.

## Test plan

- [ ] CI green
- [ ] After merge, tag \`sdk/v0.2.2\` → trusted publishing uploads to PyPI
- [ ] \`uvx --refresh pleno-anonymize redact --language ja\` works end-to-end