### PR TITLE
fix(sdk): derive __version__ from package metadata

### DIFF
--- a/packages/sdk/src/pleno_anonymize/__init__.py
+++ b/packages/sdk/src/pleno_anonymize/__init__.py
@@ -33,4 +33,12 @@ __all__ = [
     "ScanSummary",
 ]
 
-__version__ = "0.2.0"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("pleno-anonymize")
+except PackageNotFoundError:
+    # Source-tree checkout without an installed dist (e.g. editable dev) —
+    # fall back to a sentinel rather than guessing, so `--version` makes
+    # the mismatch obvious instead of silently lying.
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

\`packages/sdk/src/pleno_anonymize/__init__.py\` hardcoded \`__version__ = \"0.2.0\"\`, so \`pleno-anonymize --version\` kept reporting 0.2.0 after the 0.2.1 / 0.2.2 bumps. That stale literal misled a publish-verification step in this morning's release work — I thought \`uvx pleno-anonymize\` was still resolving the old version when the wheel installed was actually 0.2.2.

- Replace the literal with \`importlib.metadata.version(\"pleno-anonymize\")\`
- Editable / source-tree checkouts without an installed dist get \`0.0.0+unknown\` rather than a confidently wrong number

## Test plan

- [ ] CI green
- [ ] \`uv run --package pleno-anonymize python -c \"import pleno_anonymize; print(pleno_anonymize.__version__)\"\` matches the installed dist