### PR TITLE
feat: switch EN model to tok2vec v0.2.1, drop transformer footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,18 +25,17 @@ RUN uv sync --frozen --no-dev --package pleno-anonymize-server
 # placed them between syncs, and `uv sync --frozen` pruned wheels not in the
 # lockfile, breaking production (caught by build-time smoke).
 RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
-# EN model: pleno_anonymize_en-0.2.0 is transformer-based (438MB wheel +
-# torch + nvidia CUDA libs → 15.7GB image, over fly's 8GB rootfs limit).
-# Server image ships the legacy tok2vec en_ner_en-0.1.0 for /api/?lang=en;
-# pleno_anonymize_en stays SDK-only for local users who can absorb the size.
+# Both NER wheels are tok2vec-based (no torch / spacy-transformers) so the
+# image stays well under fly's 8GB rootfs limit. v0.2.1 EN replaced the
+# transformer build that pushed image size to 15.7GB (#177 rollback).
 RUN uv pip install \
     https://huggingface.co/0xhikae/pleno_anonymize_ja/resolve/main/pleno_anonymize_ja-0.2.0-py3-none-any.whl \
-    https://huggingface.co/0xhikae/en-ner-en/resolve/main/en_ner_en-0.1.0.tar.gz
+    https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.2.1-py3-none-any.whl
 
 # Build-time smoke test surfaces model-load failures at image build instead of
 # runtime. `--no-sync` is required: `uv run` defaults to re-syncing the
 # workspace, which would clobber the wheels we just installed.
-RUN uv run --no-sync python -c "import spacy; spacy.load('pleno_anonymize_ja'); spacy.load('en_ner_en'); print('models loadable')"
+RUN uv run --no-sync python -c "import spacy; spacy.load('pleno_anonymize_ja'); spacy.load('pleno_anonymize_en'); print('models loadable')"
 
 FROM python:3.12-slim
 

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pleno-anonymize"
-version = "0.2.2"
+version = "0.2.3"
 description = "Local-first Japanese PII detection and redaction. SDK + `pleno-anonymize` CLI sharing the same recognizer registry and NER pipeline as the pleno-anonymize server."
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/packages/sdk/src/pleno_anonymize/_models.py
+++ b/packages/sdk/src/pleno_anonymize/_models.py
@@ -25,7 +25,10 @@ Language = Literal["ja", "en"]
 # runtime, the SDK must work standalone.
 MODEL_WHEELS: dict[str, str] = {
     "pleno_anonymize_ja": "https://huggingface.co/0xhikae/pleno_anonymize_ja/resolve/main/pleno_anonymize_ja-0.2.0-py3-none-any.whl",
-    "pleno_anonymize_en": "https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.2.0-py3-none-any.whl",
+    # 0.2.1 = tok2vec retrain mirroring the JA recipe (F1=0.973, ~35MB wheel).
+    # 0.2.0 was a transformer build that dragged in torch + spacy-transformers;
+    # bumping past it keeps the SDK slim.
+    "pleno_anonymize_en": "https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.2.1-py3-none-any.whl",
 }
 
 LANGUAGE_TO_MODEL: dict[Language, str] = {

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -64,17 +64,10 @@ def _init_presidio():
     # resolve via spaCy entry_point lookup, not filesystem path.
     _nlp_ja = spacy.load("pleno_anonymize_ja")
 
-    # pleno_anonymize_en v0.2.0 is transformer-based and inflates the image
-    # past fly's 8GB rootfs limit (torch + nvidia CUDA libs). Server image
-    # ships the lightweight tok2vec en_ner_en-0.1.0 instead; SDK users still
-    # get pleno_anonymize_en via the auto-download path.
     try:
         _nlp_en = spacy.load("pleno_anonymize_en")
     except OSError:
-        try:
-            _nlp_en = spacy.load("en_ner_en")
-        except OSError:
-            _nlp_en = None
+        _nlp_en = None
 
     models = {"ja": _nlp_ja}
     if _nlp_en is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -2539,7 +2539,7 @@ wheels = [
 
 [[package]]
 name = "pleno-anonymize"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "presidio-analyzer" },


### PR DESCRIPTION
## Summary

#176 published the EN supervised v2 as a transformer-pipeline wheel (438MB + torch + spacy-transformers), which forced #177 to roll the server image back to the legacy \`en_ner_en-0.1.0\` because the resulting image was 15.74GB (fly's rootfs limit is 8GB).

The actual fix: the JA-recipe tok2vec EN model already existed at \`packages/training/output/en/model-best\` (F1=0.973, 55MB on disk, pipeline=['tok2vec','ner'] mirroring JA). It just hadn't been packaged and uploaded — the heavier \`output/en-transformer/\` got published instead.

This PR packages and ships the tok2vec build:

- Repackaged \`output/en/model-best\` as \`pleno_anonymize_en-0.2.1\` (~35MB wheel)
- Uploaded to https://huggingface.co/0xhikae/pleno_anonymize_en (alongside the existing 0.2.0)
- SDK \`MODEL_WHEELS[\"pleno_anonymize_en\"]\` → 0.2.1 URL
- SDK version bump → 0.2.3
- \`Dockerfile\`: install \`pleno_anonymize_en-0.2.1\`, drop \`en_ner_en-0.1.0.tar.gz\`
- \`Dockerfile\`: build-time smoke loads \`pleno_anonymize_en\`
- \`server/src/app.py\`: drop the \`en_ner_en\` try/except fallback (#177's triage)

## Trade-off

F1 0.973 (tok2vec) vs 0.980 (transformer) — 0.007 F1 isn't worth 9x footprint and torch+CUDA. Mirrors the JA model's tok2vec design.

## Test plan

- [ ] CI green (check / scan / test / sdk)
- [ ] Docker build smoke: \`spacy.load('pleno_anonymize_ja')\` and \`spacy.load('pleno_anonymize_en')\` both succeed
- [ ] Image size verify under 7GB threshold
- [ ] Fly deploy succeeds, \`/health\` ok, JA + EN analyze return PERSON entities
- [ ] After merge, tag \`sdk/v0.2.3\` → PyPI publish (subject to flatt.tech min-age for downstream consumers)