### PR TITLE
docs(bench-en): re-eval v0.2.1 tok2vec on CoNLL + 300k-en

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ backend-agnostic.
 
 ### Quality
 
-Both models are spaCy tok2vec NER trained on `ai4privacy/pii-masking-300k` (EN) and `0xhikae/pii-masking-300k-ja` (JA). In-distribution F1 ≈ 0.96–0.97; on real-text news (CoNLL-2003 EN, stockmark JP Wikipedia) F1 drops to ≈ 0.47 — the models are tuned for form-/record-style PII, not narrative prose. For higher recall on English prose, use the `openai-privacy-filter` engine. Full numbers, CIs, and methodology: [`docs/benchmark-pleno-anonymize-en.md`](docs/benchmark-pleno-anonymize-en.md), [`docs/benchmark-pleno-anonymize-ja.md`](docs/benchmark-pleno-anonymize-ja.md).
+Both models are spaCy tok2vec NER trained on `ai4privacy/pii-masking-300k` (EN) and `0xhikae/pii-masking-300k-ja` (JA). In-distribution F1 ≈ 0.96–0.97; on real-text news (CoNLL-2003 EN F1 ≈ 0.57, stockmark JP Wikipedia F1 ≈ 0.47) the models trail spaCy's `*_core_web_lg` baselines because they are tuned for form-/record-style PII, not narrative prose. For higher recall on English prose, use the `openai-privacy-filter` engine. Full numbers, CIs, and methodology: [`docs/benchmark-pleno-anonymize-en.md`](docs/benchmark-pleno-anonymize-en.md), [`docs/benchmark-pleno-anonymize-ja.md`](docs/benchmark-pleno-anonymize-ja.md).
 
 ## Detected entities
 

--- a/docs/benchmark-pleno-anonymize-en.md
+++ b/docs/benchmark-pleno-anonymize-en.md
@@ -2,62 +2,62 @@
 
 Released at [`0xhikae/pleno_anonymize_en`](https://huggingface.co/0xhikae/pleno_anonymize_en).
 
-> **Note — version mismatch:** this document describes the **v0.2.0 transformer**
-> build (`distilbert-base-uncased`, 418MB wheel). The currently-shipped artifact
-> is **v0.2.1 tok2vec** (~35MB wheel, mirrors the JA recipe; training-time
-> F1=0.973 on the same EN val split). Real-text re-eval against CoNLL-2003 is
-> pending — until then, treat the real-text numbers below as upper bounds for
-> v0.2.1 (tok2vec typically trails transformer slightly on cross-domain prose).
-
 EN counterpart of [`pleno_anonymize_ja`](./benchmark-pleno-anonymize-ja.md).
 Same recipe template, same eval protocol, same honest-reading guarantees —
 read the JP benchmark doc first if you want the protocol rationale; this
 doc only reports EN numbers and the diff from JP.
 
+Current shipped artifact: **v0.2.1 tok2vec** (~35MB wheel, no torch /
+spacy-transformers). Earlier v0.2.0 was a transformer build that pushed
+the server image past fly.io's 8GB rootfs limit and was replaced by the
+tok2vec retrain that mirrors the JA recipe.
+
 ## TL;DR
 
-| Eval set | F1 | Seed-42 CI 95% | Smoke ≥ 0.50 | Parity ≥ 0.82 |
+| Eval set | F1 | CI 95% | Smoke ≥ 0.50 | Parity ≥ 0.82 |
 |---|---:|---|:---:|:---:|
-| In-dist (ai4privacy/pii-masking-300k EN val, 300 docs) | **0.968** | — | ✅ | ✅ |
-| **Real text (CoNLL-2003 test, PII subset {PER, LOC}, 272 docs)** | **0.470** | [0.403, 0.542] | ❌ | ❌ |
-| Real text (CoNLL-2003 test, all 4 categories, 300 docs) | 0.432 | [0.359, 0.496] | ❌ | ❌ |
+| In-dist (ai4privacy/pii-masking-300k EN val) | **0.973** | — | ✅ | ✅ |
+| **Real text (CoNLL-2003 test, PII subset {PER, LOC}, 272 docs)** | **0.574** | [0.521, 0.624] | ✅ | ❌ |
+| Real text (CoNLL-2003 test, all 4 categories, 300 docs) | 0.561 | [0.511, 0.610] | ✅ | ❌ |
 
-**Honest reading:** Same shape as the JP card. In-distribution: dominates.
-**On real English news (CoNLL-2003 Reuters), it falls below Smoke.**
-spaCy `en_core_web_lg` beats it on the same real-text set (see baselines).
+**Honest reading:** In-distribution dominates as expected. On real
+English news (CoNLL-2003 Reuters) the tok2vec build now meets **Smoke**
+on both protocols (the prior transformer fell below 0.50). spaCy
+`en_core_web_lg` still wins the real-text PII subset (0.666 vs 0.574,
+−0.09 F1) — same domain-mismatch story as JP, but the gap has narrowed
+from the −0.20 we saw with the transformer.
 
 ## Methodology
 
-Char-IoU ≥ 0.5, label-agnostic. 1000-iter document-level bootstrap with
-fixed seed=42 for CIs. CoNLL-2003 ships token sequences with IOB2 tags;
-we reconstruct text by joining tokens with single spaces and derive char
-offsets from the join — the standard English detokenisation convention.
+Training: spaCy tok2vec + ner pipeline (mirroring the JA recipe), seed
+42, on the 29,908-row EN train split of `ai4privacy/pii-masking-300k`.
+The 28 fine-grained PII categories collapse to 5 super-classes
+(`PERSON`, `ADDRESS`, `ORGANIZATION`, `DATE_OF_BIRTH`, `BANK_ACCOUNT`)
+to match the SDK/server entity taxonomy. JP uses the same 5-class
+collapse.
 
-Training: 2 epochs, batch 16, lr 5e-5, fp16, seed 42 on
-`distilbert-base-uncased` (~66M params, lightweight EN-only) with the
-29,908-row EN train split of `ai4privacy/pii-masking-300k`. JP used
-`xlm-roberta-base` because it needs cross-lingual coverage; EN only needs
-English, so the smaller distilbert is the natural pick and the artefact
-is ~half the size.
+Real-text eval: char-IoU ≥ 0.5, label-agnostic, 1000-iter document-level
+bootstrap with fixed seed=42 for CIs. CoNLL-2003 ships token sequences
+with IOB2 tags; we reconstruct text by joining tokens with single spaces
+and derive char offsets from the join (standard English detokenisation).
+Label mapping: `PERSON → PER`, other tok2vec labels stay as-is.
 
 ## In-distribution evaluation
 
-Validation split of `ai4privacy/pii-masking-300k` filtered to `language == "English"`, 300 docs.
-
-| Model | F1 | P | R | Latency (CPU) |
-|---|---:|---:|---:|---:|
-| `builtin` v0.13.0 | 0.319 | 0.386 | 0.272 | 53 ms |
-| `openai-privacy-filter` v0.13.0 | 0.847 | 0.915 | 0.788 | 2.2 s |
-| **`pleno_anonymize_en` (seed 42)** | **0.968** | 0.955 | 0.982 | 19 ms |
+Validation split of `ai4privacy/pii-masking-300k` filtered to
+`language == "English"`. F1 = **0.973** (P = 0.972, R = 0.974) reported
+by spaCy's training-time scorer on the dev shard; see
+`packages/training/output/en/model-best/meta.json` for the raw payload.
 
 **Caveat:** the model was trained on the **train split** of the same
-dataset (`ai4privacy/pii-masking-300k`, language=English). Read this as
-"supervised fit on the methodology", not production performance.
+dataset, so this is a supervised-fit number, not a production estimate.
+Treat it as an upper bound.
 
 ## Real-text evaluation — CoNLL-2003
 
 Real English Reuters news with 4 entity categories: PER, ORG, LOC, MISC.
-First 300 test rows that contain ≥1 gold entity.
+First 300 test rows that contain ≥1 gold entity (dataset:
+`tomaarsen/conll2003`).
 
 Reported two ways: (a) all 4 categories, and (b) restricted to the
 **PII-relevant subset** `{PER, LOC}`. ORG and MISC are out of scope for a
@@ -67,21 +67,23 @@ PII NER by design.
 |---|---|---:|---|---:|---:|
 | **spaCy `en_core_web_lg`** | All 4 | **0.712** | [0.678, 0.746] | 0.611 | 0.852 |
 | spaCy `en_core_web_lg` | PII (PER+LOC) | 0.666 | [0.627, 0.704] | 0.542 | 0.863 |
-| **`pleno_anonymize_en`** | PII (PER+LOC) | **0.470** | [0.403, 0.542] | 0.682 | 0.358 |
-| `pleno_anonymize_en` | All 4 | 0.432 | [0.359, 0.496] | 0.702 | 0.312 |
+| **`pleno_anonymize_en` v0.2.1** | PII (PER+LOC) | **0.574** | [0.521, 0.624] | 0.675 | 0.499 |
+| `pleno_anonymize_en` v0.2.1 | All 4 | 0.561 | [0.511, 0.610] | 0.724 | 0.458 |
+| `pleno_anonymize_en` v0.2.0 (prior transformer) | PII (PER+LOC) | 0.470 | [0.403, 0.542] | 0.682 | 0.358 |
 
-**This model loses to spaCy by 0.20 F1 on the real-text PII subset.**
-Same shape as the JP result. It reflects:
+The tok2vec retrain trails `en_core_web_lg` by 0.09 F1 on the real-text
+PII subset (vs −0.20 for the prior transformer build). It reflects:
 
 1. **Domain mismatch.** Trained on form-/record-/chat-style PII text
    (ai4privacy generation methodology). CoNLL Reuters news is a very
    different distribution. The model favours precision (0.68) over
-   recall (0.36) because it was tuned on dense, fully-labelled PII
-   examples and is overly conservative on sparse news prose.
-2. **Schema mismatch.** Trained to find ~28 fine PII categories
-   (phones, emails, postcodes, ID numbers, addresses). CoNLL's `ORG`
-   and `MISC` overlap almost nothing with that schema. The PII-subset
-   numbers above already restrict to the overlap.
+   recall (0.50) because it was tuned on dense, fully-labelled PII
+   examples and is conservative on sparse news prose.
+2. **Schema mismatch.** Trained on the 5 PII super-classes
+   (PERSON, ADDRESS, ORGANIZATION, DATE_OF_BIRTH, BANK_ACCOUNT). CoNLL
+   `LOC` covers geopolitical entities (countries, cities) which our
+   `ADDRESS` class does not target; gold LOC entities under the
+   strict label match score as misses.
 3. **spaCy's home turf.** `en_core_web_lg` was trained on OntoNotes
    (news + web), and CoNLL Reuters is close in style.
 
@@ -90,37 +92,35 @@ chat/form/email.** That dataset doesn't exist publicly. Building one
 (~50–100 samples) is the highest-priority follow-up, identical to the
 JP card's open item.
 
-The CoNLL result should be read as: "on news prose, with a non-PII
-schema, this model trails spaCy". It is not a verdict on PII
-performance in production PII contexts.
+The CoNLL result should be read as: "on news prose, with a schema
+mismatch, this model trails spaCy by 0.09 F1". It is not a verdict on
+PII performance in production PII contexts.
 
 ## Acceptance tiers — final read
 
 | Tier | F1 floor | In-dist | Real (PII) | Real (full) |
 |---|---:|:---:|:---:|:---:|
-| Smoke | 0.50 | ✅ | ❌ | ❌ |
+| Smoke | 0.50 | ✅ | ✅ | ✅ |
 | Parity | 0.82 | ✅ | ❌ | ❌ |
 | Stretch | 0.88 | ✅ | ❌ | ❌ |
 
-**Smoke and Parity met in-distribution. Real-text performance is below
-Smoke even on PII-relevant categories.**
+**Smoke met across the board (was ❌ for real-text in v0.2.0). Parity
+still only met in-distribution.**
 
 Production deployment expectations should be calibrated to the
-real-text number (~0.47), not the in-distribution number (~0.97).
+real-text number (~0.57), not the in-distribution number (~0.97).
 
 ## Reproducibility
 
 All scripts in `packages/training/scripts/`:
-- `dump_pii_300k.py --language English` (re-dump the EN slice)
-- `train_supervised_300k_en.py` (seed pinned; distilbert default)
-- `eval_on_300k.py --dataset ai4privacy/pii-masking-300k --language English` (in-dist)
-- `eval_conll_en_real.py --dataset tomaarsen/conll2003` (real-text)
-- `eval_conll_en_spacy.py --model en_core_web_lg` (spaCy baseline)
+- `train_supervised_300k_en.py` (spaCy tok2vec, seed pinned)
+- `eval_conll_en_spacy.py --model pleno_anonymize_en --dataset tomaarsen/conll2003` (real-text)
+- `eval_conll_en_spacy.py --model en_core_web_lg --dataset tomaarsen/conll2003` (spaCy baseline)
+- `package_anonymize_model.py --model output/en/model-best --language en --version 0.2.1 --build-wheel` (build wheel)
 
 Run via Makefile:
 
 ```bash
-make -C packages/training dump-supervised-en
 make -C packages/training train-supervised-en          # RunPod GPU recommended
 make -C packages/training eval-300k-en
 ```


### PR DESCRIPTION
## Summary

Follow-up to #181: re-ran the EN benchmark suite against the shipped v0.2.1 tok2vec build and updated \`docs/benchmark-pleno-anonymize-en.md\` so the numbers match the deployed model.

**Real-text (CoNLL-2003 test, 300 docs, \`tomaarsen/conll2003\` mirror):**

| Subset | F1 | 95% CI | P | R |
|---|---:|---|---:|---:|
| PII (PER+LOC) | **0.574** | [0.521, 0.624] | 0.675 | 0.499 |
| All 4 cats | 0.561 | [0.511, 0.610] | 0.724 | 0.458 |

Prior transformer v0.2.0 was 0.470 / 0.432. The tok2vec retrain now meets **Smoke (≥0.50) on real text** (was ❌) and narrows the gap to \`en_core_web_lg\` (0.666 PII subset) from −0.20 → −0.09 F1.

**In-distribution:** F1 = 0.973 (spaCy training-time scorer on the EN val shard; raw payload in \`packages/training/output/en/model-best/meta.json\`).

**Baseline:** \`en_core_web_lg\` re-confirmed at PII F1 = 0.666 (matches the prior figure — sanity check passes).

Doc changes:
- Drop the \"v0.2.0 vs v0.2.1 mismatch\" top note added in #182 — body now describes v0.2.1 directly
- Methodology section rewritten for the spaCy tok2vec recipe + 5 PII super-class collapse, replacing the distilbert / HF training description
- Acceptance tiers — Smoke now ✅ across all three eval sets
- README \"Quality\" paragraph: EN real-text figure 0.47 → 0.57

## Test plan

- [ ] CI green (docs-only)