### PR TITLE
docs: use canonical pleno-dlp URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Japanese-first PII analysis and redaction. The repository ships three artifacts 
 Endpoint: https://pleno-anonymize.fly.dev (API reference at `/docs`).
 Playground: https://plenoai.com/pleno-anonymize/playground
 
-For scanning SaaS sources or filesystems for PII, use [`pleno-dlp`](https://github.com/plenoai/pleno-secret-scanner) — it talks to this server's `/api/analyze` endpoint over HTTP.
+For scanning SaaS sources or filesystems for PII, use [`pleno-dlp`](https://github.com/plenoai/pleno-dlp) — it talks to this server's `/api/analyze` endpoint over HTTP.
 
 ## Use the CLI
 


### PR DESCRIPTION
README の pleno-dlp リンクが旧名 `plenoai/pleno-secret-scanner` を指していた(rename redirect で動作はするが non-canonical)。canonical な `plenoai/pleno-dlp` に修正。

design-docs の pleno egress thesis 執筆中に発見。