### PR TITLE
chore: track AGENTS.md agent config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+pleno-anonymizeは、個人情報を匿名化するためのサービスです
+適宜pushしてバージョン管理すること
+use runpod for training (use runpod mcp: `mcp__runpod__*` — `create-pod`, `start-pod`, `get-pod`, `delete-pod`, etc.)
+do not train on local machine


### PR DESCRIPTION
リポジトリ直下に未追跡で存在していた `AGENTS.md`(agent 設定: サービス説明 / push 運用 / RunPod 学習指示)を正式に追跡。working tree を clean に戻す。