### PR TITLE
chore: add pip ecosystem to dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- `.github/dependabot.yaml` が `github-actions` のみを対象としていたため、Pythonパッケージの依存関係更新が自動化されていませんでした
- `pip` エコシステムを追加し、`pyproject.toml` / `uv.lock` の脆弱性に対して Dependabot が自動PRを作成できるようにしました

## 背景

現在 9 件の open security alert があります:
- `langsmith` / `langchain-classic` (high): public prompt deserialization
- `urllib3` x2 (high): header forwarding / decompression bomb
- `idna` (medium): CVE-2024-3651 bypass
- `unhead` (medium): hasDangerousProtocol bypass
- `transformers` x2 (medium): arbitrary code execution in Trainer
- `Pygments` (low): ReDoS

この PR により Dependabot が週次で脆弱性修正 PR を自動生成するようになります。

## Test plan

- [ ] PR マージ後に Dependabot が pip エコシステムに対して PR を作成することを確認