### PR TITLE
fix(server): resolve code scanning alerts (SSRF + stack-trace exposure)

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -5,8 +5,11 @@ import json
 import base64
 import binascii
 import io
+import ipaddress
+import socket
 import time
 import uuid
+from urllib.parse import urlsplit
 from contextlib import asynccontextmanager
 from functools import lru_cache, partial
 from typing import List, Optional, Dict, Any, Tuple
@@ -226,7 +229,7 @@ async def readiness():
     except Exception as e:
         logger.error(json.dumps({"event": "readiness_check_failed", "error": str(e)}))
         return Response(
-            content=json.dumps({"status": "not_ready", "error": str(e)}),
+            content=json.dumps({"status": "not_ready"}),
             status_code=503,
             media_type="application/json",
         )
@@ -463,12 +466,62 @@ def deanonymize_text(text: str, mapping: Dict[str, str]) -> str:
     return result
 
 
+def _is_disallowed_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Reject any address that could reach internal/cloud-metadata infrastructure."""
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+        # IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) must be unwrapped and re-checked.
+        or (isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None
+            and _is_disallowed_ip(ip.ipv4_mapped))
+    )
+
+
+def _assert_fetchable_url(image_url: str) -> None:
+    """SSRF guard: only allow http(s) URLs whose every resolved IP is public.
+
+    Raises HTTPException(400) on any violation. Validating *all* getaddrinfo
+    results blocks direct internal targets (localhost, RFC1918, 169.254.169.254,
+    etc.). httpx clients here use the default follow_redirects=False, so a
+    validated host cannot be bounced to an internal one via a 3xx redirect.
+    """
+    parts = urlsplit(image_url)
+    if parts.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="Unsupported image URL scheme")
+
+    host = parts.hostname
+    if not host:
+        raise HTTPException(status_code=400, detail="Invalid image URL host")
+
+    try:
+        infos = socket.getaddrinfo(host, parts.port or None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise HTTPException(status_code=400, detail="Image URL host could not be resolved")
+
+    addrs = {info[4][0] for info in infos}
+    if not addrs:
+        raise HTTPException(status_code=400, detail="Image URL host could not be resolved")
+
+    for addr in addrs:
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid resolved image URL address")
+        if _is_disallowed_ip(ip):
+            raise HTTPException(status_code=400, detail="Image URL resolves to a disallowed address")
+
+
 async def redact_image(image_url: str, http_client: httpx.AsyncClient) -> str:
     if image_url.startswith("data:"):
         header, data = image_url.split(",", 1)
         image_bytes = base64.b64decode(data)
         mime_type = header.split(";")[0].split(":")[1] if ":" in header else "image/png"
     else:
+        _assert_fetchable_url(image_url)
         response = await http_client.get(image_url)
         response.raise_for_status()
         image_bytes = response.content

--- a/server/tests/test_ssrf_guard.py
+++ b/server/tests/test_ssrf_guard.py
@@ -1,0 +1,85 @@
+"""SSRF guard for remote image fetching and exception-detail hygiene.
+
+`_assert_fetchable_url` must reject any URL whose scheme is not http(s) or
+whose host resolves to a non-public address (loopback, RFC1918, link-local
+cloud-metadata, IPv4-mapped IPv6, etc.). These cover the `py/full-ssrf`
+finding on `redact_image` without needing the network or NER model.
+"""
+
+import ipaddress
+import socket
+
+import pytest
+from fastapi import HTTPException
+
+import src.app as app_module
+
+
+def _patch_resolve(monkeypatch, ip: str) -> None:
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port or 0))]
+
+    monkeypatch.setattr(app_module.socket, "getaddrinfo", fake_getaddrinfo)
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",       # loopback
+        "10.0.0.5",        # RFC1918
+        "192.168.1.1",     # RFC1918
+        "169.254.169.254", # cloud metadata link-local
+        "::1",             # IPv6 loopback
+        "::ffff:127.0.0.1",  # IPv4-mapped IPv6 loopback
+        "0.0.0.0",         # unspecified
+    ],
+)
+def test_rejects_private_and_internal_targets(monkeypatch, ip) -> None:
+    _patch_resolve(monkeypatch, ip)
+    with pytest.raises(HTTPException) as exc:
+        app_module._assert_fetchable_url("https://evil.example.com/a.png")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://x/", "ftp://x/a"])
+def test_rejects_non_http_schemes(monkeypatch, url) -> None:
+    _patch_resolve(monkeypatch, "1.1.1.1")
+    with pytest.raises(HTTPException) as exc:
+        app_module._assert_fetchable_url(url)
+    assert exc.value.status_code == 400
+
+
+def test_allows_public_address(monkeypatch) -> None:
+    _patch_resolve(monkeypatch, "1.1.1.1")  # public, globally routable
+    app_module._assert_fetchable_url("https://images.example.com/cat.png")
+
+
+def test_rejects_unresolvable_host(monkeypatch) -> None:
+    def boom(*args, **kwargs):
+        raise socket.gaierror("nope")
+
+    monkeypatch.setattr(app_module.socket, "getaddrinfo", boom)
+    with pytest.raises(HTTPException) as exc:
+        app_module._assert_fetchable_url("https://nope.invalid/a.png")
+    assert exc.value.status_code == 400
+
+
+def test_is_disallowed_ip_unwraps_mapped_metadata() -> None:
+    mapped = ipaddress.ip_address("::ffff:169.254.169.254")
+    assert app_module._is_disallowed_ip(mapped) is True
+
+
+def test_readiness_failure_hides_exception_detail(monkeypatch) -> None:
+    from fastapi.testclient import TestClient
+
+    def boom() -> None:
+        raise RuntimeError("secret model path /srv/internal/weights.bin")
+
+    monkeypatch.setattr(app_module, "_init_presidio", boom)
+    client = TestClient(app_module.app)
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body == {"status": "not_ready"}
+    assert "secret model path" not in resp.text


### PR DESCRIPTION
Address the two open CodeQL alerts on server/src/app.py:

- py/full-ssrf (critical): redact_image() fetched arbitrary user-supplied
  image URLs. Add _assert_fetchable_url() guard that allows only http(s)
  schemes and rejects any host resolving to a non-public address (loopback,
  RFC1918, link-local cloud metadata 169.254.169.254, IPv4-mapped IPv6,
  reserved/multicast/unspecified). httpx clients keep the default
  follow_redirects=False, so a validated host cannot be bounced internally.

- py/stack-trace-exposure (medium): /ready returned str(e) in the response
  body. Keep logging the error server-side, but return only
  {"status": "not_ready"} to the client.

Add tests covering internal-target rejection, scheme rejection, public
allow, unresolvable host, IPv4-mapped metadata, and readiness hygiene.
