### PR TITLE
fix(sdk/ja): replace \b word boundaries with digit/letter lookarounds

### DIFF
--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -44,7 +44,9 @@ JA_MY_NUMBER = PiiRecognizer(
     entity="MY_NUMBER",
     language="ja",
     patterns=(
-        PiiPattern("my_number_spaced", r"(?<!\d)\d{4}[ 　\-]\d{4}[ 　\-]\d{4}(?!\d)", 0.5),
+        PiiPattern(
+            "my_number_spaced", r"(?<!\d)\d{4}[ 　\-]\d{4}[ 　\-]\d{4}(?!\d)", 0.5
+        ),
         PiiPattern("my_number_continuous", r"(?<!\d)\d{12}(?!\d)", 0.3),
     ),
     context=("マイナンバー", "個人番号", "my number", "通知カード"),
@@ -73,7 +75,9 @@ JA_CREDIT_CARD = PiiRecognizer(
 JA_PASSPORT = PiiRecognizer(
     entity="PASSPORT",
     language="ja",
-    patterns=(PiiPattern("ja_passport", r"(?<![A-Za-z])[A-Z]{2}\d{7}(?!\d)", 0.4),),
+    patterns=(
+        PiiPattern("ja_passport", r"(?<![A-Za-z])[A-Z]{2}\d{7}(?![A-Za-z0-9])", 0.4),
+    ),
     context=("パスポート", "旅券", "passport", "旅券番号"),
 )
 
@@ -155,7 +159,11 @@ JA_HEALTH_INSURANCE = PiiRecognizer(
 JA_RESIDENCE_CARD = PiiRecognizer(
     entity="RESIDENCE_CARD",
     language="ja",
-    patterns=(PiiPattern("residence_card", r"(?<![A-Za-z])[A-Z]{2}\d{8}[A-Z]{2}(?![A-Za-z])", 0.6),),
+    patterns=(
+        PiiPattern(
+            "residence_card", r"(?<![A-Za-z])[A-Z]{2}\d{8}[A-Z]{2}(?![A-Za-z])", 0.6
+        ),
+    ),
     context=("在留カード", "在留番号", "residence card", "在留資格"),
 )
 

--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -44,8 +44,8 @@ JA_MY_NUMBER = PiiRecognizer(
     entity="MY_NUMBER",
     language="ja",
     patterns=(
-        PiiPattern("my_number_spaced", r"\b\d{4}[ 　\-]\d{4}[ 　\-]\d{4}\b", 0.5),
-        PiiPattern("my_number_continuous", r"\b\d{12}\b", 0.3),
+        PiiPattern("my_number_spaced", r"(?<!\d)\d{4}[ 　\-]\d{4}[ 　\-]\d{4}(?!\d)", 0.5),
+        PiiPattern("my_number_continuous", r"(?<!\d)\d{12}(?!\d)", 0.3),
     ),
     context=("マイナンバー", "個人番号", "my number", "通知カード"),
 )
@@ -57,12 +57,12 @@ JA_CREDIT_CARD = PiiRecognizer(
     patterns=(
         PiiPattern(
             "credit_card_dashed",
-            r"\b\d{4}[ 　\-]\d{4}[ 　\-]\d{4}[ 　\-]\d{4}\b",
+            r"(?<!\d)\d{4}[ 　\-]\d{4}[ 　\-]\d{4}[ 　\-]\d{4}(?!\d)",
             0.6,
         ),
         PiiPattern(
             "credit_card_continuous",
-            r"\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))\d{8,12}\b",
+            r"(?<!\d)(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))\d{8,12}(?!\d)",
             0.5,
         ),
     ),
@@ -73,7 +73,7 @@ JA_CREDIT_CARD = PiiRecognizer(
 JA_PASSPORT = PiiRecognizer(
     entity="PASSPORT",
     language="ja",
-    patterns=(PiiPattern("ja_passport", r"\b[A-Z]{2}\d{7}\b", 0.4),),
+    patterns=(PiiPattern("ja_passport", r"(?<![A-Za-z])[A-Z]{2}\d{7}(?!\d)", 0.4),),
     context=("パスポート", "旅券", "passport", "旅券番号"),
 )
 
@@ -81,7 +81,7 @@ JA_PASSPORT = PiiRecognizer(
 JA_DRIVER_LICENSE = PiiRecognizer(
     entity="DRIVER_LICENSE",
     language="ja",
-    patterns=(PiiPattern("ja_driver_license", r"\b\d{12}\b", 0.2),),
+    patterns=(PiiPattern("ja_driver_license", r"(?<!\d)\d{12}(?!\d)", 0.2),),
     context=("運転免許", "免許証", "免許番号", "driver license"),
 )
 
@@ -92,7 +92,7 @@ JA_IP_ADDRESS = PiiRecognizer(
     patterns=(
         PiiPattern(
             "ipv4",
-            r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b",
+            r"(?<!\d)(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)(?!\d)",
             0.6,
         ),
     ),
@@ -106,7 +106,7 @@ JA_EMAIL = PiiRecognizer(
     patterns=(
         PiiPattern(
             "email",
-            r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\b",
+            r"(?<![a-zA-Z0-9._%+\-])[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}(?![a-zA-Z])",
             0.9,
         ),
     ),
@@ -120,10 +120,10 @@ JA_CORPORATE_NUMBER = PiiRecognizer(
     patterns=(
         PiiPattern(
             "corporate_number_spaced",
-            r"\b\d[ 　\-]\d{4}[ 　\-]\d{4}[ 　\-]\d{4}\b",
+            r"(?<!\d)\d[ 　\-]\d{4}[ 　\-]\d{4}[ 　\-]\d{4}(?!\d)",
             0.5,
         ),
-        PiiPattern("corporate_number_continuous", r"\b\d{13}\b", 0.3),
+        PiiPattern("corporate_number_continuous", r"(?<!\d)\d{13}(?!\d)", 0.3),
     ),
     context=("法人番号", "法人マイナンバー", "corporate number"),
 )
@@ -133,7 +133,7 @@ JA_HEALTH_INSURANCE = PiiRecognizer(
     entity="HEALTH_INSURANCE",
     language="ja",
     patterns=(
-        PiiPattern("insurer_number", r"\b\d{8}\b", 0.1),
+        PiiPattern("insurer_number", r"(?<!\d)\d{8}(?!\d)", 0.1),
         PiiPattern(
             "insurance_symbol_number",
             r"記号[ 　]*\d{1,6}[ 　]*番号[ 　]*\d{1,7}",
@@ -155,7 +155,7 @@ JA_HEALTH_INSURANCE = PiiRecognizer(
 JA_RESIDENCE_CARD = PiiRecognizer(
     entity="RESIDENCE_CARD",
     language="ja",
-    patterns=(PiiPattern("residence_card", r"\b[A-Z]{2}\d{8}[A-Z]{2}\b", 0.6),),
+    patterns=(PiiPattern("residence_card", r"(?<![A-Za-z])[A-Z]{2}\d{8}[A-Z]{2}(?![A-Za-z])", 0.6),),
     context=("在留カード", "在留番号", "residence card", "在留資格"),
 )
 
@@ -165,7 +165,7 @@ JA_POSTAL_CODE = PiiRecognizer(
     language="ja",
     patterns=(
         PiiPattern("postal_code_with_symbol", r"〒\d{3}[‐\-ー]\d{4}", 0.9),
-        PiiPattern("postal_code_half", r"\b\d{3}[‐\-ー]\d{4}\b", 0.3),
+        PiiPattern("postal_code_half", r"(?<!\d)\d{3}[‐\-ー]\d{4}(?!\d)", 0.3),
         PiiPattern("postal_code_fullwidth", r"〒[０-９]{3}[‐\-ー－−][０-９]{4}", 0.9),
     ),
     context=("郵便番号", "〒", "zip", "postal"),


### PR DESCRIPTION
## Summary

Fixes #205

Python's `re` treats CJK characters (kanji, hiragana, katakana) as `\w`, so `\b` between a CJK character and an ASCII digit is **never** a word boundary.  This caused every JA numeric-ID pattern (My Number, credit card, driver license, etc.) to silently miss PII embedded in Japanese prose.

**Reproduced before fix:**
```python
import re
assert re.search(r"\b\d{12}\b", "マイナンバーは123456789012です") is None  # True — bug
```

**After fix:**
```python
assert re.search(r"(?<!\d)\d{12}(?!\d)", "マイナンバーは123456789012です") is not None  # True
```

## Changes

All `\b` anchors in JA recognizer patterns are replaced with appropriate lookarounds:

| Pattern type | Old | New |
|---|---|---|
| Pure numeric (`\d…`) | `\b` → `(?<!\d)` / `(?!\d)` | prevents false-positives on longer digit runs |
| Letter-prefix (`[A-Z]{2}…`) | `\b` → `(?<![A-Za-z])` | passport, residence card |
| Email | `\b` before/after | `(?<![a-zA-Z0-9._%+\-])` / `(?![a-zA-Z])` |

Phone-number patterns already used `(?<!\d)` / `(?!\d)` correctly; no change needed there.

## Test plan
- [ ] `pytest packages/sdk/` — existing tests pass
- [ ] Manual: `マイナンバーは123456789012です` → `MY_NUMBER` detected with `language="ja"`
- [ ] Manual: `カード番号1234-5678-9012-3456を入力` → `CREDIT_CARD` detected
- [ ] Manual: `住所は150-0002東京都渋谷区` → `POSTAL_CODE` detected