### PR TITLE
fix(server): fail-closed on image redaction errors

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -612,8 +612,9 @@ async def redact_openai_request(
                                     "detail"
                                 ]
                             redacted_parts.append(redacted_part)
-                        except Exception:
-                            redacted_parts.append(part)
+                        except Exception as e:
+                            logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
+                            raise HTTPException(status_code=500, detail="image redaction failed")
                     else:
                         redacted_parts.append(part)
                 else:
@@ -711,8 +712,9 @@ async def redact_anthropic_request(
                                     "data": redacted_data,
                                 }
                                 redacted_parts.append(redacted_part)
-                            except Exception:
-                                redacted_parts.append(part)
+                            except Exception as e:
+                                logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
+                                raise HTTPException(status_code=500, detail="image redaction failed")
                         else:
                             redacted_parts.append(part)
                     else:
@@ -843,8 +845,9 @@ async def redact_responses_api_request(
                                     redacted_part = part.copy()
                                     redacted_part["image_url"] = redacted_url
                                     redacted_parts.append(redacted_part)
-                                except Exception:
-                                    redacted_parts.append(part)
+                                except Exception as e:
+                                    logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
+                                    raise HTTPException(status_code=500, detail="image redaction failed")
                             else:
                                 redacted_parts.append(part)
                         else:
@@ -956,8 +959,9 @@ async def redact_gemini_request(
                                     "data": redacted_data,
                                 }
                                 redacted_parts.append(redacted_part)
-                            except Exception:
-                                redacted_parts.append(part)
+                            except Exception as e:
+                                logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
+                                raise HTTPException(status_code=500, detail="image redaction failed")
                         else:
                             redacted_parts.append(part)
                     else:

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -613,8 +613,14 @@ async def redact_openai_request(
                                 ]
                             redacted_parts.append(redacted_part)
                         except Exception as e:
-                            logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
-                            raise HTTPException(status_code=500, detail="image redaction failed")
+                            logger.error(
+                                json.dumps(
+                                    {"event": "image_redaction_failed", "error": str(e)}
+                                )
+                            )
+                            raise HTTPException(
+                                status_code=500, detail="image redaction failed"
+                            )
                     else:
                         redacted_parts.append(part)
                 else:
@@ -713,8 +719,17 @@ async def redact_anthropic_request(
                                 }
                                 redacted_parts.append(redacted_part)
                             except Exception as e:
-                                logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
-                                raise HTTPException(status_code=500, detail="image redaction failed")
+                                logger.error(
+                                    json.dumps(
+                                        {
+                                            "event": "image_redaction_failed",
+                                            "error": str(e),
+                                        }
+                                    )
+                                )
+                                raise HTTPException(
+                                    status_code=500, detail="image redaction failed"
+                                )
                         else:
                             redacted_parts.append(part)
                     else:
@@ -846,8 +861,17 @@ async def redact_responses_api_request(
                                     redacted_part["image_url"] = redacted_url
                                     redacted_parts.append(redacted_part)
                                 except Exception as e:
-                                    logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
-                                    raise HTTPException(status_code=500, detail="image redaction failed")
+                                    logger.error(
+                                        json.dumps(
+                                            {
+                                                "event": "image_redaction_failed",
+                                                "error": str(e),
+                                            }
+                                        )
+                                    )
+                                    raise HTTPException(
+                                        status_code=500, detail="image redaction failed"
+                                    )
                             else:
                                 redacted_parts.append(part)
                         else:
@@ -960,8 +984,17 @@ async def redact_gemini_request(
                                 }
                                 redacted_parts.append(redacted_part)
                             except Exception as e:
-                                logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
-                                raise HTTPException(status_code=500, detail="image redaction failed")
+                                logger.error(
+                                    json.dumps(
+                                        {
+                                            "event": "image_redaction_failed",
+                                            "error": str(e),
+                                        }
+                                    )
+                                )
+                                raise HTTPException(
+                                    status_code=500, detail="image redaction failed"
+                                )
                         else:
                             redacted_parts.append(part)
                     else:


### PR DESCRIPTION
## Summary

Fixes #210

All four image-part handling paths in the proxy functions (`redact_openai_request`, `redact_anthropic_request`, `redact_responses_api_request`, `redact_gemini_request`) silently forwarded the original unredacted image to the upstream LLM on any exception from `redact_image`.

```python
# Before — fail-open: PII leak on every transient error
except Exception:
    redacted_parts.append(part)  # original unredacted image forwarded

# After — fail-closed
except Exception as e:
    logger.error(json.dumps({"event": "image_redaction_failed", "error": str(e)}))
    raise HTTPException(status_code=500, detail="image redaction failed")
```

**Why HTTP 500 rather than silently dropping the image?**  
Dropping images silently would change request semantics (the upstream LLM now answers without context it was supposed to have) without the caller knowing. A 500 gives the caller a clear signal to retry or handle the error. Both dropping and failing are "fail-closed" relative to the PII leak — failing the request is chosen here because it's unambiguous.

## Affected locations

| Line | Proxy | Image format |
|---|---|---|
| 615 | OpenAI chat | `image_url` |
| 714 | Anthropic | base64 `source` |
| 846 | Responses API | `input_image` |
| 959 | Gemini | `inline_data` |

## Test plan
- [ ] Send a request with an image that causes `redact_image` to throw (e.g. malformed base64) → expect HTTP 500, no PII forwarded
- [ ] Send a request with a valid image → still redacted and forwarded correctly
- [ ] Check structured log output contains `image_redaction_failed` event