### PR TITLE
fix(server): auto-detect language in proxy redaction

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -441,10 +441,25 @@ GEMINI_API_BASE = os.getenv(
 _placeholder_counter: itertools.count = itertools.count(0)
 
 
+def _detect_language(text: str) -> str:
+    """Heuristic: return 'ja' when Japanese script characters are present, else 'en'."""
+    for ch in text:
+        cp = ord(ch)
+        if (
+            0x3040 <= cp <= 0x30FF  # Hiragana + Katakana
+            or 0x4E00 <= cp <= 0x9FFF  # CJK Unified Ideographs (basic)
+            or 0x3400 <= cp <= 0x4DBF  # CJK Extension A
+        ):
+            return "ja"
+    return "en"
+
+
 def redact_text_with_mapping(
-    text: str, language: str = "en"
+    text: str, language: str | None = None
 ) -> Tuple[str, Dict[str, str]]:
     """Redact PII from text and return mapping for de-anonymization."""
+    if language is None:
+        language = _detect_language(text)
     results = _cached_analyze(text=text, language=language)
 
     # Sort by start position descending to replace from end


### PR DESCRIPTION
## Summary

Fixes #209

Every proxy call site (`redact_openai_request`, `redact_anthropic_request`, `redact_responses_api_request`, `redact_gemini_request`) called `redact_text_with_mapping(content)` with no `language` argument. The default was `"en"`, so Japanese PII in proxy traffic was **never redacted** — all JA recognizers are registered under `language="ja"` and Presidio routes recognizers by language.

## Changes

**`_detect_language(text)`** — new internal helper (no new dependencies).  
Scans the text for Hiragana (U+3040–U+30FF), Katakana, and CJK Unified Ideographs (U+3400–U+9FFF). Returns `"ja"` on first match, `"en"` otherwise. For typical proxy traffic this is O(n) on the first Japanese character, which is fast.

**`redact_text_with_mapping`** — signature changed from `language: str = "en"` to `language: str | None = None`. Calls `_detect_language()` when `language` is `None`. Explicit `language=` from callers (the `/api/analyze` and `/api/redact` endpoints) still takes precedence.

## Limitations / future work

This heuristic does not handle mixed-language documents — a mostly-English text with one Japanese sentence will run the JA pipeline. In practice this is safer than the previous behavior (running EN on fully Japanese text). A proper multi-language Presidio setup (running both analyzers and merging) would be the ideal follow-up.

## Test plan
- [ ] Send Japanese text through a proxy endpoint without explicit `language=` → JA PII redacted
- [ ] Send English text through a proxy endpoint → EN PII still redacted, no regression
- [ ] `_detect_language("マイナンバーは...")` returns `"ja"`
- [ ] `_detect_language("My name is...")` returns `"en"`
- [ ] Existing `/api/analyze` and `/api/redact` with explicit `language="en"` still works