### PR TITLE
fix(ci): set skip_export=true when dry-run and artifact is absent

### DIFF
--- a/.github/workflows/release-model.yml
+++ b/.github/workflows/release-model.yml
@@ -107,6 +107,7 @@ jobs:
           if [ "$DRY_RUN" = "true" ]; then
             echo "::warning::$full not present; dry-run continues without artifact"
             echo "artifact_present=false" >> "$GITHUB_OUTPUT"
+            echo "skip_export=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Fixes #220

The release-model workflow's verify step set `artifact_present=false` for dry-run + no artifact, but omitted `skip_export=true`. The export step's gate is `if: steps.verify.outputs.skip_export != 'true'`, so the gate was not engaged and `export_onnx.py` ran — immediately crashing because `packages/training/output/` is gitignored (no model present in CI checkout).

## Change

One line added in the `DRY_RUN=true` + artifact-absent branch:

```diff
+ echo "skip_export=true" >> "$GITHUB_OUTPUT"
```

This matches the pattern already used in the HF-Hub-present branch (line 127) where `skip_export=true` is correctly set.

## Test plan
- [ ] Trigger `workflow_dispatch` with `dry_run: true` → workflow completes without crashing at the export step
- [ ] Trigger normal (non-dry-run) release with artifact present → export step still runs normally