### PR TITLE
fix(server): use global counter for placeholder keys to prevent collision

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import itertools
 import logging
 import os
 import json
@@ -437,6 +438,9 @@ GEMINI_API_BASE = os.getenv(
 )
 
 
+_placeholder_counter: itertools.count = itertools.count(0)
+
+
 def redact_text_with_mapping(
     text: str, language: str = "en"
 ) -> Tuple[str, Dict[str, str]]:
@@ -451,7 +455,12 @@ def redact_text_with_mapping(
 
     for r in results_sorted:
         original = text[r.start : r.end]
-        placeholder = f"<{r.entity_type}_{r.start}>"
+        # Use a global counter so placeholders are unique across all texts in
+        # a single proxy request.  A key of (entity_type, offset) collides when
+        # two different messages contain the same entity type at the same byte
+        # offset, causing combined_mapping.update() to silently overwrite the
+        # first value and restore the wrong PII in the response.
+        placeholder = f"<{r.entity_type}_{next(_placeholder_counter)}>"
         mapping[placeholder] = original
         redacted_text = redacted_text[: r.start] + placeholder + redacted_text[r.end :]
 


### PR DESCRIPTION
## Summary

Fixes #211

When a proxy request contained two messages that both had an entity of the same type at the same byte offset (e.g. two `PERSON` spans at offset 0), `combined_mapping.update(mapping)` silently overwrote the first entry. De-anonymization then substituted the second person's name into both positions — leaking cross-user PII in the response.

**Minimal reproducer:**
```json
{
  "messages": [
    {"role": "user", "content": "田中太郎です"},
    {"role": "user", "content": "佐藤花子です"}
  ]
}
```
Both names start at offset 0 → both produce `<PERSON_0>` → `combined_mapping["<PERSON_0>"]` ends up as `佐藤花子` → 田中太郎 is lost.

## Change

Replace the `(entity_type, start-offset)` placeholder key with a globally unique monotone counter:

```diff
-placeholder = f"<{r.entity_type}_{r.start}>"
+placeholder = f"<{r.entity_type}_{next(_placeholder_counter)}>"
```

`_placeholder_counter = itertools.count(0)` is module-level. `asyncio`'s single-threaded event loop makes this safe without locks — no two tasks execute concurrently during `next()`.

## Test plan
- [ ] Two-message request with same-type PII at offset 0 in each → both correctly de-anonymized in response
- [ ] Single-message request with PII → unchanged behavior
- [ ] Existing `/api/redact` endpoint → unchanged behavior (uses separate mapping per call, not combined)