### PR TITLE
fix(server): strip stale Content-Length/Encoding headers from proxy responses

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -467,9 +467,18 @@ def deanonymize_text(text: str, mapping: Dict[str, str]) -> str:
 
 
 _HOP_BY_HOP_HEADERS = frozenset(
-    ["content-length", "content-encoding", "transfer-encoding", "connection",
-     "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailers",
-     "upgrade"]
+    [
+        "content-length",
+        "content-encoding",
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "upgrade",
+    ]
 )
 
 

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -466,6 +466,24 @@ def deanonymize_text(text: str, mapping: Dict[str, str]) -> str:
     return result
 
 
+_HOP_BY_HOP_HEADERS = frozenset(
+    ["content-length", "content-encoding", "transfer-encoding", "connection",
+     "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailers",
+     "upgrade"]
+)
+
+
+def _safe_response_headers(headers) -> dict:
+    """Return upstream headers with hop-by-hop and body-framing headers stripped.
+
+    The proxy mutates the response body (de-anonymization), so the upstream
+    Content-Length / Content-Encoding / Transfer-Encoding no longer apply.
+    Starlette uses the caller-provided content-length as-is and does not
+    recompute it, so forwarding stale values causes client decode failures.
+    """
+    return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS}
+
+
 def _is_disallowed_ip(ip: ipaddress._BaseAddress) -> bool:
     """Reject any address that could reach internal/cloud-metadata infrastructure."""
     return (
@@ -1117,7 +1135,7 @@ async def openai_proxy(request: Request, path: str):
     return Response(
         content=response_content,
         status_code=response.status_code,
-        headers=dict(response.headers),
+        headers=_safe_response_headers(response.headers),
         media_type=response.headers.get("content-type"),
     )
 
@@ -1186,7 +1204,7 @@ async def anthropic_proxy(request: Request, path: str):
     return Response(
         content=response_content,
         status_code=response.status_code,
-        headers=dict(response.headers),
+        headers=_safe_response_headers(response.headers),
         media_type=response.headers.get("content-type"),
     )
 
@@ -1253,6 +1271,6 @@ async def gemini_proxy(request: Request, path: str):
     return Response(
         content=response_content,
         status_code=response.status_code,
-        headers=dict(response.headers),
+        headers=_safe_response_headers(response.headers),
         media_type=response.headers.get("content-type"),
     )


### PR DESCRIPTION
## Summary

Fixes #212

The proxy forwarded the full upstream `response.headers` including `content-length`, `content-encoding`, and `transfer-encoding`. Since the proxy de-anonymizes the response body (restoring PII placeholders), the body is now different from the upstream body that these headers describe:

- `httpx` transparently decompresses `response.content`, but the proxy then forwarded `content-encoding: gzip` alongside the plain bytes → client tries to gunzip already-decoded data → decode failure
- `content-length` reflects the compressed upstream body size, which differs from the (potentially larger) de-anonymized plaintext → Starlette doesn't recompute it → body truncation

This manifests **specifically when de-anonymization changes the body size** — i.e. when the service did its job (a redacted `<PERSON_0>` is shorter than `田中太郎`).

## Change

New helper `_safe_response_headers()` strips hop-by-hop and body-framing headers (`content-length`, `content-encoding`, `transfer-encoding`, `connection`, etc.) before constructing the `Response`. Starlette then derives correct `Content-Length` from the actual mutated body.

Applied to all three proxy endpoints (OpenAI / Anthropic / Gemini).

## Test plan
- [ ] Chat completion with Japanese PII → client receives valid gzip-free JSON with correct length
- [ ] Response where de-anonymized body is longer than the placeholder → no truncation
- [ ] Non-200 responses (errors) pass through cleanly