### PR TITLE
fix(tests): correct JA adversarial test model path and add missing asserts

### DIFF
--- a/server/tests/test_adversarial_ner.py
+++ b/server/tests/test_adversarial_ner.py
@@ -14,7 +14,7 @@ try:
     import spacy
 
     _model_path = (
-        Path(__file__).parent.parent
+        Path(__file__).parent.parent.parent
         / "packages"
         / "models"
         / "pleno_anonymize_ja-0.2.0"
@@ -279,7 +279,7 @@ class TestBankAccountEdgeCases:
         # 銀行名だけなら ORGANIZATION であって BANK_ACCOUNT ではない
         bank_accounts = entities.get("BANK_ACCOUNT", [])
         # 口座番号がないのに BANK_ACCOUNT と検出するのは偽陽性
-        # ただし銀行名自体がORGとして検出されるのはOK
+        assert bank_accounts == [], f"口座番号なしなのに BANK_ACCOUNT が検出された: {bank_accounts}"
 
 
 # ============================================================

--- a/server/tests/test_adversarial_ner_en.py
+++ b/server/tests/test_adversarial_ner_en.py
@@ -280,7 +280,7 @@ class TestBankAccountEdgeCases:
         text = "Chase Bank offers excellent customer service"
         entities = _ner_entities(text)
         bank_accounts = entities.get("BANK_ACCOUNT", [])
-        # Bank name alone without account details is not BANK_ACCOUNT
+        assert bank_accounts == [], f"Bank name alone incorrectly flagged as BANK_ACCOUNT: {bank_accounts}"
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Fixes #214

Two issues in the adversarial NER test suite:

### 1. Wrong model path in `test_adversarial_ner.py`

`Path(__file__).parent.parent` resolves to `server/` when the test lives at `server/tests/test_adversarial_ner.py`. The models are at the repo root under `packages/models/`, so the path needs one extra `.parent`:

```diff
-    _model_path = Path(__file__).parent.parent / "packages" / "models" / ...
+    _model_path = Path(__file__).parent.parent.parent / "packages" / "models" / ...
```

This matches what `test_adversarial_ner_en.py` does correctly. All ~50 JA adversarial tests (PERSON, ADDRESS, DOB edge cases) were permanently `skipif`-skipped even when the model was present.

### 2. Vacuous `test_partial_bank_info` in both JA and EN files

Both tests collected `entities.get("BANK_ACCOUNT", [])` but never asserted on the result. Added the missing assertion: bank name alone (without account number) must not produce a `BANK_ACCOUNT` entity.

## Test plan
- [ ] With model present: JA adversarial tests now run (not skipped)
- [ ] `test_partial_bank_info` (JA): `三菱UFJ銀行をご利用いただきありがとうございます` → `BANK_ACCOUNT` empty
- [ ] `test_partial_bank_info` (EN): `Chase Bank offers...` → `BANK_ACCOUNT` empty