### PR TITLE
fix(server): guard _init_presidio with threading.Lock to prevent races

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -7,6 +7,7 @@ import binascii
 import io
 import ipaddress
 import socket
+import threading
 import time
 import uuid
 from urllib.parse import urlsplit
@@ -44,53 +45,65 @@ _nlp_en = None
 _analyzer = None
 _anonymizer = None
 _image_redactor = None
+_init_lock = threading.Lock()
 
 
 def _init_presidio():
     """Lazy initialization of Presidio components."""
-    global _nlp_ja, _nlp_en, _analyzer, _anonymizer, _image_redactor
+    global _nlp_ja, _nlp_en, _analyzer, _anonymizer
 
     if _analyzer is not None:
         return
 
-    import spacy
-    from presidio_analyzer import AnalyzerEngine
-    from presidio_analyzer.nlp_engine import SpacyNlpEngine
-    from presidio_anonymizer import AnonymizerEngine
-    from pleno_anonymize.recognizers.presidio_adapter import all_ja_presidio
+    with _init_lock:
+        if _analyzer is not None:  # double-checked: another thread may have won the race
+            return
 
-    class MultiLangSpacyNlpEngine(SpacyNlpEngine):
-        def __init__(self, models: dict):
-            super().__init__()
-            self.nlp = models
+        import spacy
+        from presidio_analyzer import AnalyzerEngine
+        from presidio_analyzer.nlp_engine import SpacyNlpEngine
+        from presidio_anonymizer import AnonymizerEngine
+        from pleno_anonymize.recognizers.presidio_adapter import all_ja_presidio
 
-    # Models are installed as Python packages from HF wheels (see Dockerfile);
-    # resolve via spaCy entry_point lookup, not filesystem path.
-    _nlp_ja = spacy.load("pleno_anonymize_ja")
+        class MultiLangSpacyNlpEngine(SpacyNlpEngine):
+            def __init__(self, models: dict):
+                super().__init__()
+                self.nlp = models
 
-    try:
-        _nlp_en = spacy.load("pleno_anonymize_en")
-    except OSError:
-        _nlp_en = None
+        # Models are installed as Python packages from HF wheels (see Dockerfile);
+        # resolve via spaCy entry_point lookup, not filesystem path.
+        nlp_ja = spacy.load("pleno_anonymize_ja")
 
-    models = {"ja": _nlp_ja}
-    if _nlp_en is not None:
-        models["en"] = _nlp_en
+        try:
+            nlp_en = spacy.load("pleno_anonymize_en")
+        except OSError:
+            nlp_en = None
 
-    supported_languages = list(models.keys())
-    engine = MultiLangSpacyNlpEngine(models)
-    _analyzer = AnalyzerEngine(
-        nlp_engine=engine,
-        supported_languages=supported_languages,
-    )
+        models = {"ja": nlp_ja}
+        if nlp_en is not None:
+            models["en"] = nlp_en
 
-    for recognizer in all_ja_presidio():
-        _analyzer.registry.add_recognizer(recognizer)
+        supported_languages = list(models.keys())
+        engine = MultiLangSpacyNlpEngine(models)
+        analyzer = AnalyzerEngine(
+            nlp_engine=engine,
+            supported_languages=supported_languages,
+        )
 
-    if "en" in supported_languages:
-        _analyzer.registry.load_predefined_recognizers(languages=["en"])
+        for recognizer in all_ja_presidio():
+            analyzer.registry.add_recognizer(recognizer)
 
-    _anonymizer = AnonymizerEngine()
+        if "en" in supported_languages:
+            analyzer.registry.load_predefined_recognizers(languages=["en"])
+
+        anonymizer = AnonymizerEngine()
+
+        # Assign module globals only after fully configured so concurrent
+        # get_analyzer() callers never observe a partially-initialised engine.
+        _nlp_ja = nlp_ja
+        _nlp_en = nlp_en
+        _anonymizer = anonymizer
+        _analyzer = analyzer  # publish last — acts as the visibility fence
 
 
 def get_analyzer():

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -56,7 +56,9 @@ def _init_presidio():
         return
 
     with _init_lock:
-        if _analyzer is not None:  # double-checked: another thread may have won the race
+        if (
+            _analyzer is not None
+        ):  # double-checked: another thread may have won the race
             return
 
         import spacy


### PR DESCRIPTION
## Summary

Fixes #213

Two race conditions in the lazy initialization path:

### Race 1: Double model load → OOM risk

The warmup thread (started in `lifespan`) and the first incoming request thread can both pass the `_analyzer is not None` check during the multi-second `spacy.load()` call, loading all models twice. On a 2 GB Fly.io VM this risks an OOM-kill.

### Race 2: Partially-configured analyzer visible to callers

`_analyzer` was assigned immediately after `AnalyzerEngine(...)` but **before** the JA pattern recognizers were added. A concurrent `get_analyzer()` call that observed `_analyzer` in this window received an engine with zero JA recognizers — phone numbers, My Number, credit cards, etc. would silently pass through unredacted.

## Fix

```python
_init_lock = threading.Lock()

def _init_presidio():
    if _analyzer is not None:       # fast path: no lock needed post-init
        return
    with _init_lock:
        if _analyzer is not None:   # double-check: another thread may have won
            return
        # build everything into locals first
        analyzer = AnalyzerEngine(...)
        for r in all_ja_presidio(): analyzer.registry.add_recognizer(r)
        ...
        _analyzer = analyzer        # publish last — visibility fence
```

- Outer check: avoids lock overhead on every `get_analyzer()` call once initialized (the common path)
- Inner check: prevents double-init when two threads both pass the outer check
- Late publish: `_analyzer` is assigned last, after full configuration, so it acts as the visibility fence for all other module globals

## Test plan
- [ ] Concurrent startup smoke test: spin up 10 threads all calling `get_analyzer()` at the same time → no duplicate model loads, no `AttributeError`
- [ ] Warmup thread + simultaneous HTTP request → single model load
- [ ] `/api/analyze` with Japanese phone number → detected (JA recognizers present)