### PR TITLE
fix(sdk): scan dotenv dotfiles and fix corporate_number checksum weights

### DIFF
--- a/packages/sdk/src/pleno_anonymize/_scanner.py
+++ b/packages/sdk/src/pleno_anonymize/_scanner.py
@@ -238,7 +238,8 @@ def _collect(
 
 
 def _ext_match(path: Path, allow: frozenset[str]) -> bool:
-    ext = path.suffix.lower()
+    # suffix is "" for dotfiles (e.g. .env); fall back to name for those
+    ext = path.suffix.lower() or path.name.lower()
     return ext in allow
 
 

--- a/packages/sdk/src/pleno_anonymize/recognizers/validators.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/validators.py
@@ -47,7 +47,7 @@ def my_number(value: str) -> bool:
     return expected == check
 
 
-_CORP_NUMBER_WEIGHTS = (1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2)
+_CORP_NUMBER_WEIGHTS = (2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)  # high→low position left-to-right
 
 
 def corporate_number(value: str) -> bool:

--- a/packages/sdk/src/pleno_anonymize/recognizers/validators.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/validators.py
@@ -47,7 +47,20 @@ def my_number(value: str) -> bool:
     return expected == check
 
 
-_CORP_NUMBER_WEIGHTS = (2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)  # high→low position left-to-right
+_CORP_NUMBER_WEIGHTS = (
+    2,
+    1,
+    2,
+    1,
+    2,
+    1,
+    2,
+    1,
+    2,
+    1,
+    2,
+    1,
+)  # high→low position left-to-right
 
 
 def corporate_number(value: str) -> bool:

--- a/packages/sdk/tests/recognizers/test_validators.py
+++ b/packages/sdk/tests/recognizers/test_validators.py
@@ -33,15 +33,16 @@ def test_my_number_invalid():
 
 
 def test_corporate_number_valid():
-    # body=123456789012, weights=(1,2,1,2,1,2,1,2,1,2,1,2)
-    # s = 1+4+3+8+5+12+7+16+9+0+1+4 = 70
-    # check = 9 - (70 % 9) = 9 - 7 = 2
-    assert corporate_number("2123456789012") is True
+    # Real public corporate numbers (NTA registry)
+    assert corporate_number("1180301018771") is True   # トヨタ自動車
+    assert corporate_number("5010401067252") is True   # ソニーグループ
+    assert corporate_number("7000012050002") is True   # 国税庁
 
 
 def test_corporate_number_invalid():
     assert corporate_number("1123456789012") is False
-    assert corporate_number("123456789012") is False  # too short
+    assert corporate_number("123456789012") is False   # too short
+    assert corporate_number("2123456789012") is False  # wrong check digit
 
 
 def test_validate_dispatch():

--- a/packages/sdk/tests/recognizers/test_validators.py
+++ b/packages/sdk/tests/recognizers/test_validators.py
@@ -34,14 +34,14 @@ def test_my_number_invalid():
 
 def test_corporate_number_valid():
     # Real public corporate numbers (NTA registry)
-    assert corporate_number("1180301018771") is True   # トヨタ自動車
-    assert corporate_number("5010401067252") is True   # ソニーグループ
-    assert corporate_number("7000012050002") is True   # 国税庁
+    assert corporate_number("1180301018771") is True  # トヨタ自動車
+    assert corporate_number("5010401067252") is True  # ソニーグループ
+    assert corporate_number("7000012050002") is True  # 国税庁
 
 
 def test_corporate_number_invalid():
     assert corporate_number("1123456789012") is False
-    assert corporate_number("123456789012") is False   # too short
+    assert corporate_number("123456789012") is False  # too short
     assert corporate_number("2123456789012") is False  # wrong check digit
 
 

--- a/packages/sdk/tests/test_scanner.py
+++ b/packages/sdk/tests/test_scanner.py
@@ -69,3 +69,13 @@ def test_scan_respects_include_extensions(tmp_path: Path) -> None:
     summary = scan_paths(_FakeEngine(), [str(tmp_path)], include_extensions=[".md"])
     assert summary.scanned_files == 1
     assert summary.files[0].path.endswith("keep.md")
+
+
+def test_scan_dotenv_files_are_scanned(tmp_path: Path) -> None:
+    """Dotfiles like .env must be scanned; pathlib.Path('.env').suffix == ''."""
+    (tmp_path / ".env").write_text("SECRET=a@b.example", encoding="utf-8")
+    (tmp_path / "prod.env").write_text("KEY=c@d.example", encoding="utf-8")
+    summary = scan_paths(_FakeEngine(), [str(tmp_path)])
+    scanned = {Path(f.path).name for f in summary.files}
+    assert ".env" in scanned, ".env dotfile was not scanned"
+    assert "prod.env" in scanned


### PR DESCRIPTION
## Summary

Fixes #208, partially fixes #206 (weights corrected; validator wiring deferred)

### Bug 1 — `.env` files never scanned (#208)

`pathlib.Path('/x/.env').suffix` returns `""` (dotfiles have no extension suffix in Python's pathlib), so `.env` entries in `SCAN_EXTENSIONS` never matched. A single-line fallback to `path.name` fixes this.

### Bug 2 — `corporate_number` checksum weights reversed (#206)

`_CORP_NUMBER_WEIGHTS` was `(1,2,1,2,...)` left-to-right, but the NTA spec counts positions from the lowest digit (position 1 = rightmost, weight 1; position 2 = weight 2; …). For a 12-digit body iterated left-to-right, the correct weights are `(2,1,2,1,...)`.

Verified against publicly registered corporate numbers:
- トヨタ自動車 `1180301018771` ✓  
- ソニーグループ `5010401067252` ✓  
- 国税庁 `7000012050002` ✓

The existing test was generated from the buggy convention; updated to use real numbers.

## Test plan
- [x] `uv run --project packages/sdk pytest packages/sdk/tests/` — 59 passed