### PR TITLE
fix(sdk,website,training): UTF-8 truncation, span offset, EN training pipeline bugs

### DIFF
--- a/packages/sdk/src/pleno_anonymize/_scanner.py
+++ b/packages/sdk/src/pleno_anonymize/_scanner.py
@@ -289,13 +289,31 @@ def _scan_one(
     try:
         text = chunk.decode("utf-8")
     except UnicodeDecodeError:
-        return FileScanResult(
-            path=display,
-            bytes=size,
-            language=language,
-            truncated=truncated,
-            skipped="binary",
-        )
+        if truncated:
+            # Truncation may have split a multibyte sequence (UTF-8 chars are ≤4 bytes).
+            # Strip up to 3 trailing bytes and retry before declaring binary.
+            for _trim in range(1, 4):
+                try:
+                    text = chunk[:-_trim].decode("utf-8")
+                    break
+                except UnicodeDecodeError:
+                    continue
+            else:
+                return FileScanResult(
+                    path=display,
+                    bytes=size,
+                    language=language,
+                    truncated=truncated,
+                    skipped="binary",
+                )
+        else:
+            return FileScanResult(
+                path=display,
+                bytes=size,
+                language=language,
+                truncated=truncated,
+                skipped="binary",
+            )
     if not text.strip():
         return FileScanResult(
             path=display,

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -170,8 +170,7 @@ augment-en:
 convert-en:
 	uv run python -m pleno_ner_training.convert_to_docbin \
 		--language en \
-		--input $(DATA_RAW)/en/generated.json \
-		--augment $(DATA_RAW)/en/augmented.json \
+		--input $(DATA_RAW)/en/augmented.json \
 		--output-dir $(DATA_PROCESSED)/en
 
 train-en:

--- a/packages/training/scripts/eval_conll_en_real.py
+++ b/packages/training/scripts/eval_conll_en_real.py
@@ -154,9 +154,16 @@ def score(rows, iou_thr, gold_filter=None):
     for r in rows:
         gold = [(s, e, l) for s, e, l in r["gold"]
                 if gold_filter is None or l in gold_filter]
+        # Filter pred to the same label subset so that correct non-PII predictions
+        # from baseline models are not counted as FPs in the pii-subset protocol.
+        pred = r["pred"] if gold_filter is None else [
+            p for p in r["pred"] if p[2] in gold_filter
+        ]
         if not gold:
+            # Doc has no PII-gold but may have PII predictions — those are FPs.
+            if pred:
+                per_doc.append((0, len(pred), 0))
             continue
-        pred = r["pred"]
         matched = set(); tp = fn = 0
         for g_s, g_e, _ in gold:
             best_i, best_iou = -1, 0.0

--- a/packages/training/scripts/eval_stockmark_jp_real.py
+++ b/packages/training/scripts/eval_stockmark_jp_real.py
@@ -104,9 +104,13 @@ def score(rows, pred_fn, iou_thr, gold_filter=None):
     for r in rows:
         gold = [(int(s[0]), int(s[1]), str(s[2])) for s in r["gold"]
                 if gold_filter is None or s[2] in gold_filter]
+        pred = r["pred"] if gold_filter is None else [
+            p for p in r["pred"] if p[2] in gold_filter
+        ]
         if not gold:
+            if pred:
+                per_doc.append((0, len(pred), 0))
             continue
-        pred = r["pred"]
         matched = set()
         tp = fn = 0
         for g_s, g_e, _ in gold:

--- a/packages/training/scripts/eval_stockmark_spacy.py
+++ b/packages/training/scripts/eval_stockmark_spacy.py
@@ -19,8 +19,13 @@ def score(rows, iou_thr, gold_filter=None):
     for r in rows:
         gold = [(s[0], s[1], s[2]) for s in r["gold"]
                 if gold_filter is None or s[2] in gold_filter]
-        if not gold: continue
-        pred = r["pred"]
+        pred = r["pred"] if gold_filter is None else [
+            p for p in r["pred"] if p[2] in gold_filter
+        ]
+        if not gold:
+            if pred:
+                per_doc.append((0, len(pred), 0))
+            continue
         matched = set(); tp = fn = 0
         for g_s, g_e, _ in gold:
             best_i, best_iou = -1, 0.0

--- a/packages/training/src/pleno_ner_training/augment_en_data.py
+++ b/packages/training/src/pleno_ner_training/augment_en_data.py
@@ -205,45 +205,46 @@ SHORT_NAME_TEMPLATES = [
 
 def _build_doc(template: str, **kwargs) -> dict | None:
     """Build a document with proper entity offsets from a template."""
-    entities = []
-    remaining = template
+    import re
 
-    # Simple tag-based approach: replace {key} with value and track offsets
-
-    tag_map = {
-        "person": ("PERSON", kwargs.get("person", "")),
-        "dob": ("DATE_OF_BIRTH", kwargs.get("dob", "")),
-        "address": ("ADDRESS", kwargs.get("address", "")),
-        "org": ("ORGANIZATION", kwargs.get("org", "")),
-        "bank": ("BANK_ACCOUNT", kwargs.get("bank", "")),
+    tag_labels = {
+        "person": "PERSON",
+        "dob": "DATE_OF_BIRTH",
+        "address": "ADDRESS",
+        "org": "ORGANIZATION",
+        "bank": "BANK_ACCOUNT",
     }
 
-    # First pass: handle dob_prefix (not an entity)
+    # Handle non-entity prefix first (no offset tracking needed).
+    result = template
     if "dob_prefix" in kwargs:
-        remaining = remaining.replace("{dob_prefix}", kwargs["dob_prefix"])
+        result = result.replace("{dob_prefix}", kwargs["dob_prefix"])
 
-    # Build text with entity tracking
-    result = ""
-    for tag_name, (label, value) in tag_map.items():
-        placeholder = "{" + tag_name + "}"
-        if placeholder not in remaining:
-            continue
+    # Replace placeholders in template order so that a {bank} before {address}
+    # does not get swallowed into the pre-{address} prefix (the old dict-order
+    # bug dropped BANK_ACCOUNT from every BANK_TEMPLATES doc).
+    entities = []
+    for m in re.finditer(r"\{(\w+)\}", result):
+        key = m.group(1)
+        value = kwargs.get(key, "")
         if not value:
             continue
-        parts = remaining.split(placeholder, 1)
-        result += parts[0]
-        start = len(result)
-        result += value
-        end = len(result)
-        entities.append({
-            "start": start,
-            "end": end,
-            "label": label,
-            "text": value,
-        })
-        remaining = parts[1] if len(parts) > 1 else ""
+        placeholder = m.group(0)
+        pos = result.find(placeholder)
+        if pos == -1:
+            continue
+        result = result[:pos] + value + result[pos + len(placeholder):]
+        label = tag_labels.get(key)
+        if label:
+            entities.append({
+                "start": pos,
+                "end": pos + len(value),
+                "label": label,
+                "text": value,
+            })
 
-    result += remaining
+    # Strip any remaining unfilled placeholders.
+    result = re.sub(r"\{\w+\}", "", result)
 
     if not entities:
         return None

--- a/website/src/pages/PlaygroundPage.tsx
+++ b/website/src/pages/PlaygroundPage.tsx
@@ -138,19 +138,38 @@ const Header = memo(function Header() {
   );
 });
 
+// Build a mapping from Unicode codepoint index → UTF-16 code-unit index.
+// The server returns Python (codepoint) offsets; JS String.slice uses UTF-16 units.
+// Astral chars (emoji, some CJK) are 1 codepoint but 2 UTF-16 units, so a direct
+// slice with server offsets would misalign highlights for any text containing them.
+function buildCpToUtf16Map(text: string): number[] {
+  const map: number[] = [0];
+  let u = 0;
+  for (const cp of text) {
+    u += cp.length;
+    map.push(u);
+  }
+  return map;
+}
+
 function buildHighlightedText(text: string, entities: AnalyzeResult[]) {
   if (entities.length === 0) return [{ text, type: null as string | null, score: 0 }];
+
+  const cpMap = buildCpToUtf16Map(text);
+  const toU16 = (cp: number) => cpMap[cp] ?? text.length;
 
   const sorted = [...entities].sort((a, b) => a.start - b.start);
   const segments: { text: string; type: string | null; score: number }[] = [];
   let cursor = 0;
 
   for (const entity of sorted) {
-    if (entity.start > cursor) {
-      segments.push({ text: text.slice(cursor, entity.start), type: null, score: 0 });
+    const start = toU16(entity.start);
+    const end = toU16(entity.end);
+    if (start > cursor) {
+      segments.push({ text: text.slice(cursor, start), type: null, score: 0 });
     }
-    segments.push({ text: text.slice(entity.start, entity.end), type: entity.entity_type, score: entity.score });
-    cursor = entity.end;
+    segments.push({ text: text.slice(start, end), type: entity.entity_type, score: entity.score });
+    cursor = end;
   }
   if (cursor < text.length) {
     segments.push({ text: text.slice(cursor), type: null, score: 0 });


### PR DESCRIPTION
## Summary

Fixes 4 confirmed bugs across sdk, website, and training pipeline.

### sdk — Issue #207 (high)
`_scanner.py`: Truncation at `max_bytes` could split a UTF-8 multibyte sequence, causing `UnicodeDecodeError` that incorrectly marked the whole file as binary (zero findings). Fix: strip up to 3 trailing bytes before decoding when `truncated=True`.

### website — Issue #219 (high)
`PlaygroundPage.tsx`: `buildHighlightedText` sliced with JS UTF-16 code-unit indices but the server returns Python Unicode codepoint offsets. Any astral character (emoji, many CJK) counts as 2 UTF-16 units but 1 codepoint, so highlights shifted left for text containing such chars. Fix: build a codepoint→UTF-16 map and translate offsets before slicing.

### training — Issue #215 (high)
`augment_en_data._build_doc` iterated `tag_map` in fixed dict order (person→dob→address→org→bank). In all `BANK_TEMPLATES`, `{bank}` appears before `{address}`, so the `{bank}` placeholder was consumed as literal text during the address pass, producing zero `BANK_ACCOUNT` entities and injecting `{bank}` tokens into training data. Fix: adopt the same regex-based template-order replacement used in `augment_ja_data`.

### training — Issue #216 (high)
`augment_en_data.main` wrote `original + augmented` to `augmented.json`, then Makefile's `convert-en` used both `--input generated.json` and `--augment augmented.json`. Every original doc appeared twice, with duplicates routinely landing in both train and test sets (leakage, inflated scores). Fix: use `--input augmented.json` alone in `convert-en` (mirrors JA pipeline).

### training — Issue #218 (high)
`eval_conll_en_real/eval_stockmark_jp_real/eval_stockmark_spacy score()`: In the pii-subset protocol, gold was filtered to PII labels but predictions were not. Correct non-PII predictions from baselines (ORG/MISC/etc.) were counted as FPs, inflating pleno models' relative precision. Also: docs with no PII-gold were skipped entirely, missing FPs from those docs. Fix: filter pred to the same label subset as gold; count filtered-pred FPs on no-PII-gold docs.

## Test plan

- [ ] `packages/sdk`: Run `pytest` with a large (>256KB) UTF-8 Japanese file whose `max_bytes` boundary falls mid-multibyte — confirm findings returned, `skipped` is `None`
- [ ] `website`: Test playground with text containing 😀 before a phone number — confirm highlight aligns correctly
- [ ] `training`: Run `make augment-en convert-en` on a small count — verify BANK_ACCOUNT entities appear in converted data and `augmented.json` doc count matches expected
- [ ] `training`: Run `make evaluate-en` and confirm eval scores reflect corrected FP accounting

Closes #207, #215, #216, #218, #219