### PR TITLE
fix(autotrain.sh, infra): LANG variable collision, exit code, set -e, .dockerignore .env, website.yml paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,10 @@ docs
 flake.nix
 flake.lock
 .gitmodules
+.env
+.env.*
+.venv
+website/
 # packages/training is needed (recognizers_ja.py + workspace pyproject), but
 # heavy data / outputs / artifacts are excluded to keep image small.
 packages/training/data

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'website/**'
       - 'packages/training/output/scores.json'
+      - 'packages/training/output/en-transformer/scores.json'
+      - 'packages/training/output/en/scores.json'
+      - 'packages/training/output/ja/external_scores.json'
+      - 'packages/training/output/en/external_scores.json'
       - '.github/workflows/website.yml'
 
 permissions:

--- a/autotrain.sh
+++ b/autotrain.sh
@@ -16,9 +16,10 @@
 
 set -euo pipefail
 
-LANG="${1:-ja}"
+TARGET_LANG="${1:-ja}"
 MODE="improve"
 MAX_ITER="3"
+EXIT_CODE=0
 
 # 引数パース
 shift || true
@@ -52,11 +53,11 @@ BANNER
 print_scores() {
   local label="$1"
   local latest_scores
-  latest_scores=$(find "$TRAINING_DIR/data/benchmark" -name "scores.json" -path "*/$LANG/*" 2>/dev/null \
-    | sort -V | tail -1)
+  latest_scores=$(find "$TRAINING_DIR/data/benchmark" -name "scores.json" -path "*/$TARGET_LANG/*" 2>/dev/null \
+    | sort -V | tail -1) || true
   if [ -n "$latest_scores" ] && [ -f "$latest_scores" ]; then
     local version
-    version=$(echo "$latest_scores" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+    version=$(echo "$latest_scores" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+') || true
     echo "$label (benchmark $version):"
     python3 -c "
 import json
@@ -91,7 +92,7 @@ run_claude() {
 # --- Main ---
 
 print_banner
-echo "Language:    $LANG"
+echo "Language:    $TARGET_LANG"
 echo "Mode:        $MODE"
 echo "Iterations:  $MAX_ITER"
 echo "Log:         $LOG_FILE"
@@ -103,44 +104,42 @@ echo "---"
 
 case "$MODE" in
   improve)
-    run_claude "/ner-improve $LANG $MAX_ITER" "Model Improvement"
+    run_claude "/ner-improve $TARGET_LANG $MAX_ITER" "Model Improvement" || EXIT_CODE=$?
     ;;
 
   resume)
     PREV_COUNT=$(wc -l < "$LOG_DIR/log.jsonl" | tr -d ' ')
-    run_claude "/ner-improve $LANG $MAX_ITER
+    run_claude "/ner-improve $TARGET_LANG $MAX_ITER
 
 前回の実験ログ ($PREV_COUNT 件) が packages/training/experiments/log.jsonl にあります。
 前回の結果を踏まえて、まだ試していないアプローチから改善を続けてください。" \
-      "Model Improvement (resume)"
+      "Model Improvement (resume)" || EXIT_CODE=$?
     ;;
 
   evolve)
-    run_claude "/benchmark-evolve $LANG" "Benchmark Evolution"
+    run_claude "/benchmark-evolve $TARGET_LANG" "Benchmark Evolution" || EXIT_CODE=$?
     ;;
 
   full)
     echo "=== Phase 1/3: Model Improvement ==="
-    run_claude "/ner-improve $LANG $MAX_ITER" "Model Improvement" || true
+    run_claude "/ner-improve $TARGET_LANG $MAX_ITER" "Model Improvement" || true
     echo ""
     print_scores "After improvement"
     echo ""
 
     echo "=== Phase 2/3: Benchmark Evolution ==="
-    run_claude "/benchmark-evolve $LANG" "Benchmark Evolution" || true
+    run_claude "/benchmark-evolve $TARGET_LANG" "Benchmark Evolution" || true
     echo ""
 
     echo "=== Phase 3/3: Model Improvement (vs new benchmark) ==="
     PREV_COUNT=$(wc -l < "$LOG_DIR/log.jsonl" | tr -d ' ')
-    run_claude "/ner-improve $LANG $MAX_ITER
+    run_claude "/ner-improve $TARGET_LANG $MAX_ITER
 
 ベンチマークが進化しました。新しいベンチマークに対して改善を続けてください。
 実験ログ ($PREV_COUNT 件) が packages/training/experiments/log.jsonl にあります。" \
       "Model Improvement (vs evolved benchmark)" || true
     ;;
 esac
-
-EXIT_CODE=${PIPESTATUS[0]:-0}
 
 echo ""
 echo "---"


### PR DESCRIPTION
## Summary

Three shell bugs in `autotrain.sh` (issues #224 bugs 1-3) and two infra bugs from #226 (items 1, 7).

### autotrain.sh — Issue #224 (bugs 1-3 of 4)

**Bug 1 — LANG clobbers POSIX locale variable**
`LANG="${1:-ja}"` exports an invalid locale (`ja`/`en`) into every child process (`claude`, `python3`, `sort -V`, `grep`). Renamed to `TARGET_LANG` throughout.

**Bug 2 — Exit code always 0 / unobservable**
`EXIT_CODE=${PIPESTATUS[0]:-0}` after `esac` is unreachable in `improve`/`resume`/`evolve` modes (set -e kills before reaching it if claude fails), and `full` mode uses `|| true` everywhere. Fix: initialize `EXIT_CODE=0`, capture with `|| EXIT_CODE=$?` per case branch so `print_scores` always runs and CI/cron can observe failures.

**Bug 3 — `set -euo pipefail` kills script inside `print_scores` on a fresh clone**
`find` on a missing `data/benchmark` dir and `grep -oE` on no match both exit non-zero; both are inside command substitutions that propagate under `set -e`. Added `|| true` after each.

> Bug 4 (missing `/benchmark-evolve` skill) not fixed here — requires product decision on what the skill should contain.

### infra — Issue #226 (items 1, 7)

**Item 1 — `website.yml` trigger paths missing 4 score files**
`vite.config.ts` aliases 5 score JSON files; only 1 was in the trigger `paths:`. Updating any of `en-transformer/scores.json`, `en/scores.json`, `ja/external_scores.json`, `en/external_scores.json` silently skipped redeploy. All 5 paths now listed.

**Item 7 — `.dockerignore` missing `.env`, `.venv`, `website/`**
`.env` (holds `OPENAI_API_KEY` per autotrain.sh docs) was absent; a future `COPY . .` or broad COPY would ship credentials. `.venv` and `website/` also excluded to reduce build context size.

> Items 2-6 from #226 (Dependabot uv, Docker cache, COPY --from cache, model version desync, release-pypi verify gate) are larger infra changes left for follow-up.

## Test plan
- [ ] `bash -n autotrain.sh` passes
- [ ] `./autotrain.sh en 1` uses `TARGET_LANG=en` in log output
- [ ] Confirm `echo $LANG` in a shell where `autotrain.sh` was sourced shows original locale
- [ ] website.yml trigger paths cover all aliases in `vite.config.ts`

Closes #224 (bugs 1-3)
Partial fix for #226 (items 1, 7)