### PR TITLE
fix(infra): dependabot uv, remove uv cache from runtime image, exclude packages/models (#226)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,6 @@ packages/training/CHANGELOG.md
 packages/training/__pycache__
 packages/training/**/__pycache__
 packages/models/pleno_anonymize_ja-0.2.0/pleno_anonymize_ja/__pycache__
+# Local model build artifacts — wheels are fetched from HF at build time;
+# local copies would only bloat the Docker build context (#226 item 7).
+packages/models/

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,11 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: pip
+  # uv replaces the no-op pip entry: root pyproject.toml has no direct deps
+  # (only [tool.uv.workspace]); pip doesn't recurse into workspace members so
+  # presidio/fastapi/etc. were never scanned. uv ecosystem reads uv.lock which
+  # covers all workspace members transitively.
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,11 @@ RUN apt-get update \
 
 WORKDIR /workspace
 COPY --from=builder /workspace /workspace
-COPY --from=builder /root /root
+# NOTE: /root is intentionally NOT copied from builder — it contains only the
+# uv download cache (/root/.cache/uv) which is not needed at runtime: the venv
+# is already fully installed in /workspace/.venv and CMD uses --no-sync.
+# Copying it added hundreds of MB of duplicated wheel bytes against the 8GB
+# fly.io rootfs limit (#226 item 4).
 
 EXPOSE 8080
 # `--no-sync` mirrors the build-time smoke: the runtime image already has all


### PR DESCRIPTION
## Summary

Fixes remaining items 2 and 4 from #226 (items 1, 7 already closed by #237).

- **Item 2 — Dependabot pip no-op**: Replace `package-ecosystem: pip` with `uv` in `.github/dependabot.yaml`. The root `pyproject.toml` has no direct dependencies (only `[tool.uv.workspace]`); Dependabot's pip scanner doesn't recurse into workspace members, so presidio/fastapi/etc. were never being scanned. The `uv` ecosystem reads `uv.lock` which covers all workspace members transitively.

- **Item 4 — COPY --from=builder /root /root ships uv cache**: Drop this line from the runtime stage of `Dockerfile`. `/root` in the builder contains only the uv download cache (`/root/.cache/uv`) which is unused at runtime — the venv is fully installed in `/workspace/.venv` and the CMD uses `--no-sync`. Removing it saves hundreds of MB of duplicated wheel bytes against the 8 GB fly.io rootfs limit.

- **Bonus / Item 7 extension — packages/models/ in .dockerignore**: Only a `__pycache__` subdir was excluded before; now the entire `packages/models/` directory is excluded. Local model build artifacts don't need to be in the Docker build context since wheels are fetched from HuggingFace at build time.

## Test plan

- [ ] Confirm CI passes (Docker build still works without `/root` copy)
- [ ] Confirm `uv run --no-sync uvicorn ...` still starts correctly (venv in `/workspace/.venv` is self-contained)
- [ ] Verify Dependabot creates PRs for workspace packages (presidio, fastapi, etc.) on next weekly run

https://claude.ai/code/session_019kcU1zdzc2WXWajRg2EEtA