### PR TITLE
fix(training): per-doc span matching in compare_baselines — fixes cross-doc TP inflation (#217)

### DIFF
--- a/packages/training/src/pleno_ner_training/compare_baselines.py
+++ b/packages/training/src/pleno_ner_training/compare_baselines.py
@@ -459,15 +459,32 @@ def _aggregate_recall(
     entity: str,
 ) -> dict[str, float | None]:
     """Per-template recall (token-overlap) for one entity, given pre-sliced
-    rows with `pred_spans` and `gold_spans` already entity-filtered. Returns
-    None for templates with < MIN_SPANS[entity] gold spans of that label."""
+    rows keyed by template.  Each value has a ``docs`` list of per-doc
+    ``{"pred_spans": [...], "gold_spans": [...]}`` dicts.
+
+    Matching is performed **per document** to avoid cross-doc span collisions
+    (spans are bare char-offset tuples with no doc identity; pooling them
+    allows a prediction at (0,4) in doc-17 to match gold at (0,4) in doc-3).
+    TP/FP/FN are summed across docs; recall = TP / (TP+FN).
+
+    Returns None for templates with < MIN_SPANS[entity] total gold spans."""
     out: dict[str, float | None] = {}
     for tmpl, row in rows_by_template.items():
-        gold = row["gold_spans"]
-        if len(gold) < MIN_SPANS[entity]:
+        total_gold = sum(len(d["gold_spans"]) for d in row["docs"])
+        if total_gold < MIN_SPANS[entity]:
             out[tmpl] = None
             continue
-        _, recall, _ = metrics.token_overlap_f1(row["pred_spans"], gold)
+        tp_total = fn_total = 0
+        for doc in row["docs"]:
+            n_gold = len(doc["gold_spans"])
+            if n_gold == 0:
+                continue
+            _p, r, _f = metrics.token_overlap_f1(doc["pred_spans"], doc["gold_spans"])
+            # recall = tp / (tp + fn)  →  tp = r * n_gold  (fn = (1-r)*n_gold)
+            tp = round(r * n_gold)
+            tp_total += tp
+            fn_total += n_gold - tp
+        recall = tp_total / (tp_total + fn_total) if (tp_total + fn_total) else 0.0
         out[tmpl] = recall
     return out
 
@@ -478,7 +495,16 @@ def _build_template_rows(
     k: int,
     score_bearing: bool,
 ) -> dict[str, dict]:
-    """Group per-template predictions+gold for one (variant, k, entity) cell."""
+    """Group per-template, per-doc predictions+gold for one (variant, k, entity) cell.
+
+    Returns ``{template: {"docs": [{"pred_spans": [...], "gold_spans": [...]}, ...]}}``
+
+    Spans are stored **per document** rather than pooled into flat per-template
+    lists.  Pooling was the root cause of cross-doc span matching: bare
+    ``(start, end, label)`` char offsets carry no doc identity, so a prediction
+    at ``(0, 4, ORGANIZATION)`` in doc-17 could match gold at ``(0, 4)`` in
+    doc-3, inflating TP and deflating FN (issue #217).
+    """
     # Collect (doc_idx, prediction) pairs filtered to entity.
     indexed_preds: list[tuple[int, tuple]] = []
     for row in var_rows:
@@ -499,7 +525,8 @@ def _build_template_rows(
     for doc_idx, pred in indexed_preds:
         keep_doc_pred.setdefault(doc_idx, []).append(pred)
 
-    # Build per-template rows.
+    # Build per-template, per-doc rows.  Each template gets a list of per-doc
+    # dicts so callers can match within a doc before aggregating counts.
     rows: dict[str, dict] = {}
     for row in var_rows:
         tmpl = row["template"]
@@ -507,9 +534,8 @@ def _build_template_rows(
         preds_kept = keep_doc_pred.get(row["doc_idx"], [])
         pred_spans = [(p[0], p[1], p[2]) for p in preds_kept]
         if tmpl not in rows:
-            rows[tmpl] = {"pred_spans": [], "gold_spans": []}
-        rows[tmpl]["pred_spans"].extend(pred_spans)
-        rows[tmpl]["gold_spans"].extend(gold)
+            rows[tmpl] = {"docs": []}
+        rows[tmpl]["docs"].append({"pred_spans": pred_spans, "gold_spans": gold})
     return rows
 
 
@@ -535,11 +561,18 @@ def _build_measurement_rows(
             for k in ks:
                 cells = _build_template_rows(var_rows, entity, k, spec.score_bearing)
                 for template, cell in cells.items():
-                    gold_set = {(s, e) for s, e, _lbl in cell["gold_spans"]}
-                    pred_set = {(s, e) for s, e, _lbl in cell["pred_spans"]}
-                    tp = len(gold_set & pred_set)
-                    fp = len(pred_set - gold_set)
-                    fn = len(gold_set - pred_set)
+                    # Aggregate exact-span TP/FP/FN **per document** to avoid
+                    # cross-doc deduplication: converting a pooled list to a set
+                    # collapsed identical offsets from different docs, undercounting
+                    # TP/FN when two gold spans have the same (start, end) in
+                    # different documents sharing a template (#217).
+                    tp = fp = fn = 0
+                    for doc in cell["docs"]:
+                        gold_set = {(s, e) for s, e, _lbl in doc["gold_spans"]}
+                        pred_set = {(s, e) for s, e, _lbl in doc["pred_spans"]}
+                        tp += len(gold_set & pred_set)
+                        fp += len(pred_set - gold_set)
+                        fn += len(gold_set - pred_set)
                     if tp == 0 and fp == 0 and fn == 0:
                         continue
                     rows.append(
@@ -717,10 +750,22 @@ def _strict_recall_for_best(
         return 0.0
     recalls: list[float] = []
     for row in rows.values():
-        gold = row["gold_spans"]
-        if len(gold) < MIN_SPANS[entity]:
+        # Aggregate strict-recall per doc to avoid cross-doc span collisions
+        # (same fix as _aggregate_recall / _build_measurement_rows: #217).
+        total_gold = sum(len(d["gold_spans"]) for d in row["docs"])
+        if total_gold < MIN_SPANS[entity]:
             continue
-        _, recall, _ = metrics.strict_span_f1(row["pred_spans"], gold)
+        tp_total = fn_total = 0
+        for doc in row["docs"]:
+            n_gold = len(doc["gold_spans"])
+            if n_gold == 0:
+                fp_doc = len(doc["pred_spans"])
+                continue
+            _p, r, _f = metrics.strict_span_f1(doc["pred_spans"], doc["gold_spans"])
+            tp = round(r * n_gold)
+            tp_total += tp
+            fn_total += n_gold - tp
+        recall = tp_total / (tp_total + fn_total) if (tp_total + fn_total) else 0.0
         recalls.append(recall)
     return sum(recalls) / len(recalls) if recalls else 0.0
 

--- a/packages/training/tests/test_compare_baselines.py
+++ b/packages/training/tests/test_compare_baselines.py
@@ -738,3 +738,82 @@ def test_build_measurement_rows_emits_exact_span_tp_fp_fn() -> None:
             "fn": 1,
         }
     ]
+
+
+# ============================================================================
+# Regression: cross-doc span pooling (#217)
+# ============================================================================
+
+
+def test_no_cross_doc_span_matching_in_build_template_rows() -> None:
+    """Regression for #217: spans must be matched within each document.
+
+    Two docs share template "t1".  Both have a gold ORGANIZATION span at
+    (0, 4).  Only doc-0 has a matching prediction at (0, 4); doc-1 has no
+    prediction.  Before the fix, pooling collapsed both gold spans into one
+    set entry (deduplication) and matched the single prediction against the
+    deduplicated set, yielding TP=1, FN=0 (recall=1.0).  Correct per-doc
+    accounting gives TP=1, FN=1 (recall=0.5).
+    """
+    predictions_by_variant = {
+        "custom_a": [
+            {
+                "doc_idx": 0,
+                "template": "t1",
+                "predictions": [(0, 4, "ORGANIZATION", None, 0)],
+                "gold": [(0, 4, "ORGANIZATION")],
+            },
+            {
+                "doc_idx": 1,
+                "template": "t1",
+                "predictions": [],
+                "gold": [(0, 4, "ORGANIZATION")],
+            },
+        ]
+    }
+    specs = _stub_specs({"custom_a": False})
+    rows = cb._build_measurement_rows(predictions_by_variant, specs)
+    org_rows = [r for r in rows if r["entity"] == "ORGANIZATION"]
+    assert len(org_rows) == 1
+    r = org_rows[0]
+    # Per-doc: doc-0 → tp=1, fn=0; doc-1 → tp=0, fn=1.  Aggregated: tp=1, fp=0, fn=1.
+    assert r["tp"] == 1, f"expected tp=1, got {r['tp']}"
+    assert r["fp"] == 0, f"expected fp=0, got {r['fp']}"
+    assert r["fn"] == 1, f"expected fn=1, got {r['fn']}"
+
+
+def test_no_cross_doc_span_matching_in_aggregate_recall() -> None:
+    """Regression for #217: _aggregate_recall must not inflate recall via cross-doc matching.
+
+    Two docs share template "t1".  Each doc has 5 gold ORGANIZATION spans at
+    the same offsets (0,4), (4,8), (8,12), (12,16), (16,20).  Only doc-0 has
+    matching predictions; doc-1 has none.
+
+    Before the fix, pooling the two docs' gold spans into a set collapsed all
+    duplicates down to 5 unique offsets, and the 5 predictions from doc-0
+    matched all 5, giving recall=1.0.  Correct per-doc accounting:
+      doc-0: TP=5, FN=0
+      doc-1: TP=0, FN=5
+    aggregated TP=5, FN=5 → recall=0.5.
+    """
+    offsets = [(i * 4, i * 4 + 4, "ORGANIZATION") for i in range(5)]
+    rows_by_template: dict[str, dict] = {
+        "t1": {
+            "docs": [
+                {
+                    "pred_spans": list(offsets),
+                    "gold_spans": list(offsets),
+                },
+                {
+                    "pred_spans": [],
+                    "gold_spans": list(offsets),
+                },
+            ]
+        }
+    }
+    result = cb._aggregate_recall(rows_by_template, "ORGANIZATION")
+    assert "t1" in result
+    recall = result["t1"]
+    assert recall is not None, "expected a numeric recall (total_gold=10 >= MIN_SPANS=5)"
+    # TP=5, FN=5 → 0.5
+    assert abs(recall - 0.5) < 1e-9, f"expected recall=0.5, got {recall}"


### PR DESCRIPTION
## Summary

Fixes the HIGH-priority bug reported in #217: `compare_baselines.py` was pooling prediction and gold spans across all documents sharing a template before calling `token_overlap_f1` / `strict_span_f1`. Since spans are bare `(start, end, label)` char-offset tuples with no document identity, a prediction at `(0, 4, ORGANIZATION)` in doc-17 could match a gold span at `(0, 4, ORGANIZATION)` in doc-3 — inflating TP and deflating FN. `_build_measurement_rows` additionally converted the pooled lists to sets, deduplicating identical offsets from different docs and undercounting TP/FN in the persisted artifact rows.

## Changes

**`packages/training/src/pleno_ner_training/compare_baselines.py`**

- `_build_template_rows`: now stores `{"docs": [{"pred_spans": [...], "gold_spans": [...]}, ...]}` per template instead of flat pooled lists. Each doc's spans are kept separate so downstream callers can match within a document.
- `_aggregate_recall`: iterates per-doc, calls `token_overlap_f1` within each doc, accumulates TP/FN counts, computes `recall = total_TP / (total_TP + total_FN)`.
- `_build_measurement_rows`: computes exact-span TP/FP/FN per doc using set intersection/difference within each doc, then sums across docs per template.
- `_strict_recall_for_best`: same per-doc + aggregate pattern using `strict_span_f1`.

**`packages/training/tests/test_compare_baselines.py`**

Two new regression tests that would have caught this before:
- `test_no_cross_doc_span_matching_in_build_template_rows`: two docs, same template, identical gold offsets, prediction only in doc-0 → `tp=1, fp=0, fn=1` (was `tp=1, fp=0, fn=0` before fix due to set deduplication)
- `test_no_cross_doc_span_matching_in_aggregate_recall`: same cross-doc scenario → `recall=0.5` (was `1.0` before fix)

## Test plan

- [x] All 22 existing tests pass (`uv run pytest packages/training/tests/test_compare_baselines.py`)
- [x] Two new regression tests pass and would have failed against the old code
- [ ] Re-run `compare_baselines.py` on the v0.12.0 curated corpus to get corrected R7/R8 gate scores

https://claude.ai/code/session_019kcU1zdzc2WXWajRg2EEtA