### PR TITLE
fix(sdk,server): IGNORECASE FPs on ID patterns, stale OPF install docs, HTTP 400 on missing input

### DIFF
--- a/packages/sdk/scripts/eval_pii_masking_300k.py
+++ b/packages/sdk/scripts/eval_pii_masking_300k.py
@@ -21,7 +21,7 @@ Usage:
         --output ../../output/pii-300k-eval.json
 
 Requires:
-    pip install "pleno-anonymize[openai]" datasets
+    pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main' datasets
 """
 
 from __future__ import annotations

--- a/packages/sdk/src/pleno_anonymize/_cli.py
+++ b/packages/sdk/src/pleno_anonymize/_cli.py
@@ -125,7 +125,7 @@ def _add_engine_args(p: argparse.ArgumentParser, *, include_io: bool) -> None:
         help=(
             "detection backend (default: builtin = Presidio + spaCy NER). "
             "openai-privacy-filter uses the open-source OPF model "
-            "(requires `pip install pleno-anonymize[openai]`)"
+            "(requires: pip install 'opf @ git+https://github.com/openai/privacy-filter@main')"
         ),
     )
     p.add_argument(

--- a/packages/sdk/src/pleno_anonymize/_engine.py
+++ b/packages/sdk/src/pleno_anonymize/_engine.py
@@ -74,7 +74,7 @@ def PlenoAnonymize(  # noqa: N802 - factory disguised as a class for ergonomics
 
     ``engine="openai-privacy-filter"``: :class:`OpfEngine` running the
     open-source `openai/privacy-filter` checkpoint via the `opf` package.
-    Requires the ``[openai]`` extra; the model auto-downloads on first call.
+    Requires the ``opf`` package (install separately; see _opf.py for instructions).
 
     Pass ``base_url`` (e.g. ``"https://pleno-anonymize.fly.dev"``) to
     instead use a hosted server via HTTP. The remote engine takes

--- a/packages/sdk/src/pleno_anonymize/_opf.py
+++ b/packages/sdk/src/pleno_anonymize/_opf.py
@@ -1,9 +1,10 @@
 """OpenAI Privacy Filter (OPF) engine — wraps the open-source `opf` package.
 
 Backed by the `openai/privacy-filter` HuggingFace checkpoint (Apache 2.0,
-1.5B params, 50M active). Requires the `[openai]` optional dependency:
+1.5B params, 50M active). The `[openai]` extra was removed (PyPI rejects
+direct-URL extras). Install the dependency separately:
 
-    pip install "pleno-anonymize[openai]"
+    pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main'
 
 Model weights auto-download to ``~/.opf/privacy_filter`` (or ``$OPF_CHECKPOINT``)
 on first call. CPU is supported but GPU is recommended for any non-trivial
@@ -141,8 +142,8 @@ class OpfEngine:
             from opf import OPF  # type: ignore[import-not-found]
         except ImportError as exc:
             raise RuntimeError(
-                "OpenAI Privacy Filter requires the `[openai]` extra: "
-                'pip install "pleno-anonymize[openai]"'
+                "OpenAI Privacy Filter requires the `opf` package. "
+                "Install it with: pip install 'opf @ git+https://github.com/openai/privacy-filter@main'"
             ) from exc
         device = self._device or _default_device()
         kwargs: dict[str, object] = {"device": device, "output_mode": "typed"}

--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -76,7 +76,7 @@ JA_PASSPORT = PiiRecognizer(
     entity="PASSPORT",
     language="ja",
     patterns=(
-        PiiPattern("ja_passport", r"(?<![A-Za-z])[A-Z]{2}\d{7}(?![A-Za-z0-9])", 0.4),
+        PiiPattern("ja_passport", r"(?<![A-Za-z])(?-i:[A-Z]{2})\d{7}(?![A-Za-z0-9])", 0.4),
     ),
     context=("パスポート", "旅券", "passport", "旅券番号"),
 )
@@ -161,7 +161,7 @@ JA_RESIDENCE_CARD = PiiRecognizer(
     language="ja",
     patterns=(
         PiiPattern(
-            "residence_card", r"(?<![A-Za-z])[A-Z]{2}\d{8}[A-Z]{2}(?![A-Za-z])", 0.6
+            "residence_card", r"(?<![A-Za-z])(?-i:[A-Z]{2}\d{8}[A-Z]{2})(?![A-Za-z])", 0.6
         ),
     ),
     context=("在留カード", "在留番号", "residence card", "在留資格"),

--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -76,7 +76,9 @@ JA_PASSPORT = PiiRecognizer(
     entity="PASSPORT",
     language="ja",
     patterns=(
-        PiiPattern("ja_passport", r"(?<![A-Za-z])(?-i:[A-Z]{2})\d{7}(?![A-Za-z0-9])", 0.4),
+        PiiPattern(
+            "ja_passport", r"(?<![A-Za-z])(?-i:[A-Z]{2})\d{7}(?![A-Za-z0-9])", 0.4
+        ),
     ),
     context=("パスポート", "旅券", "passport", "旅券番号"),
 )
@@ -161,7 +163,9 @@ JA_RESIDENCE_CARD = PiiRecognizer(
     language="ja",
     patterns=(
         PiiPattern(
-            "residence_card", r"(?<![A-Za-z])(?-i:[A-Z]{2}\d{8}[A-Z]{2})(?![A-Za-z])", 0.6
+            "residence_card",
+            r"(?<![A-Za-z])(?-i:[A-Z]{2}\d{8}[A-Z]{2})(?![A-Za-z])",
+            0.6,
         ),
     ),
     context=("在留カード", "在留番号", "residence card", "在留資格"),

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -438,6 +438,8 @@ async def redact(req: RedactRequest):
         elif "webp" in mime_type:
             fmt = "WEBP"
 
+        if fmt == "JPEG" and redacted_img.mode in ("RGBA", "P", "LA"):
+            redacted_img = redacted_img.convert("RGB")
         redacted_img.save(output_buffer, format=fmt)
         output_buffer.seek(0)
         encoded = base64.b64encode(output_buffer.read()).decode("utf-8")
@@ -619,6 +621,8 @@ async def redact_image(image_url: str, http_client: httpx.AsyncClient) -> str:
     elif "gif" in mime_type:
         fmt = "GIF"
 
+    if fmt == "JPEG" and redacted_image.mode in ("RGBA", "P", "LA"):
+        redacted_image = redacted_image.convert("RGB")
     redacted_image.save(output_buffer, format=fmt)
     output_buffer.seek(0)
     encoded = base64.b64encode(output_buffer.read()).decode("utf-8")

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -362,7 +362,9 @@ async def redact(req: RedactRequest):
     The response will contain a redacted image with PII blacked out.
     """
     if not req.text and not req.image:
-        raise HTTPException(status_code=400, detail="Either 'text' or 'image' must be provided")
+        raise HTTPException(
+            status_code=400, detail="Either 'text' or 'image' must be provided"
+        )
 
     result = {}
 

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -362,7 +362,7 @@ async def redact(req: RedactRequest):
     The response will contain a redacted image with PII blacked out.
     """
     if not req.text and not req.image:
-        return {"error": "Either 'text' or 'image' must be provided"}
+        raise HTTPException(status_code=400, detail="Either 'text' or 'image' must be provided")
 
     result = {}
 


### PR DESCRIPTION
## Summary

Four independent bug fixes bundled from issues #221 and #222.

### 1. IGNORECASE false positives on PASSPORT / RESIDENCE_CARD (closes #222 item 3)

Presidio passes `re.IGNORECASE` to all `PatternRecognizer` regexes by default. The `[A-Z]{2}` groups in `JA_PASSPORT` and `JA_RESIDENCE_CARD` patterns were therefore matching lowercase letters:
- `ab1234567` → flagged as `PASSPORT`
- `ab12345678cd` → flagged as `RESIDENCE_CARD`

**Fix:** Wrap the uppercase-letter segments in `(?-i:...)` to disable IGNORECASE locally — same technique already used in `JA_PERSON_LATIN`.

### 2. Stale `[openai]` extra install instructions (closes #222 item 1)

The `[openai]` extra was removed because PyPI rejects direct-URL extras. Four files still prescribed `pip install "pleno-anonymize[openai]"` — following the instruction installs nothing and users get stuck in a loop. Updated to the correct manual install command per `pyproject.toml`.

### 3. HTTP 400 for missing redact input (closes #221 item 4)

`/api/redact` returned `HTTP 200 {"error": "..."}` when neither `text` nor `image` was provided. Changed to `HTTPException(status_code=400)` for correct REST semantics.

### 4. RGBA/P/LA → RGB conversion before JPEG save (closes #221 item 6)

`Pillow` raises `OSError` when saving an RGBA (or palette-mode / LA) image as JPEG because JPEG has no alpha channel. Added `.convert("RGB")` at both image redaction save sites before `format="JPEG"`.

## Test plan

- [x] Pattern assertions verified: `ab1234567` no longer matches PASSPORT; `AB1234567` still matches
- [x] `uv run --project packages/sdk pytest packages/sdk/tests/ -x` (run in CI)