### PR TITLE
training: fix _accumulate_chunks silent-discard on over-MAX_CHARS buffer

### DIFF
--- a/packages/training/src/pleno_ner_training/mine_external_hardneg.py
+++ b/packages/training/src/pleno_ner_training/mine_external_hardneg.py
@@ -104,19 +104,22 @@ def _accumulate_chunks(sentences: Iterable[str]) -> Iterator[str]:
         # tables / list-prose dumped without periods.
         if len(sent) > MAX_CHARS * 2:
             continue
-        buf.append(sent)
-        buf_len += len(sent)
-        if buf_len >= MIN_CHARS:
-            joined = "".join(buf)
-            if len(joined) <= MAX_CHARS:
-                yield joined
-            buf = []
-            buf_len = 0
+        # If adding this sentence would exceed MAX_CHARS, cut here first.
+        if buf and buf_len + len(sent) > MAX_CHARS:
+            if buf_len >= MIN_CHARS:
+                yield "".join(buf)
+            buf = [sent]
+            buf_len = len(sent)
+        else:
+            buf.append(sent)
+            buf_len += len(sent)
+            if buf_len >= MIN_CHARS:
+                yield "".join(buf)
+                buf = []
+                buf_len = 0
     # tail: only emit if it on its own clears MIN_CHARS
     if buf_len >= MIN_CHARS:
-        joined = "".join(buf)
-        if len(joined) <= MAX_CHARS:
-            yield joined
+        yield "".join(buf)
 
 
 def is_safe_negative(text: str) -> bool:

--- a/packages/training/tests/test_mine_external_hardneg.py
+++ b/packages/training/tests/test_mine_external_hardneg.py
@@ -70,6 +70,21 @@ def test_accumulate_chunks_respects_bounds():
         assert MIN_CHARS <= len(c) <= MAX_CHARS
 
 
+def test_accumulate_chunks_does_not_discard_over_max():
+    # Two sentences whose individual length exceeds MAX_CHARS; together
+    # they would overflow. Bug: the old code dropped the buffer silently
+    # instead of cutting and starting fresh, losing both sentences.
+    s1 = "a" * (MAX_CHARS - 1)  # just below MAX_CHARS, above MIN_CHARS
+    s2 = "b" * (MAX_CHARS - 1)
+
+    chunks = list(_accumulate_chunks([s1, s2]))
+    assert len(chunks) == 2, (
+        f"both sentences must be emitted separately; got {len(chunks)} chunk(s)"
+    )
+    for c in chunks:
+        assert MIN_CHARS <= len(c) <= MAX_CHARS, f"chunk out of bounds: len={len(c)}"
+
+
 # ---------- end-to-end dry-run ----------
 
 


### PR DESCRIPTION
Closes #223 (item 3 only)

## Summary
Fixes a silent data-loss bug in `_accumulate_chunks` (mine_external_hardneg.py): when accumulated sentences pushed the buffer past `MAX_CHARS`, the entire buffer was dropped without yielding instead of "cut and start fresh" as the docstring described. This reduced the diversity of the hard-negative training corpus.

## What changed
- `mine_external_hardneg.py`: pre-append check — if adding the new sentence would exceed `MAX_CHARS`, yield the current buffer first (if `>= MIN_CHARS`) then start fresh
- Added regression test `test_accumulate_chunks_does_not_discard_over_max` covering the two-sentence over-MAX case

## What is NOT in this PR (remaining #223 items)
The other 8 items in #223 involve training-pipeline design decisions that need human review:
- **Item 1** (noise floor F0b always 0.0): requires deciding when/how to update the pin post-F1
- **Items 2, 4-9**: model selection bias, alignment failures, tie-break inconsistency, label inventory leakage, `_bio_labels` silently drops tokens, compute_ci_bootstrap unfiltered outputs — all require understanding of training semantics before fixing

## Test plan
- [ ] `pytest packages/training/tests/test_mine_external_hardneg.py -v`
- [ ] New test `test_accumulate_chunks_does_not_discard_over_max` passes
- [ ] Existing test `test_accumulate_chunks_respects_bounds` passes