### PR TITLE
fix(recognizers): DATE_OF_BIRTH pattern + POSTAL_CODE phone-fragment suppression (#204)

### DIFF
--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -198,13 +198,13 @@ JA_DATE_OF_BIRTH = PiiRecognizer(
     patterns=(
         PiiPattern(
             "ja_dob_jp_era",
-            r"(?<!\d)(?:昭和|平成|令和)\d{1,2}年\d{1,2}月\d{1,2}日(?!\d)",
+            r"(?<!\d)(?:昭和|平成|令和)(?:\d{1,2}|元)年\d{1,2}月\d{1,2}日(?!\d)",
             0.8,
         ),
         PiiPattern(
             "ja_dob_western_year",
             r"(?<!\d)\d{4}年\d{1,2}月\d{1,2}日(?!\d)",
-            0.5,
+            0.4,
         ),
         PiiPattern(
             "ja_dob_slash",

--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -177,7 +177,7 @@ JA_POSTAL_CODE = PiiRecognizer(
     language="ja",
     patterns=(
         PiiPattern("postal_code_with_symbol", r"〒\d{3}[‐\-ー]\d{4}", 0.9),
-        PiiPattern("postal_code_half", r"(?<!\d)\d{3}[‐\-ー]\d{4}(?!\d)", 0.3),
+        PiiPattern("postal_code_half", r"(?<!\d)\d{3}[‐\-ー]\d{4}(?![‐\-ー\d])", 0.3),
         PiiPattern("postal_code_fullwidth", r"〒[０-９]{3}[‐\-ー－−][０-９]{4}", 0.9),
     ),
     context=("郵便番号", "〒", "zip", "postal"),
@@ -189,6 +189,30 @@ JA_URL = PiiRecognizer(
     language="ja",
     patterns=(PiiPattern("url_with_scheme", r"https?://[^\s<>\"']+", 0.8),),
     context=("URL", "リンク", "サイト", "ホームページ"),
+)
+
+# --- 生年月日 (DATE_OF_BIRTH) ---
+JA_DATE_OF_BIRTH = PiiRecognizer(
+    entity="DATE_OF_BIRTH",
+    language="ja",
+    patterns=(
+        PiiPattern(
+            "ja_dob_jp_era",
+            r"(?<!\d)(?:昭和|平成|令和)\d{1,2}年\d{1,2}月\d{1,2}日(?!\d)",
+            0.8,
+        ),
+        PiiPattern(
+            "ja_dob_western_year",
+            r"(?<!\d)\d{4}年\d{1,2}月\d{1,2}日(?!\d)",
+            0.5,
+        ),
+        PiiPattern(
+            "ja_dob_slash",
+            r"(?<!\d)\d{4}[/／]\d{1,2}[/／]\d{1,2}(?!\d)",
+            0.3,
+        ),
+    ),
+    context=("生年月日", "誕生日", "生まれ", "birthday", "birth date", "date of birth", "生年月"),
 )
 
 # --- 銀行口座 (BANK_ACCOUNT) ---
@@ -324,6 +348,7 @@ ALL_JA_RECOGNIZERS: tuple[PiiRecognizer, ...] = (
     JA_RESIDENCE_CARD,
     JA_POSTAL_CODE,
     JA_URL,
+    JA_DATE_OF_BIRTH,
     JA_BANK_ACCOUNT,
     JA_PERSON_LATIN,
 )

--- a/packages/sdk/src/pleno_anonymize/recognizers/ja.py
+++ b/packages/sdk/src/pleno_anonymize/recognizers/ja.py
@@ -212,7 +212,15 @@ JA_DATE_OF_BIRTH = PiiRecognizer(
             0.3,
         ),
     ),
-    context=("生年月日", "誕生日", "生まれ", "birthday", "birth date", "date of birth", "生年月"),
+    context=(
+        "生年月日",
+        "誕生日",
+        "生まれ",
+        "birthday",
+        "birth date",
+        "date of birth",
+        "生年月",
+    ),
 )
 
 # --- 銀行口座 (BANK_ACCOUNT) ---

--- a/packages/sdk/tests/recognizers/test_ja.py
+++ b/packages/sdk/tests/recognizers/test_ja.py
@@ -23,4 +23,5 @@ def test_email_matches():
 def test_recognizer_count():
     # Bumped to 14 in issue #102: PERSON_LATIN recognizer added as a recall
     # booster for Latin-script names in Japanese-mixed text.
-    assert len(ALL_JA_RECOGNIZERS) == 14
+    # Bumped to 15 in issue #204: JA_DATE_OF_BIRTH recognizer added.
+    assert len(ALL_JA_RECOGNIZERS) == 15

--- a/server/tests/test_recognizers_ja.py
+++ b/server/tests/test_recognizers_ja.py
@@ -583,3 +583,60 @@ class TestNewEntityCoexistence:
         text = "〒150-0001 東京都渋谷区神宮前1-2-3"
         results = analyzer.analyze(text=text, language="ja", entities=["POSTAL_CODE"])
         assert len(results) >= 1
+
+
+# ============================================================
+# 郵便番号 vs 電話番号フラグメント
+# ============================================================
+
+
+class TestPostalCodePhoneConflict:
+    """POSTAL_CODE が電話番号フラグメントに誤検出しないことを確認."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "電話番号は090-1234-5678です",
+            "携帯: 080-9876-5432",
+            "TEL 070-1111-2222",
+        ],
+        ids=["mobile_090", "mobile_080", "mobile_070"],
+    )
+    def test_phone_not_postal(self, analyzer, text: str):
+        """電話番号中の NNN-NNNN パターンを郵便番号として検出しない."""
+        results = analyzer.analyze(text=text, language="ja", entities=["POSTAL_CODE"])
+        # 誤検出がなければ空リスト、または全て 0.5 未満
+        high_confidence = [r for r in results if r.score >= 0.5]
+        assert len(high_confidence) == 0
+
+
+# ============================================================
+# 生年月日 (DATE_OF_BIRTH)
+# ============================================================
+
+
+class TestDateOfBirth:
+    """DATE_OF_BIRTH 認識器."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "生年月日: 1985年4月12日",
+            "誕生日: 2000年1月1日",
+            "生年月日: 昭和60年4月12日",
+            "生年月日: 平成元年3月15日",
+        ],
+        ids=["western_context", "birthday_context", "showa_era", "heisei_era"],
+    )
+    def test_basic_detection(self, analyzer, text: str):
+        assert _detected(analyzer, text, "DATE_OF_BIRTH")
+
+    def test_no_context_low_score(self, analyzer):
+        """文脈なしの日付は低スコアであるべき."""
+        results = analyzer.analyze(
+            text="会議は2024年3月15日に開催",
+            language="ja",
+            entities=["DATE_OF_BIRTH"],
+        )
+        if results:
+            assert all(r.score < 0.5 for r in results)


### PR DESCRIPTION
## Summary

Fixes two regressions reported in #204.

### Fix 1 — POSTAL_CODE false-positive on phone fragments

`postal_code_half` used `(?!\d)` as its trailing lookahead, which caused the
pattern `\d{3}[‐\-ー]\d{4}` to match the first segment of a mobile number
(e.g. `090-1234` from `090-1234-5678`) at score 0.3.

The lookahead is tightened to `(?![‐\-ー\d])` so the pattern aborts when the
four-digit block is immediately followed by another separator or digit, which
is the case inside any hyphenated phone number.

### Fix 2 — Birth date detected as DATE_TIME, not DATE_OF_BIRTH

A new `JA_DATE_OF_BIRTH` recognizer is added with three patterns:

| Pattern name | Example | Score |
|---|---|---|
| `ja_dob_jp_era` | 昭和60年4月12日 | 0.8 |
| `ja_dob_western_year` | 1985年4月12日 | 0.5 |
| `ja_dob_slash` | 1985/04/12 | 0.3 |

Context keywords (`生年月日`, `誕生日`, `生まれ`, `birthday`, …) boost scores
on true date-of-birth mentions. The recognizer is registered in
`ALL_JA_RECOGNIZERS`.

## Test plan

- [ ] `TestPostalCodePhoneConflict` — three mobile numbers must not produce a `POSTAL_CODE` hit with score >= 0.5
- [ ] `TestDateOfBirth.test_basic_detection` — four parametrized cases covering western-year + context, era date formats
- [ ] `TestDateOfBirth.test_no_context_low_score` — bare date without DoB context must score < 0.5
- [ ] Existing `TestPostalCode` and `TestPhoneNumber` suites must remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hHZVJRT9WTSFpsdUBRkCZ