### PR TITLE
feat(sdk): add Apple MPS device support for OPF engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Full API surface: [`packages/sdk`](packages/sdk).
 | Engine | Install | Speed | Notes |
 |---|---|---|---|
 | `builtin` (default) | `pip install pleno-anonymize` | ~50 ms/doc CPU | Regex + checksum validators for structured IDs; slim deps |
-| `openai-privacy-filter` | `pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main'` | ~2 s/doc CPU, ~30 ms GPU | English prose, secret detection, higher recall |
+| `openai-privacy-filter` | `pip install pleno-anonymize 'opf @ git+https://github.com/openai/privacy-filter@main'` | ~1.2 s/doc CPU, ~30 ms CUDA GPU | English prose, secret detection, higher recall |
 
 ```bash
 # default — builtin Presidio + pleno_anonymize_ja
@@ -90,6 +90,8 @@ pleno-anonymize analyze --engine openai-privacy-filter --language en \
 ```
 
 OPF adds a `SECRET` class not covered by the builtin engine.
+Apple MPS is supported (`--opf-device mps`) but CPU is faster on macOS
+due to MoE kernel dispatch overhead — see [`docs/benchmark.md`](docs/benchmark.md) §5.1a.
 
 ### Quality
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Backend Comparison on ai4privacy/pii-masking-300k
 
-**Last updated:** 2026-05-12
+**Last updated:** 2026-06-20
 **Authors:** pleno-anonymize team
 **Status:** Initial release. Sample size will grow as additional runs land
 (see [§7](#7-reproducibility)).
@@ -138,18 +138,22 @@ documents, single-threaded, no batching. Cold model load is excluded
 
 ### 4.3 Hardware
 
-| Component | Spec |
-|---|---|
-| CPU | Apple M-series, 12 cores |
-| RAM | 64 GB |
-| GPU | None (deliberately — establishes the CPU-only floor) |
-| OS | macOS 25.3 (Darwin) |
-| Python | 3.12.8 |
-| PyTorch | 2.11.0 (CPU build) |
+Two hardware configurations are reported. Machine A is the original
+CPU-only baseline; Machine B adds the Apple MPS (Metal Performance
+Shaders) GPU measurement.
 
-GPU numbers are interpolated from the OPF model card claim of ≈30 ms/doc
-on a single A100 [\[1\]](#references); we have not measured them
-ourselves and flag this as future work.
+| Component | Machine A | Machine B |
+|---|---|---|
+| CPU | Apple M-series, 12 cores | Apple M3, 8P+2E cores |
+| RAM | 64 GB | 24 GB |
+| GPU | None (CPU-only floor) | Apple M3, 10-core GPU (Metal 4) |
+| OS | macOS 25.3 (Darwin) | macOS 26.3 (Darwin) |
+| Python | 3.12.8 | 3.12.8 |
+| PyTorch | 2.11.0 (CPU build) | 2.12.0 (MPS-capable) |
+
+CUDA GPU numbers are interpolated from the OPF model card claim of
+≈30 ms/doc on a single A100 [\[1\]](#references); we have not measured
+them ourselves and flag this as future work.
 
 ## 5. Results
 
@@ -176,6 +180,37 @@ in-house EN NER simply does not cover the dataset's vocabulary. The
 latency gap (≈200× at n = 300, partly inflated by `builtin` running
 warmer on the larger sample) remains qualitatively the same: OPF runs a
 1.5B-parameter transformer per call.
+
+### 5.1a Apple MPS (Metal) latency (English, τ = 0.5, Machine B)
+
+To evaluate whether Apple's Metal Performance Shaders backend can
+accelerate OPF on Apple Silicon, we measured OPF on Machine B with
+`--opf-device mps` and `--opf-device cpu` in sequential (non-concurrent)
+runs. OPF's MoE layer requires Triton kernels for GPU-optimized
+inference; Triton is unavailable on macOS, so MPS falls back to a
+pure-PyTorch codepath (`OPF_MOE_TRITON=0`).
+
+| Device | Precision | Recall | F1 | Latency / doc | n |
+|---|---:|---:|---:|---:|---:|
+| CPU (Machine B) | 0.904 | 0.747 | 0.818 | **1,151 ms** | 300 |
+| MPS (Machine B) | 0.904 | 0.748 | 0.818 | 1,848 ms | 300 |
+
+**CPU is 38 % faster than MPS on this workload.** Quality metrics are
+identical (deterministic model, same checkpoint). The MPS slowdown is
+attributed to three factors: (i) the pure-PyTorch MoE fallback performs
+many small per-expert matrix multiplications that do not amortize MPS
+kernel launch overhead; (ii) the Viterbi CRF decoder runs sequentially
+on CPU for non-CUDA devices, introducing MPS→CPU synchronization stalls;
+(iii) Apple M3 CPU cores are fast enough at bf16 matmuls that the
+overhead of dispatching to MPS exceeds the compute benefit for this model
+shape.
+
+MPS is therefore supported (`--opf-device mps`) but **not auto-selected**
+by the device detection logic. The operational recommendation for macOS
+remains `--opf-device cpu` (or omit the flag — CPU is the default on
+non-CUDA machines). MPS may become competitive if OPF upstream ships a
+Metal-native or fused MoE kernel, or if a future PyTorch version improves
+MPS dispatch overhead for sparse workloads.
 
 ### 5.4 Sample-size sensitivity
 
@@ -254,15 +289,24 @@ artifact of taxonomy mismatch.
 
 ### 6.2 Latency-quality tradeoff
 
-OPF's 2.2 s/doc on CPU is incompatible with interactive workloads (the
-LLM proxy budgets <100 ms for preprocessing). The model card reports
-≈30 ms on a single A100 GPU, which would close the gap entirely; we
-defer the empirical GPU number to a follow-up that runs on a RunPod A100
-or H100 pod. Until that lands, the operational recommendation is:
+OPF's 1.2–2.2 s/doc on CPU (hardware-dependent) is incompatible with
+interactive workloads (the LLM proxy budgets <100 ms for preprocessing).
+The model card reports ≈30 ms on a single A100 GPU, which would close
+the gap entirely; we defer the empirical CUDA GPU number to a follow-up
+that runs on a RunPod A100 or H100 pod.
+
+**Apple MPS does not help.** On Apple M3, MPS is 38 % slower than CPU
+(§5.1a). The root cause is OPF's 128-expert sparse MoE architecture: the
+Triton-optimized kernel is unavailable on macOS, and the pure-PyTorch
+fallback generates many small per-expert matmuls that do not amortize MPS
+dispatch overhead. MPS is supported as an explicit opt-in
+(`--opf-device mps`) for experimentation but is not recommended for
+production use. Until CUDA GPU inference is on the operational menu, the
+recommendation is:
 
 * **Latency-bound traffic (Japanese proxy hot path, default):** `builtin`
 * **Accuracy-bound traffic (English-heavy, batch redaction, audit logs):**
-  `openai-privacy-filter`
+  `openai-privacy-filter` (CPU)
 * **Secret detection (API keys, credentials):** `openai-privacy-filter`
   is currently the only path — `builtin` has no `SECRET` class.
 
@@ -292,8 +336,8 @@ or H100 pod. Until that lands, the operational recommendation is:
   should degrade more gracefully.
 * **No batching.** OPF supports batched inference; our latency numbers
   are the worst-case single-call regime.
-* **CPU-only.** GPU latency is interpolated from the OPF model card, not
-  measured.
+* **No CUDA GPU.** CUDA latency is interpolated from the OPF model card,
+  not measured. Apple MPS was measured but is slower than CPU (§5.1a).
 * **No fine-tuning.** OPF supports task-specific fine-tuning; we
   evaluate the off-the-shelf checkpoint. A fine-tune on JP-first data
   could close the language gap and is in scope for follow-up work.

--- a/packages/sdk/scripts/eval_pii_masking_300k.py
+++ b/packages/sdk/scripts/eval_pii_masking_300k.py
@@ -223,7 +223,7 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument(
         "--opf-device",
         default=None,
-        choices=("cpu", "cuda"),
+        choices=("cpu", "cuda", "mps"),
         help="device hint for openai-privacy-filter (auto-detected if omitted)",
     )
     args = p.parse_args(argv)

--- a/packages/sdk/src/pleno_anonymize/_cli.py
+++ b/packages/sdk/src/pleno_anonymize/_cli.py
@@ -131,7 +131,7 @@ def _add_engine_args(p: argparse.ArgumentParser, *, include_io: bool) -> None:
     p.add_argument(
         "--opf-device",
         default=None,
-        choices=("cpu", "cuda"),
+        choices=("cpu", "cuda", "mps"),
         help="device for openai-privacy-filter (auto-detected by default)",
     )
     p.add_argument(

--- a/packages/sdk/src/pleno_anonymize/_opf.py
+++ b/packages/sdk/src/pleno_anonymize/_opf.py
@@ -40,7 +40,13 @@ OPF_LABEL_TO_PLENO: dict[str, str] = {
 
 
 def _default_device() -> str:
-    """Pick `cuda` if available, else `cpu`. Keeps the CLI usable on laptops."""
+    """Pick the best available accelerator: ``cuda`` > ``cpu``.
+
+    MPS is supported (``--opf-device mps``) but not auto-selected: OPF's
+    pure-PyTorch MoE fallback (Triton is unavailable on macOS) runs ~40 %
+    slower on MPS than on CPU due to kernel-launch overhead on many small
+    expert matmuls.
+    """
     try:
         import torch  # type: ignore[import-not-found]
 
@@ -145,6 +151,10 @@ class OpfEngine:
                 'pip install "pleno-anonymize[openai]"'
             ) from exc
         device = self._device or _default_device()
+        if device == "mps":
+            import os
+
+            os.environ.setdefault("OPF_MOE_TRITON", "0")
         kwargs: dict[str, object] = {"device": device, "output_mode": "typed"}
         if self._checkpoint is not None:
             kwargs["model"] = self._checkpoint


### PR DESCRIPTION
## Summary

Add Apple Metal Performance Shaders (MPS) as a supported device for the OpenAI Privacy Filter engine. MPS is available as an explicit opt-in (`--opf-device mps`) but **not auto-selected** — benchmarks show CPU is faster.

## Benchmark results (Apple M3, 24GB, n=300, sequential runs)

| Device | F1 | Latency / doc |
|---|---:|---:|
| CPU | 0.818 | **1,151 ms** |
| MPS | 0.818 | 1,848 ms |

**CPU is 38% faster than MPS** on this workload. The MPS slowdown is caused by OPF's 128-expert sparse MoE architecture: the Triton-optimized kernel is unavailable on macOS, and the pure-PyTorch fallback generates many small per-expert matmuls that do not amortize MPS kernel dispatch overhead.

## Changes

- `_opf.py`: auto-set `OPF_MOE_TRITON=0` when device is `mps` (Triton unavailable on macOS); keep auto-detection as `cuda > cpu`
- `_cli.py`, eval script: add `mps` to `--opf-device` choices
- `docs/benchmark.md`: add §5.1a with MPS vs CPU measurements
- `README.md`: note MPS support with CPU recommendation