### PR TITLE
feat(playground): add openai/privacy-filter as a third engine

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -47,8 +47,10 @@ _analyzer = None
 _anonymizer = None
 _image_redactor = None
 _appi_pipeline = None
+_openai_pf_pipeline = None
 _init_lock = threading.Lock()
 _appi_lock = threading.Lock()
+_openai_pf_lock = threading.Lock()
 
 
 def _init_presidio():
@@ -214,6 +216,80 @@ def _analyze_appi(text: str) -> list[dict]:
     return entities
 
 
+# openai/privacy-filter — Apache-2.0 token-classification model.
+# 8 categories with BIOES tags: account_number, private_address, private_email,
+# private_person, private_phone, private_url, private_date, secret.
+_OPENAI_PF_MODEL_ID = os.getenv("OPENAI_PF_MODEL_ID", "openai/privacy-filter")
+
+# Map model's label vocabulary onto the playground's display types so the
+# existing entity legend / colour map covers it without a second taxonomy.
+_OPENAI_PF_TYPE_MAP = {
+    "private_person": "PERSON",
+    "private_email": "EMAIL_ADDRESS",
+    "private_phone": "PHONE_NUMBER",
+    "private_address": "ADDRESS",
+    "private_url": "URL",
+    "private_date": "DATE_TIME",
+    "account_number": "ACCOUNT_NUMBER",
+    "secret": "SECRET",
+}
+
+
+def _get_openai_pf_pipeline():
+    global _openai_pf_pipeline
+    if _openai_pf_pipeline is not None:
+        return _openai_pf_pipeline
+    with _openai_pf_lock:
+        if _openai_pf_pipeline is not None:
+            return _openai_pf_pipeline
+        from transformers import (
+            AutoModelForTokenClassification,
+            AutoTokenizer,
+            pipeline,
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained(_OPENAI_PF_MODEL_ID)
+        model = AutoModelForTokenClassification.from_pretrained(_OPENAI_PF_MODEL_ID)
+        # aggregation_strategy="first": merge BIOES subword tags into full entity
+        # spans whose offsets correspond to the original text. Other strategies
+        # ("simple", "max", "average") drop sub-token alignment metadata needed
+        # for the playground's character-level highlight overlay.
+        _openai_pf_pipeline = pipeline(
+            task="token-classification",
+            model=model,
+            tokenizer=tokenizer,
+            aggregation_strategy="first",
+        )
+        return _openai_pf_pipeline
+
+
+def _analyze_openai_pf(text: str) -> list[dict]:
+    pipe = _get_openai_pf_pipeline()
+    raw = pipe(text)
+    out: list[dict] = []
+    for span in raw:
+        group = span.get("entity_group") or span.get("entity")
+        if not group or group == "O":
+            continue
+        etype = _OPENAI_PF_TYPE_MAP.get(group, group.upper())
+        start = int(span["start"])
+        end = int(span["end"])
+        # Playground returns codepoint offsets elsewhere; the HF tokenizer here
+        # reports UTF-16-agnostic codepoint offsets too because Python str is
+        # codepoint-indexed. text[start:end] therefore preserves the original
+        # span exactly.
+        out.append(
+            {
+                "entity_type": etype,
+                "start": start,
+                "end": end,
+                "score": float(span.get("score", 0.0)),
+                "text": text[start:end],
+            }
+        )
+    return out
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Warm up NER models in background after startup."""
@@ -346,8 +422,12 @@ class AnalyzeRequest(BaseModel):
     entities: Optional[List[str]] = None
     engine: str = Field(
         default="default",
-        pattern=r"^(default|appi)$",
-        description="NER engine: 'default' (spaCy + Presidio) or 'appi' (APPI Art. 2(3) DeBERTa)",
+        pattern=r"^(default|appi|openai-privacy-filter)$",
+        description=(
+            "NER engine: 'default' (spaCy + Presidio), "
+            "'appi' (APPI Art. 2(3) DeBERTa), or "
+            "'openai-privacy-filter' (openai/privacy-filter 1.5B MoE)"
+        ),
     )
 
 
@@ -360,8 +440,12 @@ class RedactRequest(BaseModel):
     fill_color: Optional[List[int]] = [0, 0, 0]  # RGB for image redaction
     engine: str = Field(
         default="default",
-        pattern=r"^(default|appi)$",
-        description="NER engine: 'default' (spaCy + Presidio) or 'appi' (APPI Art. 2(3) DeBERTa)",
+        pattern=r"^(default|appi|openai-privacy-filter)$",
+        description=(
+            "NER engine: 'default' (spaCy + Presidio), "
+            "'appi' (APPI Art. 2(3) DeBERTa), or "
+            "'openai-privacy-filter' (openai/privacy-filter 1.5B MoE)"
+        ),
     )
 
     @field_validator("fill_color")
@@ -406,6 +490,11 @@ async def analyze(req: AnalyzeRequest):
 
     if req.engine == "appi":
         return await loop.run_in_executor(None, partial(_analyze_appi, req.text))
+
+    if req.engine == "openai-privacy-filter":
+        return await loop.run_in_executor(
+            None, partial(_analyze_openai_pf, req.text)
+        )
 
     entities_key = tuple(req.entities) if req.entities else None
     results = await loop.run_in_executor(
@@ -460,10 +549,13 @@ async def redact(req: RedactRequest):
     result = {}
 
     if req.text:
-        if req.engine == "appi":
+        if req.engine in {"appi", "openai-privacy-filter"}:
+            analyze_fn = (
+                _analyze_appi if req.engine == "appi" else _analyze_openai_pf
+            )
 
-            def _redact_appi():
-                entities = _analyze_appi(req.text)
+            def _redact_from_entities():
+                entities = analyze_fn(req.text)
                 text = req.text
                 for ent in sorted(entities, key=lambda e: e["start"], reverse=True):
                     et = ent["entity_type"]
@@ -471,7 +563,7 @@ async def redact(req: RedactRequest):
                 return text
 
             loop = asyncio.get_event_loop()
-            result["text"] = await loop.run_in_executor(None, _redact_appi)
+            result["text"] = await loop.run_in_executor(None, _redact_from_entities)
             result["items"] = []
         else:
             entities_key = tuple(req.entities) if req.entities else None

--- a/website/src/pages/PlaygroundPage.tsx
+++ b/website/src/pages/PlaygroundPage.tsx
@@ -115,6 +115,24 @@ const ENTITY_COLORS: Record<string, { bg: string; text: string; border: string; 
     border: 'rgba(139, 92, 246, 0.3)',
     glow: 'rgba(139, 92, 246, 0.15)',
   },
+  ACCOUNT_NUMBER: {
+    bg: 'rgba(20, 184, 166, 0.12)',
+    text: '#2dd4bf',
+    border: 'rgba(20, 184, 166, 0.3)',
+    glow: 'rgba(20, 184, 166, 0.15)',
+  },
+  SECRET: {
+    bg: 'rgba(234, 179, 8, 0.12)',
+    text: '#facc15',
+    border: 'rgba(234, 179, 8, 0.3)',
+    glow: 'rgba(234, 179, 8, 0.15)',
+  },
+  ADDRESS: {
+    bg: 'rgba(251, 146, 60, 0.12)',
+    text: '#fb923c',
+    border: 'rgba(251, 146, 60, 0.3)',
+    glow: 'rgba(251, 146, 60, 0.15)',
+  },
   DEFAULT: {
     bg: 'rgba(148, 163, 184, 0.12)',
     text: '#94a3b8',
@@ -151,6 +169,16 @@ const MODELS: ModelDef[] = [
       '患者 山田太郎はうつ病と診断され、2023年より通院中である。',
       '佐藤花子様の健康診断結果: HbA1c 7.2%、血圧 152/96mmHg。要精密検査。',
       '被告人 渡辺健は窃盗罪で懲役1年6月の判決を受けた。',
+    ],
+  },
+  {
+    engine: 'openai-privacy-filter',
+    name: 'OpenAI Privacy Filter (1.5B MoE)',
+    description: 'openai/privacy-filter — 8 PII spans (person/email/phone/address/url/date/account/secret)',
+    samples: [
+      'My name is Harry Potter and my email is harry.potter@hogwarts.edu. Call me at +1-555-0142.',
+      'Wire $4,500 to account 0123-456789 owned by Jane Doe. Internal ref: ORDER-77821-XB.',
+      'Patient Yamada Taro (DOB 1985-03-12) visited clinic on 2024-09-01. Contact: taro@example.com.',
     ],
   },
 ];
@@ -727,7 +755,10 @@ export default function PlaygroundPage() {
                       if (hasResult) return true;
                       const appiTypes = ['MEDICAL_HISTORY', 'HEALTH_CHECKUP', 'DISABILITY', 'CRIMINAL_RECORD', 'CRIME_VICTIM', 'RACE', 'CREED', 'SOCIAL_STATUS', 'PERSON', 'ADDRESS', 'ORGANIZATION', 'DATE_OF_BIRTH', 'BANK_ACCOUNT'];
                       const defaultTypes = ['PERSON', 'EMAIL_ADDRESS', 'PHONE_NUMBER', 'LOCATION', 'DATE_TIME', 'URL'];
-                      return engine === 'appi' ? appiTypes.includes(k) : defaultTypes.includes(k);
+                      const openaiTypes = ['PERSON', 'EMAIL_ADDRESS', 'PHONE_NUMBER', 'ADDRESS', 'URL', 'DATE_TIME', 'ACCOUNT_NUMBER', 'SECRET'];
+                      if (engine === 'appi') return appiTypes.includes(k);
+                      if (engine === 'openai-privacy-filter') return openaiTypes.includes(k);
+                      return defaultTypes.includes(k);
                     })
                     .map(([type, color]) => (
                       <div key={type} className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

Adds [openai/privacy-filter](https://huggingface.co/openai/privacy-filter) — OpenAI's open-source 1.5B-parameter MoE PII detector (Apache-2.0) — as a third engine in the playground, alongside `default` (spaCy + Presidio) and `appi` (DeBERTa).

Selecting **OpenAI Privacy Filter (1.5B MoE)** in the model dropdown routes `/api/analyze` and `/api/redact` through the new pipeline; everything else (highlight overlay, redact mode, copy, entity legend) keeps working unchanged.

## What changed

**Server (`server/src/app.py`)**
- Lazy-load `openai/privacy-filter` via `transformers.pipeline("token-classification", aggregation_strategy="first")` so subword BIOES tags collapse into character-offset spans aligned to the input text.
- Map the model's 8 labels (`private_person`, `private_email`, `private_phone`, `private_address`, `private_url`, `private_date`, `account_number`, `secret`) onto the playground's display types so the existing legend covers them.
- Extend the `engine` regex to `^(default|appi|openai-privacy-filter)$` and dispatch through both analyze and redact endpoints (redact reuses the offset-replacement path already used by `appi`).

**Playground (`website/src/pages/PlaygroundPage.tsx`)**
- Add a third `MODELS` entry with sample inputs that exercise the model's strengths (account numbers, dates, secrets).
- Add `ACCOUNT_NUMBER`, `SECRET`, `ADDRESS` to the entity colour map.
- Extend the legend filter so only the 8 relevant types surface when this engine is selected.

## Notes

- Model is ~1.5B params (50M active per inference thanks to MoE). First request will be slow due to download/load; subsequent requests reuse the cached pipeline.
- No new API key / credential is required — runs entirely on-device on the server.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Python syntax parses cleanly
- [ ] Manual: open Playground, select OpenAI Privacy Filter, run a sample, confirm entities render and redact mode produces `<PERSON>` etc.