### PR TITLE
fix(server): eager-load openai/privacy-filter in lifespan warmup

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -375,6 +375,22 @@ async def lifespan(app: FastAPI):
     def _warmup():
         _init_presidio()
         logger.info("Models loaded successfully")
+        # openai/privacy-filter ships as quantized ONNX with a 1.6 GB external
+        # data blob. Even with the build-time prefetch (see Dockerfile), the
+        # first onnxruntime.InferenceSession load takes ~60 s on the fly
+        # machine — past the gateway timeout, so the first user request after
+        # a cold start would 502. Eager-load it during lifespan so the cold
+        # request burn lands on the machine boot, not on a real user.
+        try:
+            _get_openai_pf_pipeline()
+            logger.info("openai/privacy-filter session ready")
+        except Exception as e:
+            # Best-effort: if this engine fails to load (e.g. HF transient),
+            # the default + appi engines must still come up. The lazy path
+            # in _analyze_openai_pf will surface the real error on demand.
+            logger.error(
+                json.dumps({"event": "openai_pf_warmup_failed", "error": str(e)})
+            )
 
     threading.Thread(target=_warmup, daemon=True).start()
     yield


### PR DESCRIPTION
## Why

User reported 502 Bad Gateway against `/api/analyze?engine=openai-privacy-filter` in production after a fly cold start. The first `onnxruntime.InferenceSession` load of the 1.6 GB external-data quantized ONNX takes ~60 s on the fly machine — past the gateway timeout — so the first user request after a machine boot reliably 502s even though the build-time prefetch already removed the network fetch.

## Fix

Mirror the appi engine's existing lifespan warmup pattern: kick off the openai/privacy-filter ONNX session load on the existing background warmup thread, so the cold burn happens during machine boot, not on a real user request.

Wrapped in try/except so a transient HF failure on this engine alone doesn't block the default + appi engines from coming up; the lazy path in `_analyze_openai_pf` will surface the real error on demand.

## Verification plan

1. Wait for deploy.
2. Force a cold start (or wait for fly autostop).
3. `curl POST /api/analyze … engine=openai-privacy-filter` should return 200 on the first attempt.