### PR TITLE
fix(website): declare packages field in pnpm-workspace.yaml

### DIFF
--- a/server/src/app.py
+++ b/server/src/app.py
@@ -375,6 +375,22 @@ async def lifespan(app: FastAPI):
     def _warmup():
         _init_presidio()
         logger.info("Models loaded successfully")
+        # openai/privacy-filter ships as quantized ONNX with a 1.6 GB external
+        # data blob. Even with the build-time prefetch (see Dockerfile), the
+        # first onnxruntime.InferenceSession load takes ~60 s on the fly
+        # machine — past the gateway timeout, so the first user request after
+        # a cold start would 502. Eager-load it during lifespan so the cold
+        # request burn lands on the machine boot, not on a real user.
+        try:
+            _get_openai_pf_pipeline()
+            logger.info("openai/privacy-filter session ready")
+        except Exception as e:
+            # Best-effort: if this engine fails to load (e.g. HF transient),
+            # the default + appi engines must still come up. The lazy path
+            # in _analyze_openai_pf will surface the real error on demand.
+            logger.error(
+                json.dumps({"event": "openai_pf_warmup_failed", "error": str(e)})
+            )
 
     threading.Thread(target=_warmup, daemon=True).start()
     yield

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - .
 allowBuilds:
   esbuild: true
   vue-demi: true


### PR DESCRIPTION
Deploy Website workflow has failed on every push since #263 with `ERROR packages field missing or empty`. pnpm v9 (used in .github/workflows/website.yml) requires a `packages:` field — without it `pnpm install --frozen-lockfile` exits 1 before any build can run.

As a direct result, the Playground UI at https://plenoai.com/pleno-anonymize/playground has been frozen at the pre-#263 build — the new OpenAI Privacy Filter entry never appeared in the model dropdown (verified just now in a browser).

Add `packages: ['.']` so pnpm treats the website dir as a single-package workspace and unblocks every subsequent website deploy.