### PR TITLE
ci(deploy): drop started-state poll in ref-drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
       # have rejected the image during unpack (rootfs > 8GB, registry race) and
       # left the previous image running. Assert the running image ref differs
       # from the pre-deploy snapshot — this is the signal that the new image
-      # actually became live, since flyctl tags with `deployment-<ts>` per push.
+      # was accepted by fly's registry, since flyctl tags with
+      # `deployment-<ts>` per push. Application-level health (new machine is
+      # actually serving) is verified by the /ready check below; we don't
+      # double-wait for "started" state here.
       - name: Verify deployed image ref changed
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -110,36 +113,16 @@ jobs:
           set -eu
           EXPECTED_SHA="${{ github.sha }}"
           BEFORE='${{ steps.pre_deploy.outputs.before }}'
-          # `flyctl deploy --strategy immediate` returns once the platform has
-          # accepted the request, but machines pass through "replacing" before
-          # reaching "started" — the previous one-shot check on commit 7836162
-          # caught machines mid-replace and reported a false "no started
-          # machine" error. Poll for up to ~2 min so the verification only
-          # fires after fly's machine state has settled.
-          STARTED=0
-          AFTER=""
-          for i in $(seq 1 24); do
-            flyctl machine list --app pleno-anonymize --json > machines.json
-            STARTED=$(jq '[.[] | select(.state=="started")] | length' machines.json)
-            AFTER=$(jq -r '[.[] | .config.image] | sort | unique | join(",")' machines.json)
-            echo "attempt $i: started=${STARTED} after=${AFTER}"
-            [ "$STARTED" -ge 1 ] && break
-            sleep 5
-          done
+          flyctl machine list --app pleno-anonymize --json > machines.json
+          AFTER=$(jq -r '[.[] | .config.image] | sort | unique | join(",")' machines.json)
           cat machines.json
           echo "before=${BEFORE}"
           echo "after=${AFTER}"
-          echo "started_count=${STARTED}"
-          if [ "$STARTED" -lt 1 ]; then
-            echo "::error::no started machine after deploy within 2min (sha=${EXPECTED_SHA})"
-            exit 1
-          fi
-          # Empty BEFORE = first deploy / pre-snapshot failed; skip drift check
-          # but still require AFTER to be non-empty.
           if [ -z "$AFTER" ]; then
             echo "::error::no image ref on any machine after deploy (sha=${EXPECTED_SHA})"
             exit 1
           fi
+          # Empty BEFORE = first deploy / pre-snapshot failed; skip drift check.
           if [ -n "$BEFORE" ] && [ "$BEFORE" = "$AFTER" ]; then
             echo "::error::image ref unchanged after deploy (silent fly reject suspected; sha=${EXPECTED_SHA}, image=${AFTER})"
             exit 1


### PR DESCRIPTION
## What

Removes the 14-attempt × 5s poll loop in `Verify deployed image ref changed` that waited for at least one machine to reach `started` state. Reduces the step from a worst-case 2 min poll to a single `flyctl machine list` call (~1s).

## Why

PR #272 cut the deploy job from 608s to 350s by moving to fly's remote builder, but missed the 5-min target by 50s. Per-step breakdown of the post-#272 run (#27900547207):

| step | duration |
| --- | --- |
| setup | 4s |
| flyctl deploy --remote-only | 250s |
| **Verify deployed image ref changed** | **72s** |
| Verify /ready | 21s |
| total | 350s |

Looking at the verify-step log, 13 of 14 poll attempts saw `started_count=0`. The new `deployment-<ts>` ref was already visible at attempt 1 (so the silent-deploy guard already had its signal); the polling was waiting for fly to bring a machine to `started` after `flyctl deploy --strategy immediate` returned early.

Application-level health — whether the new machine actually serves traffic — is what the `/ready` curl loop covers (up to 6 min, took 21s on the last run). Doubling that wait here adds nothing; the ref-drift check just needs to confirm fly accepted the new image, which is true the instant `flyctl deploy` exits.

Expected new total: ~280s (under 5 min).