### PR TITLE
release: EN model 0.3.0 rollout (server pin + SDK 0.2.4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,19 @@ pleno-anonymizeは、個人情報を匿名化するためのサービスです
 適宜pushしてバージョン管理すること
 use runpod for training (use runpod mcp: `mcp__runpod__*` — `create-pod`, `start-pod`, `get-pod`, `delete-pod`, etc.)
 do not train on local machine
+
+<!-- agentops:dreaming:start -->
+# Project memory (managed by agentops dreaming — do not edit between markers)
+
+## ai4privacy-license-constraint ([[ai4privacy-license-constraint]])
+ai4privacy/pii-masking-300k は非商用・派生物公開に書面許諾が必要 — 訓練には使えず評価専用
+
+## en-model-030-release-pending ([[en-model-030-release-pending]])
+EN NER 0.3.0 (pii-300k F1 0.5812, +79%) は PR #288 — HF wheel アップロード完了まで未マージ
+
+## face-redaction-feature ([[face-redaction-feature]])
+Face redaction via OpenCV YuNet merged in PR #195; README banner uses presidio OCR redaction
+
+## readme-redact-banner ([[readme-redact-banner]])
+README before/after presidio OCR redaction banner + reproducible generator script
+<!-- agentops:dreaming:end -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN uv pip install https://github.com/explosion/spacy-models/releases/download/e
 # transformer build that pushed image size to 15.7GB (#177 rollback).
 RUN uv pip install \
     https://huggingface.co/0xhikae/pleno_anonymize_ja/resolve/main/pleno_anonymize_ja-0.2.0-py3-none-any.whl \
-    https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.2.1-py3-none-any.whl
+    https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.3.0-py3-none-any.whl
 
 # Pre-download APPI ONNX model files into HF cache so the first
 # /api/analyze?engine=appi request doesn't block on a network fetch.

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pleno-anonymize"
-version = "0.2.3"
+version = "0.2.4"
 description = "Local-first Japanese PII detection and redaction. SDK + `pleno-anonymize` CLI sharing the same recognizer registry and NER pipeline as the pleno-anonymize server."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
PR #288 の EN 改善を配布経路に反映します。

- **Dockerfile**: `pleno_anonymize_en` 0.2.1 → 0.3.0(main マージで server にデプロイ)
- **SDK 0.2.4**: マージ後に `sdk/v0.2.4` タグを push して PyPI trusted publishing を発火(0.3.0 auto-download URL / overlap dedup / taxonomy mapping fix を含む)

wheel は HF にアップロード済み・URL 解決確認済み (HTTP 200, 26.5MB)。