### PR TITLE
fix(autotrain): sync entrypoint with ner-improve loop assumptions

### DIFF
--- a/autotrain.sh
+++ b/autotrain.sh
@@ -3,30 +3,32 @@
 # プロジェクトルートに配置し、ルートから実行すること
 #
 # Usage:
-#   ./autotrain.sh                    # モデル改善: ja, 3イテレーション
-#   ./autotrain.sh ja 5               # モデル改善: 日本語, 5イテレーション
-#   ./autotrain.sh en 3               # モデル改善: 英語, 3イテレーション
-#   ./autotrain.sh ja 5 --resume      # 前回の続きから再開
-#   ./autotrain.sh ja --evolve        # ベンチマーク進化
-#   ./autotrain.sh ja 5 --full        # モデル改善 → ベンチマーク進化 → モデル改善
+#   ./autotrain.sh                    # モデル改善: en, 3イテレーション
+#   ./autotrain.sh en 5               # モデル改善: 英語, 5イテレーション
+#   ./autotrain.sh fr 3               # モデル改善: フランス語, 3イテレーション
+#   ./autotrain.sh en 5 --resume      # 前回の続きから再開
 #
 # 前提:
 #   - claude CLI がインストール済み
 #   - .env に OPENAI_API_KEY が設定済み
+#   - ja は ai4privacy/pii-masking-300k に日本語行が無いため評価不能 (exit 1)
 
 set -euo pipefail
 
-TARGET_LANG="${1:-ja}"
+TARGET_LANG="${1:-en}"
 MODE="improve"
 MAX_ITER="3"
 EXIT_CODE=0
+
+if [ "$TARGET_LANG" = "ja" ]; then
+  echo "error: ai4privacy/pii-masking-300k に日本語行は無く、このループでは ja を評価できません (.claude/skills/ner-improve/SKILL.md 参照)。en 等サポート言語を指定してください。" >&2
+  exit 1
+fi
 
 # 引数パース
 shift || true
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --evolve)  MODE="evolve"; shift ;;
-    --full)    MODE="full"; shift ;;
     --resume)  MODE="resume"; shift ;;
     *)         MAX_ITER="$1"; shift ;;
   esac
@@ -52,24 +54,20 @@ BANNER
 
 print_scores() {
   local label="$1"
-  local latest_scores
-  latest_scores=$(find "$TRAINING_DIR/data/benchmark" -name "scores.json" -path "*/$TARGET_LANG/*" 2>/dev/null \
-    | sort -V | tail -1) || true
-  if [ -n "$latest_scores" ] && [ -f "$latest_scores" ]; then
-    local version
-    version=$(echo "$latest_scores" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+') || true
-    echo "$label (benchmark $version):"
-    python3 -c "
-import json
-with open('$latest_scores') as f:
-    scores = json.load(f)
-for model, s in scores.items():
-    if model.startswith('_'): continue
-    print(f'  {model}: F1={s[\"ents_f\"]*100:.1f}%  P={s[\"ents_p\"]*100:.1f}%  R={s[\"ents_r\"]*100:.1f}%')
-    for label, v in s.get('ents_per_type', {}).items():
-        print(f'    {label}: F1={v[\"f\"]*100:.1f}%  P={v[\"p\"]*100:.1f}%  R={v[\"r\"]*100:.1f}%')
-" 2>/dev/null || echo "  (scores not parseable)"
+  local latest
+  latest=$(ls -t "$PROJECT_ROOT"/output/pii-300k-eval-*.json 2>/dev/null | head -1) || true
+  if [ -z "$latest" ]; then
+    echo "$label: no baseline eval yet"
+    return
   fi
+  echo "$label ($(basename "$latest")):"
+  python3 -c "
+import json
+with open('$latest') as f:
+    data = json.load(f)
+for engine, s in data['results'].items():
+    print(f'  {engine}: F1={s[\"f1\"]*100:.1f}%  P={s[\"precision\"]*100:.1f}%  R={s[\"recall\"]*100:.1f}%')
+" 2>/dev/null || echo "  (scores not parseable)"
 }
 
 run_claude() {
@@ -114,30 +112,6 @@ case "$MODE" in
 前回の実験ログ ($PREV_COUNT 件) が packages/training/experiments/log.jsonl にあります。
 前回の結果を踏まえて、まだ試していないアプローチから改善を続けてください。" \
       "Model Improvement (resume)" || EXIT_CODE=$?
-    ;;
-
-  evolve)
-    run_claude "/benchmark-evolve $TARGET_LANG" "Benchmark Evolution" || EXIT_CODE=$?
-    ;;
-
-  full)
-    echo "=== Phase 1/3: Model Improvement ==="
-    run_claude "/ner-improve $TARGET_LANG $MAX_ITER" "Model Improvement" || true
-    echo ""
-    print_scores "After improvement"
-    echo ""
-
-    echo "=== Phase 2/3: Benchmark Evolution ==="
-    run_claude "/benchmark-evolve $TARGET_LANG" "Benchmark Evolution" || true
-    echo ""
-
-    echo "=== Phase 3/3: Model Improvement (vs new benchmark) ==="
-    PREV_COUNT=$(wc -l < "$LOG_DIR/log.jsonl" | tr -d ' ')
-    run_claude "/ner-improve $TARGET_LANG $MAX_ITER
-
-ベンチマークが進化しました。新しいベンチマークに対して改善を続けてください。
-実験ログ ($PREV_COUNT 件) が packages/training/experiments/log.jsonl にあります。" \
-      "Model Improvement (vs evolved benchmark)" || true
     ;;
 esac
 


### PR DESCRIPTION
## 概要
`autotrain.sh` が `/ner-improve` skill (`.claude/skills/ner-improve/SKILL.md`) の現行前提と3点で乖離していた問題を修正する。

## 変更内容
1. デフォルト言語を `ja` → `en` に変更。`ja` が明示指定された場合は `pii-masking-300k` に日本語行が無く評価不能である旨のエラーを出力して `exit 1`。
2. 凍結方針 (self-made benchmark は v0.13.0 で凍結済み) に反して存在しない `/benchmark-evolve` skill を呼んでいた `--evolve` / `--full` モードを削除し、usage コメントを更新。
3. `print_scores()` を、凍結ベンチ `packages/training/data/benchmark/*/scores.json` ではなく、判定に使われる `output/pii-300k-eval-*.json` の最新ファイルから overall F1 / precision / recall を表示するよう置換 (`python3 -c` でパース、ファイル無しの場合は "no baseline eval yet" と表示)。

変更は `autotrain.sh` のみ。`bash -n autotrain.sh` で構文検証済み。

Closes #291