### PR TITLE
feat(models): single source of truth for model versions

### DIFF
--- a/packages/models/versions.json
+++ b/packages/models/versions.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Single source of truth for shipped NER model versions (#296). packages/sdk/src/pleno_anonymize/_models.py:MODEL_WHEELS is NOT generated from this file at runtime (SDK must work standalone, see _models.py:23-25) — packages/sdk/tests/test_model_versions.py asserts the two stay in sync instead. Bump here first, then run `make release-model` in packages/training.",
+  "ja": {
+    "version": "0.3.0",
+    "hf_repo": "0xhikae/pleno_anonymize_ja",
+    "wheel_url": "https://huggingface.co/0xhikae/pleno_anonymize_ja/resolve/main/pleno_anonymize_ja-0.3.0-py3-none-any.whl"
+  },
+  "en": {
+    "version": "0.3.0",
+    "hf_repo": "0xhikae/pleno_anonymize_en",
+    "wheel_url": "https://huggingface.co/0xhikae/pleno_anonymize_en/resolve/main/pleno_anonymize_en-0.3.0-py3-none-any.whl"
+  }
+}

--- a/packages/sdk/tests/test_model_versions.py
+++ b/packages/sdk/tests/test_model_versions.py
@@ -1,0 +1,70 @@
+"""Consistency gate between the single-source-of-truth versions.json (#296)
+and pleno_anonymize._models.MODEL_WHEELS.
+
+_models.py never reads versions.json at runtime — the SDK must keep working
+standalone even if packages/models/ is absent from an installed wheel (see
+_models.py:23-25). So instead of generating MODEL_WHEELS from versions.json,
+this test asserts they agree and fails CI the moment someone bumps one file
+without the other.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pleno_anonymize._models import MODEL_WHEELS
+
+# packages/sdk/tests/test_model_versions.py -> packages/models/versions.json
+VERSIONS_JSON = Path(__file__).resolve().parents[2] / "models" / "versions.json"
+
+LANGUAGE_TO_MODEL_NAME = {
+    "ja": "pleno_anonymize_ja",
+    "en": "pleno_anonymize_en",
+}
+
+
+def _load_versions() -> dict:
+    with VERSIONS_JSON.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_versions_json_exists() -> None:
+    assert VERSIONS_JSON.is_file(), f"single source of truth missing: {VERSIONS_JSON}"
+
+
+@pytest.mark.parametrize("language", sorted(LANGUAGE_TO_MODEL_NAME))
+def test_model_wheels_matches_versions_json(language: str) -> None:
+    versions = _load_versions()
+    model_name = LANGUAGE_TO_MODEL_NAME[language]
+    entry = versions[language]
+
+    assert model_name in MODEL_WHEELS, (
+        f"{model_name} declared in versions.json but missing from MODEL_WHEELS"
+    )
+    assert MODEL_WHEELS[model_name] == entry["wheel_url"], (
+        f"MODEL_WHEELS[{model_name!r}] and versions.json[{language!r}].wheel_url "
+        "have drifted — bump both together (see packages/training/Makefile "
+        "release-model target)."
+    )
+    # The version pinned in versions.json must actually be embedded in the
+    # wheel filename the URL resolves to — catches a version bump that forgot
+    # to also update the URL (or vice versa).
+    assert f"-{entry['version']}-py3-none-any.whl" in entry["wheel_url"], (
+        f"versions.json[{language!r}]: version {entry['version']!r} is not "
+        f"reflected in wheel_url {entry['wheel_url']!r}"
+    )
+
+
+def test_no_extra_models_in_wheels() -> None:
+    """Every MODEL_WHEELS entry must trace back to versions.json — otherwise
+    the SDK could ship a model with no recorded version provenance."""
+    versions = _load_versions()
+    known_models = {
+        LANGUAGE_TO_MODEL_NAME[lang]
+        for lang in versions
+        if lang in LANGUAGE_TO_MODEL_NAME
+    }
+    assert set(MODEL_WHEELS) == known_models

--- a/packages/training/MODEL_VERSIONING.md
+++ b/packages/training/MODEL_VERSIONING.md
@@ -83,3 +83,28 @@ pleno_ner_training.export_onnx` 呼び出しに `--revision` / `--dry-run` を
 scaffolding として #71 PR は merge する。実 push は trained artifact が
 `packages/training/output/hf-ja-v02-tiny/` に生成された後 (#48 完了後) に
 最初の `model/v*` tag を切って発火する。
+
+## SDK wheel (`pleno_anonymize_ja`/`_en`) の version single source of truth (#296)
+
+上記の `model/v*` tag flow は ONNX artifact (`0xhikae/ja-ner-onnx`) 向けで、
+SDK が pip install する spaCy wheel (`0xhikae/pleno_anonymize_ja` /
+`_en`) とは別チャネル。こちらは出荷のたびに (1) `make package(-en)` の
+`--version` 手打ち (2) `packages/sdk/src/pleno_anonymize/_models.py` の
+`MODEL_WHEELS` URL 手編集、の2箇所が独立に乖離しうる問題があった (#296)。
+
+`packages/models/versions.json` を言語ごとの `{version, hf_repo, wheel_url}`
+の single source of truth とし、以下のフローに統一する:
+
+1. `make release-model MODEL_LANG=<ja|en> MODEL_VERSION=<x.y.z>`
+   (`packages/training/` から実行) — versions.json を更新し、その version
+   で該当言語の package target を実行し、SDK 側の整合性テスト
+   (`packages/sdk/tests/test_model_versions.py`) を流す。
+2. テストが落ちた場合 (version を上げた直後は必ず落ちる):
+   `packages/sdk/src/pleno_anonymize/_models.py` の `MODEL_WHEELS` を
+   versions.json の新しい wheel_url に手編集する。`_models.py` は SDK が
+   standalone で動くために versions.json を実行時に読まない設計 (同ファイル
+   23-25行のコメント参照) なので、生成ではなくこのテストで両者を拘束する。
+3. 上の 1〜2 コマンドが最後に案内する既存フロー — `push_model_to_hf.py` で
+   wheel を HF Hub に push し、`packages/sdk/pyproject.toml` の version を
+   上げて `sdk/vX.Y.Z` tag を push (trusted publishing で PyPI に出荷) —
+   を実行する。ここは #296 の変更範囲外で、既存の手順のまま。

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -19,7 +19,8 @@
        export-onnx-en-v01-tiny push-hf-en-v01-tiny all-hf-en-v01-tiny \
        train-supervised-ja eval-300k-ja eval-stockmark-ja push-model-hf \
        dump-supervised-en train-supervised-en eval-300k-en push-model-hf-en \
-       generate-special-care convert-hf-special-care train-special-care eval-special-care all-special-care
+       generate-special-care convert-hf-special-care train-special-care eval-special-care all-special-care \
+       release-model
 
 MODEL ?= gpt-5.4-nano
 DOCS_PER_TEMPLATE ?= 20
@@ -40,6 +41,11 @@ DATA_RAW = data/raw
 DATA_PROCESSED = data/processed
 OUTPUT_DIR = output
 MODELS_DIR = ../models
+
+# Single source of truth for shipped model version / HF repo / wheel URL
+# (#296). package / package-en read the version from here instead of a
+# hardcoded --version flag; release-model writes to it.
+VERSIONS_JSON = $(MODELS_DIR)/versions.json
 
 # === 日本語 (既存) ===
 
@@ -96,7 +102,7 @@ package:
 		--model $(OUTPUT_DIR)/model-best \
 		--output $(MODELS_DIR) \
 		--language ja \
-		--version 0.1.0 \
+		--version $(shell jq -r '.ja.version' $(VERSIONS_JSON)) \
 		--build-wheel
 
 # === 日本語 v0.2.0 ===
@@ -206,7 +212,7 @@ package-en:
 		--model $(OUTPUT_DIR)/en/model-best \
 		--output $(MODELS_DIR) \
 		--language en \
-		--version 0.1.1 \
+		--version $(shell jq -r '.en.version' $(VERSIONS_JSON)) \
 		--build-wheel
 
 all-en: generate-en augment-en convert-en train-en evaluate-en package-en
@@ -743,6 +749,45 @@ clean:
 	rm -rf $(OUTPUT_DIR) $(DATA_RAW) $(DATA_PROCESSED)
 
 all: generate convert train evaluate package
+
+# Single-command model version bump (#296): updates versions.json (the
+# source of truth), rebuilds the language's wheel from that version, then
+# re-runs the sdk drift test. HF push and git tag stay manual — the closing
+# echo spells out exactly what's left, since automating those means holding
+# HF_TOKEN / write-tag credentials here instead of in the existing dedicated
+# flows (push_model_to_hf.py, sdk/v* tag CI).
+#
+# Usage: make release-model MODEL_LANG=en MODEL_VERSION=0.4.0
+release-model:
+	@if [ "$(MODEL_LANG)" != "ja" ] && [ "$(MODEL_LANG)" != "en" ]; then \
+		echo "usage: make release-model MODEL_LANG=<ja|en> MODEL_VERSION=<x.y.z>"; \
+		exit 1; \
+	fi
+	@if [ -z "$(MODEL_VERSION)" ]; then \
+		echo "usage: make release-model MODEL_LANG=<ja|en> MODEL_VERSION=<x.y.z>"; \
+		exit 1; \
+	fi
+	@repo=$$(jq -r '.$(MODEL_LANG).hf_repo' $(VERSIONS_JSON)); \
+	jq --arg v '$(MODEL_VERSION)' \
+	   --arg url "https://huggingface.co/$$repo/resolve/main/pleno_anonymize_$(MODEL_LANG)-$(MODEL_VERSION)-py3-none-any.whl" \
+	   '.$(MODEL_LANG).version = $$v | .$(MODEL_LANG).wheel_url = $$url' \
+	   $(VERSIONS_JSON) > $(VERSIONS_JSON).tmp && mv $(VERSIONS_JSON).tmp $(VERSIONS_JSON); \
+	echo "versions.json updated: $(MODEL_LANG) -> $(MODEL_VERSION)"
+	$(MAKE) $(if $(filter en,$(MODEL_LANG)),package-en,package)
+	-cd ../sdk && uv run pytest tests/test_model_versions.py -q
+	@echo ""
+	@echo "== release-model $(MODEL_LANG) $(MODEL_VERSION): versions.json + wheel built =="
+	@echo "if the test above failed (expected on a real bump): hand-edit MODEL_WHEELS in"
+	@echo "  packages/sdk/src/pleno_anonymize/_models.py"
+	@echo "to the new wheel_url — the SDK never reads versions.json at runtime (must stay"
+	@echo "standalone, see _models.py:23-25) — then re-run:"
+	@echo "  cd ../sdk && uv run pytest tests/test_model_versions.py"
+	@echo "remaining manual steps (existing flows, unchanged by this target):"
+	@echo "  1. push the wheel to HF: uv run python scripts/push_model_to_hf.py \\"
+	@echo "       --model-dir $(MODELS_DIR)/pleno_anonymize_$(MODEL_LANG)-$(MODEL_VERSION) \\"
+	@echo "       --repo $$(jq -r '.$(MODEL_LANG).hf_repo' $(VERSIONS_JSON))"
+	@echo "  2. bump packages/sdk/pyproject.toml version, then:"
+	@echo "       git tag sdk/vX.Y.Z && git push origin sdk/vX.Y.Z"
 
 # Supervised JP NER on 0xhikae/pii-masking-300k-ja train split.
 # Dataset is private; dump to local JSONL first, then scp to RunPod.


### PR DESCRIPTION
## 概要

出荷のたびに `make package-en --version` 手打ち → `_models.py` の
`MODEL_WHEELS` URL 手編集、の2箇所が独立に乖離する問題 (#296) を解消する。

## 変更

- `packages/models/versions.json` (新規): 言語ごとの `{version, hf_repo,
  wheel_url}` single source of truth。現行値は `_models.py:MODEL_WHEELS`
  の 0.3.0 をそのまま転記。
- `packages/sdk/tests/test_model_versions.py` (新規): `_models.py` の
  `MODEL_WHEELS` と versions.json が一致することを検証。乖離すると CI が
  落ちる。`_models.py` 自体は versions.json を実行時に読まない設計を維持
  (SDK は standalone で動く必要があるため — `_models.py:23-25` 参照) なので、
  生成ではなくテストで拘束する方式にした。
- `packages/training/Makefile`: `package` (ja) / `package-en` の
  `--version` ハードコード (0.1.0 / 0.1.1、実際の出荷 0.3.0 と既に乖離)
  を versions.json から jq で読む形に修正。`release-model` target を追加:
  `make release-model MODEL_LANG=en MODEL_VERSION=0.4.0` で versions.json
  更新 → package 実行 → 整合性テストまで1コマンド化。HF push / git tag は
  既存フローに委ねる (target 内で行わない) — 最後の echo で次の手順を案内。
- `packages/training/MODEL_VERSIONING.md`: 新フローの節を末尾に追加
  (既存の ONNX `model/v*` tag flow の記述は #295 の担当のため変更なし)。

## 制約遵守

- `_models.py` の `MODEL_WHEELS` の値そのものは変更していない (0.3.0 のまま)。
- `SKILL.md` には触れていない。

## 検証

- `cd packages/sdk && uv run pytest -q` → 63 passed (新規4件含む)。
- `uvx ruff check` / `uvx ruff format --check` → pass。
- `make -n package` / `make -n package-en` → versions.json の 0.3.0 を
  正しく読むことを確認。
- `release-model` は versions.json のテンポラリコピーで jq 更新ロジックを
  個別検証 (対象言語のみ更新され、他言語は不変)。実モデル成果物が無いため
  (ローカル訓練禁止・#48 の trained artifact 前提)、package/pytest を含む
  フルパイプラインの実行検証は未実施 — `make -n release-model
  MODEL_LANG=en MODEL_VERSION=0.4.0` でコマンド列と ja/en の target 振り分け
  (`package` vs `package-en`) を確認済み。

Closes #296