### PR TITLE
fix(training): guard pii-masking-300k license constraints (#294)

### DIFF
--- a/.claude/skills/ner-improve/SKILL.md
+++ b/.claude/skills/ner-improve/SKILL.md
@@ -241,6 +241,7 @@ Next steps:
 - **Never** modify the baseline dataset, the evaluator (`packages/sdk/scripts/eval_pii_masking_300k.py`), or the IoU threshold — the public ruler is fixed.
 - **Never** modify the self-made benchmark data under `packages/training/data/benchmark/v0.*/` — frozen as of v0.13.0.
 - **Never** modify `packages/training/src/pleno_ner_training/entity_types.py` (entity definitions are stable).
+- **Never** train on `ai4privacy/pii-masking-300k` or its local dumps (`data/raw/*-300k-supervised/`) — evaluation-only license; derivative models require written permission.
 - Working directory for training commands: `packages/training/`.
 - Use `dotenvx run -f ../../.env --` for commands that call the OpenAI API.
 - Use `uv run` for all Python commands.

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -752,13 +752,22 @@ SUPERVISED_BASE ?= FacebookAI/xlm-roberta-base
 SUPERVISED_EPOCHS ?= 2
 SUPERVISED_SEED ?= 42
 
+# Guarded: pii-masking-300k(-ja) is non-commercially licensed and evaluation-only
+# for this project (#294). Requires explicit written-permission acknowledgement.
 train-supervised-ja:
+	@if [ "$(I_HAVE_WRITTEN_PERMISSION)" != "1" ]; then \
+		echo "ERROR: pii-masking-300k-ja training requires written permission from" >&2; \
+		echo "AI4Privacy (non-commercial license). Re-run with I_HAVE_WRITTEN_PERMISSION=1" >&2; \
+		echo "only if you have obtained that permission in writing." >&2; \
+		exit 1; \
+	fi
 	uv run --extra training --extra hf python scripts/train_supervised_300k_ja.py \
 		--data-dir $(SUPERVISED_DATA) \
 		--output-dir $(SUPERVISED_OUT) \
 		--base-model $(SUPERVISED_BASE) \
 		--epochs $(SUPERVISED_EPOCHS) \
-		--seed $(SUPERVISED_SEED)
+		--seed $(SUPERVISED_SEED) \
+		--i-have-written-permission
 
 HF_MODEL_REPO ?= 0xhikae/pleno_anonymize_ja
 push-model-hf:
@@ -796,13 +805,22 @@ dump-supervised-en:
 		--language English \
 		--output-dir $(SUPERVISED_EN_DATA)
 
+# Guarded: pii-masking-300k is non-commercially licensed and evaluation-only
+# for this project (#294). Requires explicit written-permission acknowledgement.
 train-supervised-en:
+	@if [ "$(I_HAVE_WRITTEN_PERMISSION)" != "1" ]; then \
+		echo "ERROR: pii-masking-300k (EN) training requires written permission from" >&2; \
+		echo "AI4Privacy (non-commercial license). Re-run with I_HAVE_WRITTEN_PERMISSION=1" >&2; \
+		echo "only if you have obtained that permission in writing." >&2; \
+		exit 1; \
+	fi
 	uv run --extra training --extra hf python scripts/train_supervised_300k_en.py \
 		--data-dir $(SUPERVISED_EN_DATA) \
 		--output-dir $(SUPERVISED_EN_OUT) \
 		--base-model $(SUPERVISED_EN_BASE) \
 		--epochs $(SUPERVISED_EN_EPOCHS) \
-		--seed $(SUPERVISED_EN_SEED)
+		--seed $(SUPERVISED_EN_SEED) \
+		--i-have-written-permission
 
 HF_MODEL_REPO_EN ?= 0xhikae/pleno_anonymize_en
 push-model-hf-en:

--- a/packages/training/data/raw/README.md
+++ b/packages/training/data/raw/README.md
@@ -1,0 +1,23 @@
+# data/raw — dataset provenance notes
+
+## `en-300k-supervised/`, `ja-300k-supervised/`
+
+Local JSONL dumps of `ai4privacy/pii-masking-300k` (EN split) and
+`0xhikae/pii-masking-300k-ja` (JA split, itself derived from the same
+upstream dataset), produced by `scripts/dump_pii_300k.py`.
+
+**Evaluation-only. Do not train on these dumps.** The upstream dataset is
+licensed non-commercially; training a model on it, or publishing any
+derivative model, requires written permission from AI4Privacy. This
+project's shipped models (v0.3.0+) are trained on license-clean Faker
+synthetic data instead — see
+`packages/sdk/src/pleno_anonymize/_models.py`.
+
+`scripts/train_supervised_300k_en.py` and `train_supervised_300k_ja.py`
+refuse to run without an explicit `--i-have-written-permission` flag, and
+the corresponding `Makefile` targets (`train-supervised-en`,
+`train-supervised-ja`) refuse to run without `I_HAVE_WRITTEN_PERMISSION=1`.
+Both directories are also git-ignored — the dumps never leave the local
+machine or a training pod.
+
+See issue #294.

--- a/packages/training/pyproject.toml
+++ b/packages/training/pyproject.toml
@@ -50,6 +50,16 @@ bench = [
     "en-core-web-lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl",
 ]
 
+[dependency-groups]
+# `uv run pytest` must resolve from within packages/training itself — this
+# package ships its own uv.lock so it can be scp'd to a RunPod pod standalone
+# (project CLAUDE.md: do not train on local machine); the workspace-root
+# sdk dev group does not carry over here. Mirrors
+# packages/sdk/pyproject.toml's dev group.
+dev = [
+    "pytest>=8.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/training/scripts/dump_pii_300k.py
+++ b/packages/training/scripts/dump_pii_300k.py
@@ -1,5 +1,8 @@
 """Dump a language slice of ai4privacy/pii-masking-300k to local JSONL.
 
+WARNING: the dumped data is for evaluation only; do not train on it
+without written permission from AI4Privacy (non-commercial license).
+
 Mirror of how the JP supervised v2 pipeline reads its data
 (`train_supervised_300k_ja.py`). The trainer reads from local
 ``train.jsonl`` / ``dev.jsonl`` so the dataset load happens once on a
@@ -81,6 +84,11 @@ def main() -> None:
     p.add_argument("--dev-limit", type=int, default=0, help="0 = no limit")
     p.add_argument("--output-dir", type=Path, required=True)
     args = p.parse_args()
+
+    print(
+        "[warning] dumped data is for evaluation only; do not train on it without "
+        "written permission from AI4Privacy (non-commercial license)."
+    )
 
     from datasets import load_dataset
 

--- a/packages/training/scripts/train_supervised_300k_en.py
+++ b/packages/training/scripts/train_supervised_300k_en.py
@@ -1,5 +1,8 @@
 """Supervised v2 (EN): train on local JSONL dump of ai4privacy/pii-masking-300k EN split.
 
+WARNING: pii-masking-300k is evaluation-only for this project. Training on
+it requires written permission from AI4Privacy (non-commercial license).
+
 Mirrors `train_supervised_300k_ja.py` (same loader, same BIO encoding,
 same Trainer config, same seed pinning) but defaults to a *lightweight*
 English-only backbone — `distilbert-base-uncased` (~66M params, ~265 MB
@@ -26,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -64,7 +68,21 @@ def main() -> None:
     parser.add_argument("--lr", type=float, default=5e-5)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--train-limit", type=int, default=0, help="0 = use full train.jsonl")
+    parser.add_argument("--i-have-written-permission", action="store_true",
+                        help="Confirms you hold written permission from AI4Privacy to train on "
+                             "pii-masking-300k (non-commercial license). Required to proceed.")
     args = parser.parse_args()
+
+    if not args.i_have_written_permission:
+        print(
+            "ERROR: ai4privacy/pii-masking-300k is non-commercially licensed; training on it "
+            "(and publishing any derivative model) requires written permission from AI4Privacy. "
+            "This project treats the dataset as evaluation-only "
+            "(see packages/sdk/src/pleno_anonymize/_models.py). Re-run with "
+            "--i-have-written-permission only if you have obtained that permission in writing.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     import os
     import random

--- a/packages/training/scripts/train_supervised_300k_ja.py
+++ b/packages/training/scripts/train_supervised_300k_ja.py
@@ -1,5 +1,8 @@
 """Supervised v2: train on local JSONL dump of 0xhikae/pii-masking-300k-ja JP split.
 
+WARNING: pii-masking-300k is evaluation-only for this project. Training on
+it requires written permission from AI4Privacy (non-commercial license).
+
 Iteration 1 trained on 2,014 synthetic samples and hit F1 0.352 on the
 validation split — domain-shift-limited. This script trains directly
 on the train split of the same dataset (label-agnostic IoU eval on
@@ -74,7 +77,22 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=16)
     parser.add_argument("--lr", type=float, default=5e-5)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--i-have-written-permission", action="store_true",
+                        help="Confirms you hold written permission from AI4Privacy to train on "
+                             "pii-masking-300k (non-commercial license). Required to proceed.")
     args = parser.parse_args()
+
+    if not args.i_have_written_permission:
+        print(
+            "ERROR: 0xhikae/pii-masking-300k-ja is derived from ai4privacy/pii-masking-300k, "
+            "which is non-commercially licensed; training on it (and publishing any derivative "
+            "model) requires written permission from AI4Privacy. This project treats the "
+            "dataset as evaluation-only (see packages/sdk/src/pleno_anonymize/_models.py). "
+            "Re-run with --i-have-written-permission only if you have obtained that permission "
+            "in writing.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     # Reproducibility: fix all RNGs we touch.
     import os, random

--- a/packages/training/tests/test_license_guard.py
+++ b/packages/training/tests/test_license_guard.py
@@ -1,0 +1,51 @@
+"""Guard test for #294: pii-masking-300k is evaluation-only for this project.
+
+`train_supervised_300k_en.py` trains on a local dump of the non-commercially
+licensed `ai4privacy/pii-masking-300k` dataset. An autonomous agent (e.g.
+`/ner-improve`) could mistake the filename for a usable training script and
+run it, producing a derivative model published without the written
+permission the license requires. The script must abort before any heavy
+work (dataset load, model download, training) starts unless the caller
+passes `--i-have-written-permission`.
+
+This subprocess-invokes the real script with no flags, so it also pins that
+the guard runs before the `datasets`/`transformers` imports — the test
+completes in well under a second, no training or network I/O involved.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "train_supervised_300k_en.py"
+
+
+def test_refuses_without_permission_flag() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 1, (
+        f"expected exit 1 without --i-have-written-permission, got {result.returncode}\n"
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "written permission" in result.stderr
+    assert "AI4Privacy" in result.stderr
+
+
+def test_help_mentions_permission_flag() -> None:
+    """--help should surface the flag without tripping the guard (argparse exits 0 first)."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert "--i-have-written-permission" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,10 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1D"
+
 [manifest]
 members = [
     "pleno-anonymize",
@@ -2626,7 +2630,7 @@ wheels = [
 
 [[package]]
 name = "pleno-anonymize"
-version = "0.2.3"
+version = "0.2.5"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "presidio-analyzer" },
@@ -2760,6 +2764,11 @@ training = [
     { name = "spacy-transformers" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'hf'", specifier = ">=0.30" },
@@ -2787,6 +2796,9 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.40" },
 ]
 provides-extras = ["training", "hf", "bench"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "pluggy"


### PR DESCRIPTION
## Summary

`ai4privacy/pii-masking-300k` is non-commercially licensed; training on it (or publishing a derivative model) requires written permission from AI4Privacy. This project treats the dataset as evaluation-only (v0.3.0 models are trained on license-clean Faker synthetic data instead, per `packages/sdk/src/pleno_anonymize/_models.py:31-34`), but the 300k training scripts/Makefile targets were runnable with no acknowledgement of that constraint — an autonomous agent (e.g. `/ner-improve`) could mistake the filenames for usable training scripts and produce a license-violating derivative model.

## Changes

- **`train_supervised_300k_{en,ja}.py`**: `main()` now aborts (exit 1, stderr warning) before any dataset/model loading unless `--i-have-written-permission` is passed. Docstrings lead with the license warning.
- **`dump_pii_300k.py`**: docstring + runtime stdout warning that dumped data is evaluation-only. Dumping itself is not blocked (evaluation dumps are legitimate).
- **`Makefile`**: `train-supervised-en` / `train-supervised-ja` now require `I_HAVE_WRITTEN_PERMISSION=1` or exit 1, and forward `--i-have-written-permission` to the script when set.
- **`data/raw/README.md`** (new): documents `en-300k-supervised/` / `ja-300k-supervised/` as evaluation-only dumps.
- **`.claude/skills/ner-improve/SKILL.md`**: added a single `## Constraints` bullet forbidding training on pii-masking-300k or its local dumps (only this one line touched, per concurrent-edit constraint).
- **`tests/test_license_guard.py`** (new): subprocess-invokes the EN script with no flags, asserts exit 1 and the written-permission message on stderr. The guard runs before any heavy import, so the test completes in well under a second.
- **`packages/training/pyproject.toml` + root `uv.lock`**: added a `dev` dependency group (`pytest`) to `pleno-ner-training` so `cd packages/training && uv run pytest tests/test_license_guard.py` works standalone (mirrors `packages/sdk`'s existing dev group). Training logic itself is untouched.

## Verification

```
cd packages/training && uv run pytest tests/test_license_guard.py -v
# 2 passed
```

Closes #294