### PR TITLE
docs: sync ner-improve SKILL.md / MODEL_VERSIONING.md / runpod-training.md with reality

### DIFF
--- a/.claude/skills/ner-improve/SKILL.md
+++ b/.claude/skills/ner-improve/SKILL.md
@@ -60,8 +60,10 @@ generate_data / augment → convert_to_docbin → spacy train → evaluate → e
 - Training package: `packages/training/`
 - Prompts: `packages/training/src/pleno_ner_training/prompts/`
 - Training configs: `packages/training/configs/`
-- Raw / processed training data: `packages/training/data/raw/{language}/`, `data/processed/{language}/`
-- Model output: `packages/training/output/`
+- Raw training data: `packages/training/data/raw/` — not a uniform `{language}/` layout. On disk: `en/` (`generated.json`, `augmented.json`), `ja-v02/` (`generated.json`, `augmented.json`, `address_precision_extra.json`), `ja-v02-extra/` (`generated.json`). Gitignored and not yet materialized until their target runs: `ja-300k-supervised/`, `en-300k-supervised/` (`make dump-supervised-en`, `scripts/train_supervised_300k_{ja,en}.py --data-dir`), `ja-special-care/` (`make generate-special-care`).
+- Processed training data: `packages/training/data/processed/<name>/` — gitignored `.spacy` DocBins produced by `convert_to_docbin` (e.g. `ja-v02/train.spacy`).
+- Model output: `packages/training/output/` (the Makefile's `$(OUTPUT_DIR)`, gitignored). No fixed `{language}/` schema — each Makefile target writes its own subdir, e.g. `ja-v02/model-best` (`train-v02`), `en-ner-supervised-v2/` (`train-supervised-en`), `hf-ja-v02-tiny*/` (HF tracks). Currently populated: `output/scores.json`, `output/ja/`, `output/en/`, `output/en-transformer/` (see the `model-best` path used in Phase 2 below). Run `ls packages/training/output/` to confirm the current layout before assuming a path.
+- Baseline-eval JSON reports: repo-root `output/` (e.g. `output/pii-300k-eval-en-300.json`, written in Phase 0/2 below) — gitignored and **distinct from `packages/training/output/`** above. Root `output/` holds public-baseline eval results; `packages/training/output/` holds trained model checkpoints/scores. Same name, different directory — do not conflate them.
 - Experiment log: `packages/training/experiments/log.jsonl`
 - Baseline evaluator: `packages/sdk/scripts/eval_pii_masking_300k.py`
 - Makefile: `packages/training/Makefile`

--- a/packages/training/MODEL_VERSIONING.md
+++ b/packages/training/MODEL_VERSIONING.md
@@ -1,8 +1,13 @@
 # Model Versioning
 
-ONNX NER モデルを HuggingFace Hub (`0xhikae/ja-ner-onnx`) に release する手順と
-バージョニング規約。Closes #71. CI 実装は
+spaCy CNN の ONNX NER モデルを HuggingFace Hub (`0xhikae/ja-ner-onnx`) に
+release する手順とバージョニング規約。Closes #71. CI 実装は
 `.github/workflows/release-model.yml` を参照。
+
+このリポジトリには他に 2 つの独立した HF 配布先があるが、いずれも本 doc の
+tag-push フローの対象外 (下記「他の配布先との関係」参照): SDK が自動
+ダウンロードする `pleno_anonymize_{ja,en}` wheel と、server の APPI エンジンが
+使う `ja-ner-appi-v1-onnx`。
 
 ## TL;DR
 
@@ -78,11 +83,27 @@ pleno_ner_training.export_onnx` 呼び出しに `--revision` / `--dry-run` を
 追加した形で実行する (Makefile target の wrapper にはしない — workflow で
 直接 flag を制御するほうが dry-run path が明示的になるため)。
 
-## 実 release は #48 完了後
+## 現状 (2026-07 時点)
 
-scaffolding として #71 PR は merge する。実 push は trained artifact が
-`packages/training/output/hf-ja-v02-tiny/` に生成された後 (#48 完了後) に
-最初の `model/v*` tag を切って発火する。
+`model/v0.13.0` tag で `0xhikae/ja-ner-onnx` への実 push が 1 回発火済み。
+このタグ運用は spaCy CNN (`ja-v02` / `hf-ja-v02-tiny*` 系) の ONNX 成果物専用
+であり、以下の「他の配布先との関係」で説明する ja/en 0.3.0 の出荷経路とは
+別系統である。
+
+## 他の配布先との関係
+
+同じ repo に、本 doc の tag-push フローとは別の HF 配布先が 2 つ存在する。
+混同しないこと。
+
+| 配布先 | 用途 | push 経路 | 参照元 |
+|---|---|---|---|
+| `0xhikae/ja-ner-onnx` | spaCy CNN の ONNX export (本 doc の対象) | `model/v*` tag → `release-model.yml` | `export_onnx.py` |
+| `0xhikae/pleno_anonymize_ja` / `pleno_anonymize_en` | SDK が実行時に自動 download する model wheel。ja/en とも 0.3.0 を出荷済み | `make push-model-hf` / `push-model-hf-en` → `scripts/push_model_to_hf.py` (tag 起点ではない ad-hoc push) | `packages/sdk/src/pleno_anonymize/_models.py` の `MODEL_WHEELS` |
+| `0xhikae/ja-ner-appi-v1-onnx` | server の APPI エンジン (要配慮個人情報, DeBERTa v2 ONNX) が読む transformer モデル。`APPI_MODEL_ID` 環境変数で上書き可能 | 単発 feature 実装時に手動 push (本 doc の release flow 対象外) | `server/src/app.py` の `_APPI_MODEL_ID` |
+
+ja/en 0.3.0 の出荷は `pleno_anonymize_{ja,en}` 経路で完了済みであり、本 doc の
+`model/v*` tag-push は spaCy CNN ONNX 成果物を追加 release したい場合にのみ
+使う。
 
 ## SDK wheel (`pleno_anonymize_ja`/`_en`) の version single source of truth (#296)
 

--- a/packages/training/tests/test_docs_paths.py
+++ b/packages/training/tests/test_docs_paths.py
@@ -1,0 +1,82 @@
+"""Verify `packages/training/` path references in agent-facing docs are real.
+
+SKILL.md (`.claude/skills/ner-improve/SKILL.md`) and `MODEL_VERSIONING.md`
+are read and trusted by autonomous agents. Issue #295: agents burned
+iterations exploring paths those docs claimed existed but didn't, because
+the docs drifted from the actual directory layout over time. This test
+extracts every inline-code `packages/training/...` path reference from both
+docs and asserts it resolves against the real repo tree, so drift is caught
+by CI instead of by an agent mid-loop.
+
+Dynamic path templates — glob segments like `v0.*` or placeholders like
+`<name>` / `{language}` — cannot resolve to one literal path by design, so
+only their static ancestor directory is required to exist.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILL_MD = REPO_ROOT / ".claude/skills/ner-improve/SKILL.md"
+MODEL_VERSIONING_MD = REPO_ROOT / "packages/training/MODEL_VERSIONING.md"
+
+# Fenced code blocks hold illustrative examples (e.g. a hypothetical
+# experiment-log entry) that are not path references to verify.
+_FENCE_RE = re.compile(r"```.*?```", re.S)
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_PATH_RE = re.compile(r"packages/training/[A-Za-z0-9_.\-/*<>{}]*")
+
+# Any of these characters mark a path as a glob/placeholder template rather
+# than a literal, resolvable path.
+_DYNAMIC_MARKERS = re.compile(r"[*<>{}]")
+
+
+def _extract_training_paths(doc: Path) -> set[str]:
+    text = _FENCE_RE.sub("", doc.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for span in _INLINE_CODE_RE.findall(text):
+        found.update(_PATH_RE.findall(span))
+    return found
+
+
+def _static_parent(path_str: str) -> str:
+    """Directory that would *contain* instances of a glob/placeholder template.
+
+    E.g. `data/processed/<name>/` -> `data` (`data/processed` itself is a
+    gitignored, on-demand directory and legitimately absent until a training
+    run creates it; `data` is not, so a deleted/renamed pipeline stage still
+    fails this check).
+    """
+    static_part = _DYNAMIC_MARKERS.split(path_str, maxsplit=1)[0].rstrip("/")
+    return static_part.rsplit("/", 1)[0]
+
+
+def _assert_paths_resolve(paths: set[str]) -> None:
+    missing = []
+    for raw in sorted(paths):
+        if _DYNAMIC_MARKERS.search(raw):
+            parent = _static_parent(raw)
+            if not (REPO_ROOT / parent).is_dir():
+                missing.append(f"{raw!r} (static ancestor {parent!r} missing)")
+            continue
+        candidate = raw.rstrip("/")
+        if not (REPO_ROOT / candidate).exists():
+            missing.append(raw)
+    assert not missing, (
+        "doc references packages/training/ paths that do not exist:\n"
+        + "\n".join(missing)
+    )
+
+
+def test_skill_md_training_paths_exist():
+    paths = _extract_training_paths(SKILL_MD)
+    assert paths, "expected packages/training/ path references in SKILL.md"
+    _assert_paths_resolve(paths)
+
+
+def test_model_versioning_md_training_paths_exist():
+    paths = _extract_training_paths(MODEL_VERSIONING_MD)
+    assert paths, "expected packages/training/ path references in MODEL_VERSIONING.md"
+    _assert_paths_resolve(paths)


### PR DESCRIPTION
## 背景

agent が信頼する `SKILL.md` / `MODEL_VERSIONING.md` / `runpod-training.md` の記載が実態と乖離しており、存在しないパスの探索でトークンを浪費していた (#295)。

## 変更内容

**`.claude/skills/ner-improve/SKILL.md`** — Key paths 節のみ更新 (他は未変更):
- `data/raw/{language}/` という誤った一様レイアウト記述を、実ディレクトリ (`en/`, `ja-v02/`, `ja-v02-extra/`) と、Makefile ターゲット実行時にのみ生成される gitignored ディレクトリ (`ja-300k-supervised/`, `en-300k-supervised/`, `ja-special-care/`) の区別を明示する記述に置き換え
- model output が言語ごとに固定スキーマではなく Makefile ターゲットごとに書き先が変わる実態を明記し、現在実在するサブディレクトリを列挙
- リポジトリルート `output/` (baseline-eval JSON) と `packages/training/output/` (モデル成果物) という同名・別役割の2箇所を明示して混同を防止

**`packages/training/MODEL_VERSIONING.md`**:
- 「実 release は #48 完了後」という陳腐化した未来形記述を削除し、ja/en 0.3.0 出荷済みという現状に更新
- 配布先が実際には3系統 (`0xhikae/ja-ner-onnx` = spaCy CNN ONNX / `pleno_anonymize_{ja,en}` = SDK wheel / `ja-ner-appi-v1-onnx` = server APPI エンジン) あることを表で明記し、`server/src/app.py` の `APPI_MODEL_ID` および SDK `_models.py` の `MODEL_WHEELS` と整合させた

**`packages/training/docs/runpod-training.md`**:
- Python 3.13 前提の記述を、training パッケージの `requires-python = ">=3.12"` に合わせて修正 (`runpod-gpu-inference.md` と表現を統一)
- ハードコード IP の除去は #292 の担当のため未変更

**`packages/training/tests/test_docs_paths.py`** (新規):
- SKILL.md / MODEL_VERSIONING.md からインラインコードの `packages/training/...` パス参照を正規表現で抽出し、実リポジトリに存在することを検証
- glob (`v0.*`) / プレースホルダ (`<name>`) を含む動的パスは、その静的な祖先ディレクトリの存在チェックに緩和
- `packages/training/pyproject.toml` に `dev` dependency-group (pytest) を追加。従来 training パッケージには dev group が無く `uv run pytest` 自体が失敗していた (副次的な技術的負債の解消)

## 動作確認

```
cd packages/training && uv run --frozen pytest tests/test_docs_paths.py -v
# 2 passed
```

意図的に `packages/training/Makefile` への参照を存在しないパスに書き換えてテストが red になることを確認済み (回帰検知が機能することの確認)。

Closes #295