### PR TITLE
feat(training): code RunPod training pipeline (#292)

### DIFF
--- a/.claude/skills/ner-improve/SKILL.md
+++ b/.claude/skills/ner-improve/SKILL.md
@@ -142,11 +142,12 @@ Log the hypothesis to the experiment log, then proceed immediately. Do NOT ask f
 
 2. **Implement** the specific change (recognizer, prompts, augmented data, config).
 
-3. **Train** the language being improved:
+3. **Train** the language being improved, on RunPod (per CLAUDE.md: do **not** train on the local machine). `make runpod-train-en` / `make runpod-train-ja` is the single path — it wraps `scripts/runpod_train.py`, which does create-pod → upload → train (CNN config, ~5–10 min) → collect `model-best` → delete-pod as one command, deleting the pod even on failure:
    ```bash
-   cd packages/training && make train-en   # or the appropriate Makefile target
+   cd packages/training
+   RUNPOD_API_KEY=... make runpod-train-en   # or runpod-train-ja
    ```
-   Use the CNN config for rapid iteration (~5–10 min). Use RunPod via the `mcp__runpod__*` MCP tools (`create-pod`, `start-pod`, `get-pod`, `delete-pod`) for GPU training (per CLAUDE.md: do **not** train on the local machine).
+   To see the pod spec / upload list / train command without spending anything, run `make runpod-train-en DRY_RUN=1` first. See `packages/training/docs/runpod-training.md` for details.
 
 4. **Evaluate against the baseline** (the only metric that gates Phase 3):
    ```bash

--- a/packages/training/Makefile
+++ b/packages/training/Makefile
@@ -1,5 +1,6 @@
 .PHONY: generate convert train train-cnn evaluate benchmark-external benchmark-huggingface package clean \
-       generate-en augment-en convert-en train-en evaluate-en benchmark-external-en package-en all-en \
+       generate-en augment-en convert-en train-en train-en-cnn evaluate-en benchmark-external-en package-en all-en \
+       runpod-train-ja runpod-train-en \
        benchmark-v02-generate benchmark-v02-generate-en benchmark-v02-evaluate benchmark-v02-evaluate-en \
        benchmark-v03-generate benchmark-v03-generate-en benchmark-v03-evaluate benchmark-v03-evaluate-en \
        benchmark-v04-generate benchmark-v04-generate-en benchmark-v04-evaluate benchmark-v04-evaluate-en \
@@ -27,6 +28,20 @@ BATCHES_PER_TEMPLATE ?= 50
 MAX_WORKERS ?= 5
 GPU_ID ?= 0
 DOTENVX = dotenvx run -f ../../.env --
+
+# CLAUDE.md: "do not train on local machine". The four in-process spaCy
+# train targets below (train, train-cnn, train-en, train-en-cnn) refuse to
+# run unless LOCAL=1 is passed explicitly (see the guard at the top of each
+# recipe) — use `make runpod-train-en` / `make runpod-train-ja` instead
+# (#292). LOCAL is opt-in per invocation, e.g. `make train-cnn LOCAL=1`.
+LOCAL ?=
+LOCAL_TRAIN_GUARD = @test "$(LOCAL)" = "1" || { echo "CLAUDE.md: do not train on local machine. Use \`make runpod-train-*\` or pass LOCAL=1 to override." >&2; exit 1; }
+
+# Set DRY_RUN=1 to have the runpod-train-* targets print their execution
+# plan (pod spec, upload paths, remote commands) and exit without calling
+# the RunPod API or spending money.
+DRY_RUN ?=
+RUNPOD_DRY_RUN_FLAG = $(if $(DRY_RUN),--dry-run,)
 
 # Path (or spaCy package name) used by the en benchmark evaluate targets.
 # Default mirrors the ja side which uses $(OUTPUT_DIR)/model-best — i.e. the
@@ -59,6 +74,7 @@ convert:
 		--output-dir $(DATA_PROCESSED)/ja
 
 train:
+	$(LOCAL_TRAIN_GUARD)
 	uv run --extra training python -m spacy train configs/train_transformer.cfg \
 		--output $(OUTPUT_DIR) \
 		--paths.train $(DATA_PROCESSED)/ja/train.spacy \
@@ -66,6 +82,7 @@ train:
 		--gpu-id $(GPU_ID)
 
 train-cnn:
+	$(LOCAL_TRAIN_GUARD)
 	uv run python -m spacy train configs/train_cnn.cfg \
 		--output $(OUTPUT_DIR) \
 		--paths.train $(DATA_PROCESSED)/ja/train.spacy \
@@ -175,6 +192,7 @@ convert-en:
 		--output-dir $(DATA_PROCESSED)/en
 
 train-en:
+	$(LOCAL_TRAIN_GUARD)
 	uv run --extra training python -m spacy train configs/train_transformer_en.cfg \
 		--output $(OUTPUT_DIR)/en \
 		--paths.train $(DATA_PROCESSED)/en/train.spacy \
@@ -182,10 +200,29 @@ train-en:
 		--gpu-id $(GPU_ID)
 
 train-en-cnn:
+	$(LOCAL_TRAIN_GUARD)
 	uv run python -m spacy train configs/train_cnn_en.cfg \
 		--output $(OUTPUT_DIR)/en \
 		--paths.train $(DATA_PROCESSED)/en/train.spacy \
 		--paths.dev $(DATA_PROCESSED)/en/dev.spacy
+
+runpod-train-ja:
+	uv run --extra training python scripts/runpod_train.py \
+		--language ja \
+		--train-config configs/train_cnn.cfg \
+		--data-dir $(DATA_PROCESSED)/ja \
+		--remote-output-dir $(OUTPUT_DIR) \
+		--local-output-dir $(OUTPUT_DIR)/model-best \
+		$(RUNPOD_DRY_RUN_FLAG)
+
+runpod-train-en:
+	uv run --extra training python scripts/runpod_train.py \
+		--language en \
+		--train-config configs/train_cnn_en.cfg \
+		--data-dir $(DATA_PROCESSED)/en \
+		--remote-output-dir $(OUTPUT_DIR)/en \
+		--local-output-dir $(OUTPUT_DIR)/en/model-best \
+		$(RUNPOD_DRY_RUN_FLAG)
 
 evaluate-en:
 	uv run python -m pleno_ner_training.evaluate \

--- a/packages/training/docs/runpod-training.md
+++ b/packages/training/docs/runpod-training.md
@@ -2,15 +2,28 @@
 
 spaCy CNN学習をRunPod CPUポッドで実行する手順。
 
+`make runpod-train-ja` / `make runpod-train-en` (実体は
+`scripts/runpod_train.py`) が create-pod → データ転送 → 学習実行 → artifact
+回収 → delete-pod を1コマンドで実行する。ポッドのIP/PORTは実行の都度
+RunPod APIから取得するため、本ドキュメントにハードコードされたIPは存在しない
+（していた場合は陳腐化した古い手順）。`try/finally` で学習が失敗しても pod は
+必ず削除されるため、手動 Terminate 忘れによるコスト垂れ流しは起きない。
+
 ## 推奨構成
 
 | 項目 | 推奨値 | 備考 |
 |---|---|---|
-| インスタンス | CPU5 Compute-Optimized | 5+ GHz, DDR5, AMD EPYC 4564P |
-| vCPU / RAM | **8 vCPU / 16 GB** | OOM回避のため必須（下記参照） |
+| インスタンス | CPU5 Compute-Optimized (`cpuFlavorIds=["cpu5c"]`) | 5+ GHz, DDR5, AMD EPYC 4564P |
+| vCPU / RAM | **8 vCPU / 16 GB** (`--vcpu-count 8`, スクリプトのデフォルト) | OOM回避のため必須（下記参照） |
 | コスト | $0.28/hr | 学習30-60分 = $0.14-0.28/回 |
-| テンプレート | Runpod Ubuntu 20.04 | Python 3.13同梱 |
-| SSH | 有効必須 | SCP/SFTPはexposed TCP経由 |
+| イメージ | `runpod/base:0.6.2-cpu` (スクリプトのデフォルト、`--image` で上書き可) | Python 3.13同梱の RunPod Ubuntu 20.04 系イメージ |
+| SSH | 有効必須 | `scripts/runpod_train.py` がポッド作成時に `22/tcp` を公開し、SSH/SCPで接続する |
+
+これらは全て `scripts/runpod_train.py` の CLI 引数のデフォルト値であり、
+`--cpu-flavor-id` / `--vcpu-count` / `--image` 等で明示的に上書きできる。
+値が古くなった場合は https://console.runpod.io/deploy?type=CPU で最新の
+イメージ/フレーバーを確認し、フラグで上書きするか本ドキュメントとスクリプトの
+デフォルトを更新すること（IPのような一過性の値をハードコードしない）。
 
 ## OOM（メモリ不足）に関する重要な注意
 
@@ -34,9 +47,11 @@ spaCy CNN学習をRunPod CPUポッドで実行する手順。
 
 ### OOM回避のルール
 
-1. **8 vCPU / 16 GB ($0.28/hr) を最小構成とする**
-2. データ量が40,000件を超える場合は 16 vCPU / 32 GB ($0.56/hr) を検討
-3. 学習開始後5分以内に `free -h` でメモリ使用量を確認し、80%を超えていたらポッドをアップグレード
+1. **8 vCPU / 16 GB ($0.28/hr) を最小構成とする** (`scripts/runpod_train.py` のデフォルト)
+2. データ量が40,000件を超える場合は `--vcpu-count 16` (16 vCPU / 32 GB, $0.56/hr) を検討
+3. `scripts/runpod_train.py` は学習コマンドをブロッキング実行するため、学習中の
+   メモリ使用量を見たい場合は別ターミナルから
+   `ssh -p <port> root@<ip> free -h` （IP/PORTは実行中のログに出力される）
 4. **コスト節約のために小さいインスタンスを選ぶと、OOMでデータとコストの両方を失う** — 大きめを選ぶ方が結果的に安い
 
 ## 手順
@@ -56,76 +71,55 @@ uv run python -m pleno_ner_training.convert_to_docbin \
   --language ja \
   --input data/raw/ja-v02/augmented.json \
   --output-dir data/processed/ja-v02
-
-# アーカイブ作成
-tar czf /tmp/ner-train-data.tar.gz data/processed/ja-v02/ configs/train_cnn.cfg
 ```
 
-### 2. ポッドデプロイ (Chrome)
+`data/processed/ja-v02` のように既定の `data/processed/ja` 以外のディレクトリを
+使う場合は、次のステップで `--data-dir` を明示的に渡す（後述）。
 
-1. https://console.runpod.io/deploy?type=CPU&cpu=cpu5c-4-8&template=runpod-ubuntu
-2. SSH terminal access にチェック
-3. "Deploy on-demand" クリック
-4. Pods画面でSSH接続情報を確認:
-   - **SSH over exposed TCP** の `ssh root@<IP> -p <PORT>` を使用（SCP対応）
+### 2. 学習実行 (1コマンド)
 
-### 3. データ転送 & 依存関係インストール
+デフォルトの `data/processed/ja` / `configs/train_cnn.cfg` (ja) または
+`data/processed/en` / `configs/train_cnn_en.cfg` (en) で学習する場合:
 
 ```bash
-# IPとPORTはRunPod Pods画面から取得
-export RUNPOD_IP=213.173.111.68
-export RUNPOD_PORT=13653
+export RUNPOD_API_KEY=...  # https://console.runpod.io/user/settings
 
-# アップロード
-scp -o StrictHostKeyChecking=no -P $RUNPOD_PORT -i ~/.ssh/id_ed25519 \
-  /tmp/ner-train-data.tar.gz root@$RUNPOD_IP:/root/
-
-# 展開 & 依存関係
-ssh -o StrictHostKeyChecking=no -p $RUNPOD_PORT root@$RUNPOD_IP -i ~/.ssh/id_ed25519 '
-  cd /root && tar xzf ner-train-data.tar.gz 2>/dev/null
-  pip install spacy 2>&1 | tail -1
-  pip install ja_core_news_sm@https://github.com/explosion/spacy-models/releases/download/ja_core_news_sm-3.8.0/ja_core_news_sm-3.8.0-py3-none-any.whl 2>&1 | tail -1
-  echo "READY"
-'
+make runpod-train-ja   # 日本語
+make runpod-train-en   # 英語
 ```
 
-### 4. 学習実行 (nohup)
+任意のデータ/configを使う場合は `scripts/runpod_train.py` を直接呼ぶ:
 
 ```bash
-# nohupで実行（SSH切断に耐える）
-ssh -o StrictHostKeyChecking=no -p $RUNPOD_PORT root@$RUNPOD_IP -i ~/.ssh/id_ed25519 '
-  cd /root && nohup python3.13 -m spacy train configs/train_cnn.cfg \
-    --output output/ja-v02 \
-    --paths.train data/processed/ja-v02/train.spacy \
-    --paths.dev data/processed/ja-v02/dev.spacy \
-    > /root/train.log 2>&1 & echo $! && echo "TRAINING_STARTED"
-'
+RUNPOD_API_KEY=... uv run --extra training python scripts/runpod_train.py \
+  --language ja \
+  --train-config configs/train_cnn.cfg \
+  --data-dir data/processed/ja-v02 \
+  --local-output-dir output/ja-v02/model-best
 ```
 
-### 5. 進捗確認
+このコマンド1つで以下が全て実行される（詳細は `scripts/runpod_train.py --help`）:
+
+1. RunPod REST API (`POST /pods`) でポッド作成 (CPU5 Compute-Optimized, 8 vCPU/16GB)
+2. SSHが疎通するまでポーリング
+3. `--train-config` / `--data-dir` を `scp` でアップロード
+4. 言語に応じた `pip install`（ja は `ja_core_news_sm` の wheel も含む）
+5. `python3.13 -m spacy train <config> --output <dir> --paths.train ... --paths.dev ...` を実行
+6. `output/**/model-best` を `scp` でローカルに回収
+7. **成功・失敗を問わず** `DELETE /pods/{id}` でポッドを削除 (`try/finally`)
+
+### 3. 計画だけ確認したい場合 (課金なし)
+
+API を一切呼ばずに、作成されるポッドスペック・アップロードされるファイル・
+実行される remote コマンドを表示する:
 
 ```bash
-ssh -o StrictHostKeyChecking=no -p $RUNPOD_PORT root@$RUNPOD_IP -i ~/.ssh/id_ed25519 \
-  'tail -10 /root/train.log'
+make runpod-train-ja DRY_RUN=1
+# あるいは
+uv run python scripts/runpod_train.py --language ja --dry-run
 ```
 
-### 6. モデルダウンロード & ポッド破棄
-
-```bash
-# model-bestをバックアップ
-ssh ... 'cd /root && tar czf /tmp/model-best.tar.gz output/ja-v02/model-best/'
-scp -o StrictHostKeyChecking=no -P $RUNPOD_PORT -i ~/.ssh/id_ed25519 \
-  root@$RUNPOD_IP:/tmp/model-best.tar.gz /tmp/model-best.tar.gz
-
-# ローカルに展開
-cd packages/training
-rm -rf output/ja-v02/model-best
-tar xzf /tmp/model-best.tar.gz
-
-# RunPodポッドをTerminate（Chrome: Pods → 3点メニュー → Terminate Pod）
-```
-
-### 7. ベンチマーク評価 (ローカル)
+### 4. ベンチマーク評価 (ローカル)
 
 ```bash
 for v in v0.4.0 v0.5.0 v0.12.0; do
@@ -136,7 +130,10 @@ done
 
 ## 注意事項
 
-- **pythonコマンド**: RunPod Ubuntu 20.04では `python3.13` を使用（`python3` は3.8）
-- **メモリ**: 4GB RAMではOOMするため、4vCPU/8GBを使用
-- **SSH切断対策**: 必ず `nohup` でバックグラウンド実行
-- **コスト管理**: 学習完了後は必ずポッドをTerminate
+- **pythonコマンド**: RunPod Ubuntu 20.04系イメージでは `python3` が3.8を指すため、
+  `scripts/runpod_train.py` は既定で `python3.13` を使う（`--python-bin` で上書き可）。
+- **メモリ**: 4GB RAMではOOMするため、8 vCPU/16GB 以上を使用（上記参照）。
+- **コスト管理**: `scripts/runpod_train.py` が学習完了後・失敗後を問わず自動でポッドを
+  削除するため、手動 Terminate 操作は不要（`--dry-run` はポッドを一切作成しない）。
+- **SSH鍵**: 既定は `~/.ssh/id_ed25519`（`--ssh-key` で上書き可）。RunPodアカウントに
+  対応する公開鍵を登録しておくこと。

--- a/packages/training/pyproject.toml
+++ b/packages/training/pyproject.toml
@@ -18,6 +18,10 @@ training = [
     "spacy-transformers>=1.3",
     "openai>=2.44.0",
     "pyyaml>=6.0.3",
+    # scripts/runpod_train.py talks to the RunPod REST API directly. Already
+    # present transitively via openai, but declared explicitly so it isn't
+    # silently lost if that transitive path ever changes (#292).
+    "requests>=2.31",
 ]
 hf = [
     "transformers>=4.40",

--- a/packages/training/scripts/runpod_train.py
+++ b/packages/training/scripts/runpod_train.py
@@ -1,0 +1,409 @@
+"""Single-command RunPod training orchestrator (issue #292).
+
+Replaces the manual workflow in `docs/runpod-training.md` (console-click pod
+deploy, hand-copied IP/PORT, manual scp, manual "Terminate Pod" click) with
+one process that: create-pod -> wait for SSH -> upload data -> run the spaCy
+training command -> scp the artifact back -> delete-pod. The delete always
+runs (`try/finally`), so a crash mid-training cannot leave a pod billing
+forever the way a forgotten manual Terminate click could.
+
+Pod sizing mirrors the OOM findings in `docs/runpod-training.md` (CPU
+CNN training needs >= 8 vCPU / 16 GB — smaller configs OOM and hang the
+SSH daemon on real data volumes). The optional GPU path mirrors the
+"Usage on RunPod" docstring in `train_supervised_300k_en.py` (transformer
+training needs a GPU pod, not the CPU5 flavor used for CNN training).
+
+RunPod REST API (https://rest.runpod.io/v1): POST/GET/DELETE /pods, using
+the same field names (`imageName`, `computeType`, `cpuFlavorIds`,
+`vcpuCount`, `gpuTypeIds`, `portMappings`, ...) as the `mcp__runpod__*`
+tools, so a pod created here looks the same in the RunPod console.
+
+Usage::
+
+    # Plan only -- no network calls, no charges. Prints the pod spec,
+    # the files that would be uploaded, and the exact remote commands.
+    uv run python scripts/runpod_train.py --language ja --dry-run
+
+    # Real run (creates a billable pod).
+    RUNPOD_API_KEY=... uv run --extra training python scripts/runpod_train.py \\
+        --language en \\
+        --train-config configs/train_cnn_en.cfg \\
+        --data-dir data/processed/en \\
+        --local-output-dir output/en/model-best
+
+Wired into `make runpod-train-ja` / `make runpod-train-en` (see Makefile).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+API_BASE_URL = "https://rest.runpod.io/v1"
+
+# RunPod's official lightweight CPU-only template ("Runpod Ubuntu 20.04" in
+# docs/runpod-training.md). Verify at https://console.runpod.io/deploy?type=CPU
+# before relying on this tag long-term -- override with --image / RUNPOD_IMAGE
+# if RunPod has retired it. This is the one place the image lives now,
+# instead of being re-discovered by hand every run.
+DEFAULT_CPU_IMAGE = "runpod/base:0.6.2-cpu"
+
+# Per-language defaults lifted directly from the existing Makefile targets
+# (train-cnn / train-en-cnn) and docs/runpod-training.md, so `make
+# runpod-train-ja` / `make runpod-train-en` produce the same training run
+# those local-only targets would have, just executed on RunPod instead.
+LANGUAGE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "ja": {
+        "train_config": "configs/train_cnn.cfg",
+        "data_dir": "data/processed/ja",
+        "remote_output_dir": "output",
+        "local_output_dir": "output/model-best",
+        # docs/runpod-training.md step 3: ja tokenization needs the ja
+        # pipeline wheel (sudachi dict), not just bare spacy.
+        "pip_packages": [
+            "spacy",
+            "ja_core_news_sm@https://github.com/explosion/spacy-models/releases/download/ja_core_news_sm-3.8.0/ja_core_news_sm-3.8.0-py3-none-any.whl",
+        ],
+    },
+    "en": {
+        "train_config": "configs/train_cnn_en.cfg",
+        "data_dir": "data/processed/en",
+        "remote_output_dir": "output/en",
+        "local_output_dir": "output/en/model-best",
+        "pip_packages": ["spacy"],
+    },
+}
+
+
+@dataclass
+class PodSpec:
+    """Maps 1:1 onto the RunPod REST `POST /pods` request body."""
+
+    name: str
+    image: str
+    compute_type: str  # "CPU" or "GPU"
+    container_disk_gb: int
+    volume_gb: int
+    ports: list[str]
+    cloud_type: str = "SECURE"
+    cpu_flavor_ids: list[str] | None = None
+    vcpu_count: int | None = None
+    gpu_type_ids: list[str] | None = None
+    gpu_count: int | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_api_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "imageName": self.image,
+            "computeType": self.compute_type,
+            "containerDiskInGb": self.container_disk_gb,
+            "volumeInGb": self.volume_gb,
+            "ports": self.ports,
+            "cloudType": self.cloud_type,
+            "env": self.env,
+        }
+        if self.compute_type == "CPU":
+            payload["cpuFlavorIds"] = self.cpu_flavor_ids
+            payload["vcpuCount"] = self.vcpu_count
+        else:
+            payload["gpuTypeIds"] = self.gpu_type_ids
+            payload["gpuCount"] = self.gpu_count
+        return payload
+
+
+@dataclass
+class TrainingPlan:
+    """Everything `--dry-run` shows and the real run executes -- built once,
+    by one function, so the two paths can never silently diverge."""
+
+    pod_spec: PodSpec
+    uploads: list[str]
+    remote_workdir: str
+    remote_setup_command: str | None
+    remote_train_command: str
+    artifact_remote_path: str
+    artifact_local_path: str
+    ssh_key: str
+    boot_timeout_s: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pod_spec": self.pod_spec.to_api_payload(),
+            "uploads": self.uploads,
+            "remote_workdir": self.remote_workdir,
+            "remote_setup_command": self.remote_setup_command,
+            "remote_train_command": self.remote_train_command,
+            "artifact_remote_path": self.artifact_remote_path,
+            "artifact_local_path": self.artifact_local_path,
+            "ssh_key": self.ssh_key,
+            "boot_timeout_s": self.boot_timeout_s,
+        }
+
+
+class RunPodClient:
+    """Thin wrapper around the RunPod REST API. `requests` is imported lazily
+    so `--dry-run` never needs it installed."""
+
+    def __init__(self, api_key: str, base_url: str = API_BASE_URL, timeout: float = 30.0) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+
+    def create_pod(self, spec: PodSpec) -> dict[str, Any]:
+        import requests
+
+        resp = requests.post(
+            f"{self._base_url}/pods",
+            headers=self._headers(),
+            json=spec.to_api_payload(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_pod(self, pod_id: str) -> dict[str, Any]:
+        import requests
+
+        resp = requests.get(
+            f"{self._base_url}/pods/{pod_id}",
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_pod(self, pod_id: str) -> None:
+        import requests
+
+        resp = requests.delete(
+            f"{self._base_url}/pods/{pod_id}",
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+
+
+def wait_for_pod_ready(
+    client: RunPodClient,
+    pod_id: str,
+    timeout_s: int = 300,
+    poll_interval_s: float = 5.0,
+) -> tuple[str, int]:
+    """Poll GET /pods/{id} until SSH (port 22) has a public IP + mapped port."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        pod = client.get_pod(pod_id)
+        ip = pod.get("publicIp")
+        ssh_port = (pod.get("portMappings") or {}).get("22")
+        if ip and ssh_port:
+            return ip, int(ssh_port)
+        time.sleep(poll_interval_s)
+    raise TimeoutError(f"pod {pod_id} did not expose SSH within {timeout_s}s")
+
+
+def _ssh_base_args(host: str, port: int, ssh_key: str) -> list[str]:
+    return [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-p",
+        str(port),
+        "-i",
+        ssh_key,
+        f"root@{host}",
+    ]
+
+
+def run_remote_command(host: str, port: int, ssh_key: str, command: str) -> None:
+    subprocess.run(_ssh_base_args(host, port, ssh_key) + [command], check=True)
+
+
+def upload_paths(host: str, port: int, ssh_key: str, local_paths: list[str], remote_dir: str) -> None:
+    for local_path in local_paths:
+        subprocess.run(
+            [
+                "scp",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-P",
+                str(port),
+                "-i",
+                ssh_key,
+                "-r",
+                local_path,
+                f"root@{host}:{remote_dir}/",
+            ],
+            check=True,
+        )
+
+
+def download_path(host: str, port: int, ssh_key: str, remote_path: str, local_path: str) -> None:
+    Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "scp",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-P",
+            str(port),
+            "-i",
+            ssh_key,
+            "-r",
+            f"root@{host}:{remote_path}",
+            local_path,
+        ],
+        check=True,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--language", choices=sorted(LANGUAGE_DEFAULTS), required=True)
+    parser.add_argument("--train-config", help="spaCy train config, relative to packages/training/")
+    parser.add_argument("--data-dir", help="dir containing train.spacy/dev.spacy")
+    parser.add_argument("--remote-output-dir", help="output dir on the pod passed to `spacy train --output`")
+    parser.add_argument("--local-output-dir", help="where model-best is saved locally after download")
+    parser.add_argument("--pod-name", help="override the generated pod name")
+    parser.add_argument("--compute-type", choices=["CPU", "GPU"], default="CPU")
+    parser.add_argument(
+        "--cpu-flavor-id",
+        default="cpu5c",
+        help="RunPod CPU flavor id. cpu5c = 'CPU5 Compute-Optimized' from docs/runpod-training.md",
+    )
+    parser.add_argument(
+        "--vcpu-count",
+        type=int,
+        default=8,
+        help="8 vCPU is the documented OOM-safe minimum for CNN training (docs/runpod-training.md)",
+    )
+    parser.add_argument("--gpu-type-id", action="append", dest="gpu_type_ids", help="repeatable; only used with --compute-type GPU")
+    parser.add_argument("--gpu-count", type=int, default=1)
+    parser.add_argument("--gpu-id", type=int, default=None, help="passed to `spacy train --gpu-id` when training on a GPU pod")
+    parser.add_argument("--image", default=DEFAULT_CPU_IMAGE)
+    parser.add_argument("--container-disk-gb", type=int, default=20)
+    parser.add_argument("--volume-gb", type=int, default=5, help="ephemeral single-run pod: no persistent volume needed")
+    parser.add_argument("--python-bin", default="python3.13", help="RunPod Ubuntu 20.04's `python3` is 3.8; use python3.13")
+    parser.add_argument("--remote-workdir", default="/root")
+    parser.add_argument("--ssh-key", default=os.path.expanduser("~/.ssh/id_ed25519"))
+    parser.add_argument("--boot-timeout-s", type=int, default=300, help="max seconds to wait for the pod to expose SSH")
+    parser.add_argument("--api-key", default=None, help="defaults to $RUNPOD_API_KEY")
+    parser.add_argument("--api-base-url", default=API_BASE_URL)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the plan (pod spec, uploads, commands) as JSON and exit; makes no API calls",
+    )
+    return parser
+
+
+def build_plan(args: argparse.Namespace) -> TrainingPlan:
+    """Pure function -- resolves language defaults + CLI overrides into a
+    concrete plan. No network/subprocess side effects, so both --dry-run and
+    the real run go through this exact code path."""
+    defaults = LANGUAGE_DEFAULTS[args.language]
+    train_config = args.train_config or defaults["train_config"]
+    data_dir = args.data_dir or defaults["data_dir"]
+    remote_output_dir = args.remote_output_dir or defaults["remote_output_dir"]
+    local_output_dir = args.local_output_dir or defaults["local_output_dir"]
+    pip_packages: list[str] = defaults["pip_packages"]
+
+    pod_name = args.pod_name or f"ner-train-{args.language}-{int(time.time())}"
+
+    pod_spec = PodSpec(
+        name=pod_name,
+        image=args.image,
+        compute_type=args.compute_type,
+        container_disk_gb=args.container_disk_gb,
+        volume_gb=args.volume_gb,
+        ports=["22/tcp"],
+        cpu_flavor_ids=[args.cpu_flavor_id] if args.compute_type == "CPU" else None,
+        vcpu_count=args.vcpu_count if args.compute_type == "CPU" else None,
+        gpu_type_ids=args.gpu_type_ids if args.compute_type == "GPU" else None,
+        gpu_count=args.gpu_count if args.compute_type == "GPU" else None,
+    )
+
+    config_name = Path(train_config).name
+    data_name = Path(data_dir).name
+    train_cmd = (
+        f"cd {args.remote_workdir} && {args.python_bin} -m spacy train {config_name} "
+        f"--output {remote_output_dir} "
+        f"--paths.train {data_name}/train.spacy "
+        f"--paths.dev {data_name}/dev.spacy"
+    )
+    if args.compute_type == "GPU" and args.gpu_id is not None:
+        train_cmd += f" --gpu-id {args.gpu_id}"
+
+    setup_cmd = " && ".join(f"pip install {pkg}" for pkg in pip_packages) if pip_packages else None
+
+    return TrainingPlan(
+        pod_spec=pod_spec,
+        uploads=[train_config, data_dir],
+        remote_workdir=args.remote_workdir,
+        remote_setup_command=setup_cmd,
+        remote_train_command=train_cmd,
+        artifact_remote_path=f"{args.remote_workdir}/{remote_output_dir}/model-best",
+        artifact_local_path=local_output_dir,
+        ssh_key=args.ssh_key,
+        boot_timeout_s=args.boot_timeout_s,
+    )
+
+
+def run_training(plan: TrainingPlan, api_key: str, api_base_url: str) -> int:
+    """Create the pod, run the plan, and always delete the pod -- success or
+    failure. This is the guarantee issue #292 asks for: no forgotten
+    Terminate click, no orphaned billing pod."""
+    client = RunPodClient(api_key, base_url=api_base_url)
+    pod = client.create_pod(plan.pod_spec)
+    pod_id = pod["id"]
+    print(f"created pod {pod_id} ({plan.pod_spec.name})")
+    try:
+        host, port = wait_for_pod_ready(client, pod_id, timeout_s=plan.boot_timeout_s)
+        print(f"pod {pod_id} ready: ssh -p {port} root@{host}")
+
+        upload_paths(host, port, plan.ssh_key, plan.uploads, plan.remote_workdir)
+        print(f"uploaded {len(plan.uploads)} path(s) to {plan.remote_workdir}")
+
+        if plan.remote_setup_command:
+            run_remote_command(host, port, plan.ssh_key, plan.remote_setup_command)
+            print("remote setup command finished")
+
+        run_remote_command(host, port, plan.ssh_key, plan.remote_train_command)
+        print("training command finished")
+
+        download_path(host, port, plan.ssh_key, plan.artifact_remote_path, plan.artifact_local_path)
+        print(f"artifact saved to {plan.artifact_local_path}")
+        return 0
+    finally:
+        print(f"deleting pod {pod_id}")
+        client.delete_pod(pod_id)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    plan = build_plan(args)
+
+    if args.dry_run:
+        print(json.dumps(plan.to_dict(), indent=2))
+        return 0
+
+    api_key = args.api_key or os.environ.get("RUNPOD_API_KEY")
+    if not api_key:
+        print("error: RUNPOD_API_KEY is not set (env var or --api-key)", file=sys.stderr)
+        return 1
+
+    return run_training(plan, api_key=api_key, api_base_url=args.api_base_url)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/training/tests/test_runpod_train.py
+++ b/packages/training/tests/test_runpod_train.py
@@ -1,0 +1,194 @@
+"""Tests for issue #292: scripts/runpod_train.py.
+
+`scripts/` is not an importable package (no __init__.py, not part of the
+`pleno_ner_training` src layout), so the module under test is loaded by
+file path rather than `import`.
+
+Two things matter for this script and nothing else does, because the real
+RunPod API is never called in CI:
+
+1. `--dry-run` fully resolves the plan (pod spec / uploads / remote
+   commands) and prints it without touching the network.
+2. `delete_pod` always runs, even when a step after `create_pod` raises --
+   this is the "no orphaned billing pod" guarantee from the issue.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+TRAINING_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = TRAINING_ROOT / "scripts" / "runpod_train.py"
+
+
+def _load_runpod_train() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("runpod_train", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses' `_is_type` resolves `list[str] | None`-style postponed
+    # annotations via `sys.modules[cls.__module__]`, so the module must be
+    # registered before exec_module runs the class bodies.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runpod_train = _load_runpod_train()
+
+
+# ---------------------------------------------------------------------------
+# --dry-run: plan resolution, no network calls
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_ja_prints_plan_without_touching_the_network(monkeypatch, capsys):
+    class ExplodingClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("dry-run must not construct a RunPodClient")
+
+    monkeypatch.setattr(runpod_train, "RunPodClient", ExplodingClient)
+    monkeypatch.delenv("RUNPOD_API_KEY", raising=False)
+
+    exit_code = runpod_train.main(["--language", "ja", "--dry-run", "--pod-name", "test-ja-pod"])
+    assert exit_code == 0
+
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["pod_spec"]["name"] == "test-ja-pod"
+    assert plan["pod_spec"]["computeType"] == "CPU"
+    assert plan["pod_spec"]["cpuFlavorIds"] == ["cpu5c"]
+    assert plan["pod_spec"]["vcpuCount"] == 8
+    assert plan["uploads"] == ["configs/train_cnn.cfg", "data/processed/ja"]
+    assert "spacy train train_cnn.cfg" in plan["remote_train_command"]
+    assert "--paths.train ja/train.spacy" in plan["remote_train_command"]
+    assert "--paths.dev ja/dev.spacy" in plan["remote_train_command"]
+    assert plan["artifact_local_path"] == "output/model-best"
+    # ja needs the sudachi-backed tokenizer wheel; en does not.
+    assert "ja_core_news_sm" in plan["remote_setup_command"]
+
+
+def test_dry_run_en_uses_en_language_defaults(capsys):
+    exit_code = runpod_train.main(["--language", "en", "--dry-run", "--pod-name", "test-en-pod"])
+    assert exit_code == 0
+
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["uploads"] == ["configs/train_cnn_en.cfg", "data/processed/en"]
+    assert "spacy train train_cnn_en.cfg" in plan["remote_train_command"]
+    assert plan["artifact_local_path"] == "output/en/model-best"
+    assert plan["remote_setup_command"] == "pip install spacy"
+
+
+def test_dry_run_requires_no_api_key(monkeypatch):
+    monkeypatch.delenv("RUNPOD_API_KEY", raising=False)
+    # Would fail before reaching dry-run print if the env var were required.
+    assert runpod_train.main(["--language", "ja", "--dry-run"]) == 0
+
+
+def test_missing_api_key_fails_fast_without_dry_run(monkeypatch):
+    monkeypatch.delenv("RUNPOD_API_KEY", raising=False)
+    assert runpod_train.main(["--language", "ja"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cleanup guarantee: delete_pod always runs, even on failure
+# ---------------------------------------------------------------------------
+
+
+class FakeRunPodClient:
+    """Records calls; lets a test inject a failure at any step."""
+
+    instances: list["FakeRunPodClient"] = []
+
+    def __init__(self, api_key: str, base_url: str = "") -> None:
+        self.api_key = api_key
+        self.calls: list[tuple] = []
+        self.deleted_pod_ids: list[str] = []
+        FakeRunPodClient.instances.append(self)
+
+    def create_pod(self, spec):
+        self.calls.append(("create_pod", spec))
+        return {"id": "pod-123"}
+
+    def get_pod(self, pod_id: str):
+        self.calls.append(("get_pod", pod_id))
+        return {"publicIp": "10.0.0.1", "portMappings": {"22": 2222}}
+
+    def delete_pod(self, pod_id: str) -> None:
+        self.calls.append(("delete_pod", pod_id))
+        self.deleted_pod_ids.append(pod_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_client_registry():
+    FakeRunPodClient.instances.clear()
+    yield
+    FakeRunPodClient.instances.clear()
+
+
+def _plan_args(**overrides):
+    args = runpod_train.build_arg_parser().parse_args(
+        ["--language", "ja", "--pod-name", "test-pod"]
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return runpod_train.build_plan(args)
+
+
+def test_delete_pod_runs_after_a_successful_training_run(monkeypatch):
+    monkeypatch.setattr(runpod_train, "RunPodClient", FakeRunPodClient)
+    monkeypatch.setattr(runpod_train, "upload_paths", lambda *a, **k: None)
+    monkeypatch.setattr(runpod_train, "run_remote_command", lambda *a, **k: None)
+    monkeypatch.setattr(runpod_train, "download_path", lambda *a, **k: None)
+
+    plan = _plan_args()
+    exit_code = runpod_train.run_training(plan, api_key="fake-key", api_base_url="https://example.invalid")
+
+    assert exit_code == 0
+    client = FakeRunPodClient.instances[0]
+    assert client.deleted_pod_ids == ["pod-123"]
+
+
+@pytest.mark.parametrize(
+    "failing_step",
+    ["upload_paths", "run_remote_command", "download_path"],
+)
+def test_delete_pod_still_runs_when_a_later_step_raises(monkeypatch, failing_step):
+    monkeypatch.setattr(runpod_train, "RunPodClient", FakeRunPodClient)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(f"simulated failure in {failing_step}")
+
+    for step in ("upload_paths", "run_remote_command", "download_path"):
+        monkeypatch.setattr(runpod_train, step, _boom if step == failing_step else (lambda *a, **k: None))
+
+    plan = _plan_args()
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        runpod_train.run_training(plan, api_key="fake-key", api_base_url="https://example.invalid")
+
+    # The whole point of the try/finally: pod deletion is not optional.
+    client = FakeRunPodClient.instances[0]
+    assert client.deleted_pod_ids == ["pod-123"]
+
+
+def test_delete_pod_still_runs_when_pod_never_boots(monkeypatch):
+    monkeypatch.setattr(runpod_train, "RunPodClient", FakeRunPodClient)
+
+    class NeverReadyClient(FakeRunPodClient):
+        def get_pod(self, pod_id: str):
+            self.calls.append(("get_pod", pod_id))
+            return {"publicIp": None, "portMappings": {}}
+
+    monkeypatch.setattr(runpod_train, "RunPodClient", NeverReadyClient)
+
+    plan = _plan_args(boot_timeout_s=0)
+    with pytest.raises(TimeoutError):
+        runpod_train.run_training(plan, api_key="fake-key", api_base_url="https://example.invalid")
+
+    client = NeverReadyClient.instances[0]
+    assert client.deleted_pod_ids == ["pod-123"]


### PR DESCRIPTION
## Summary

Codifies the RunPod training pipeline that issue #292 flagged as prose-only / hardcoded-IP-dependent.

- `packages/training/scripts/runpod_train.py`: single-command orchestrator — create-pod → wait for SSH → upload data/config → run `spacy train` → scp `model-best` back → delete-pod, via the RunPod REST API (`RUNPOD_API_KEY`). Pod deletion always runs (`try/finally`), including on any failure. `--dry-run` resolves the full plan (pod spec, uploads, remote commands) as JSON, no network calls.
- `make runpod-train-ja` / `make runpod-train-en`: wired to the same config/data-dir/output-dir as the existing `train-cnn` / `train-en-cnn` targets. `DRY_RUN=1` forwards `--dry-run`.
- The four local spaCy train targets (`train`, `train-cnn`, `train-en`, `train-en-cnn`) now refuse to run unless `LOCAL=1` is passed, per CLAUDE.md ("do not train on local machine") — they print a pointer at `make runpod-train-*` and exit 1 otherwise. Recipe bodies are unchanged, only a guard line was prepended.
- `docs/runpod-training.md`: dropped the hardcoded IP/PORT (`213.173.111.68:13653`) and the manual console-click pod-deploy step; documents the new single-command flow and its (overridable) pod-sizing defaults (CPU5 Compute-Optimized, 8 vCPU/16 GB per the existing OOM findings).
- `.claude/skills/ner-improve/SKILL.md`: updated **only** Phase 2 step 3 (Train) to route through `make runpod-train-en`/`runpod-train-ja` instead of the old local-target + MCP-tools mix. No other section touched.
- `packages/training/tests/test_runpod_train.py`: dry-run plan assertions for both languages, plus mocked-`RunPodClient` tests proving `delete_pod` always runs — success path, and failure injected at each of upload / remote-train / download / boot-timeout.

## Verification

```
cd packages/training && uv run pytest tests/test_runpod_train.py -v
# 9 passed
```

Manually confirmed:
- `make train-cnn` (no `LOCAL=1`) exits 1 with the CLAUDE.md pointer message; `make train LOCAL=1` runs the original recipe unchanged.
- `make runpod-train-ja DRY_RUN=1` / `make runpod-train-en DRY_RUN=1` print the resolved plan with no API calls.
- `uvx ruff check` passes on the new script and test file.

No real RunPod API calls were made in developing or testing this change (constraint honored — all coverage is dry-run or mocked).

Closes #292