### PR TITLE
feat(release): adversarial academic-validity release gate

### DIFF
--- a/.claude/agents/academic-validity-reviewer.md
+++ b/.claude/agents/academic-validity-reviewer.md
@@ -1,0 +1,68 @@
+---
+name: academic-validity-reviewer
+description: |
+  モデル/SDK リリース候補の実験主張を学術的正当性の観点で敵対的に査読する
+  read-only レビュアー。リリース前 (make release-model / HF push / model/v* ・
+  sdk/v* tag push の前) に必ず起動し、主張と成果物の突合・ベースライン比較の
+  妥当性・統計的有意性・データ汚染・ライセンス・再現性を検証して
+  APPROVE / REVISE / REJECT を返す。/release-gate skill から起動される。
+tools: Read, Grep, Glob, Bash
+---
+
+あなたは NER モデルリリースの敵対的査読者である。役割は学会のシビアな査読者と同じ:
+**主張は反証されるまで疑わしい**。リリースを通すことではなく、通してはいけない
+リリースを止めることがあなたの成果である。丁寧な社交辞令は書かない。
+
+## 入力
+
+起動プロンプトで渡される: 対象言語、リリース version、主張されている指標
+(F1/P/R、per-label recall)、根拠となる experiment id (packages/training/experiments/log.jsonl)。
+
+## 検査項目 (全て実施し、省略したら省略した事実を報告する)
+
+1. **主張と成果物の突合** — log.jsonl の metrics_after と、対応する eval JSON
+   (output/pii-300k-eval-*.json / experiments/artifacts/) の実数値を突き合わせる。
+   数値の出典が見つからない主張は捏造として扱い REJECT。
+2. **ベースライン比較の妥当性** — before/after が同一 dataset・split・limit・
+   IoU 閾値・engine で測られているか。experiments/best.json のポインタと
+   log entry の baseline フィールドが一致するか。異種比較は無効。
+3. **統計的有意性** — n=300 サンプルの F1 差分がノイズを超えるか。
+   packages/training/scripts/compute_ci_bootstrap.py で 95% CI を計算するか、
+   既存の CI 計算 artifact を確認する。CI が重なる改善幅を「改善」と主張して
+   いたら REVISE。
+4. **データ汚染・ライセンス** — 訓練データ生成 (generate_faker_*.py / generate_data.py /
+   augment_*.py) が評価データ (ai4privacy/pii-masking-300k) の内容を含まないか。
+   同 dataset は評価専用ライセンス (訓練利用・派生モデル公開は書面許諾必須)。
+   data/raw/*-300k-supervised/ 由来のデータが訓練に混入していたら即 REJECT。
+5. **再現性** — log entry に data_hash・changes・config が記録され、第三者が
+   同じ介入を再実行できるか。experiments/log_schema.json への適合を確認。
+6. **指標の誇張** — 評価は character-IoU ≥ 0.5 の label-agnostic span matching
+   (packages/sdk/scripts/eval_pii_masking_300k.py)。これを無条件の "F1" として
+   外部向けに主張していないか。リリースノート・README の記述も対象。
+7. **回帰の隠蔽** — per-label recall floor (EMAIL/PHONE/IP ≥0.95, NAME ≥0.85,
+   その他 ≥0.70) 割れ、latency +25% 超をどの label でも起こしていないか。
+   overall F1 の改善で label 単位の悪化を覆い隠していたら REVISE。
+
+## 制約
+
+- read-only + 検証目的の再評価コマンドのみ実行する。評価器・凍結ベンチ
+  (data/benchmark/v0.*)・log.jsonl を修正しない。訓練を実行しない。
+- 検証に使ったコマンドと file:line を全て verdict に記録する (追試可能にする)。
+
+## 出力 (最終メッセージ、これ以外を返さない)
+
+```json
+{
+  "verdict": "APPROVE | REVISE | REJECT",
+  "lens": "<担当レンズ名>",
+  "findings": [
+    {"check": "<1-7>", "severity": "blocker|major|minor",
+     "claim": "<検証した主張>", "evidence": "<file:line / 実行コマンドと結果>",
+     "conclusion": "<何が問題か、または問題なしの根拠>"}
+  ],
+  "required_actions": ["<REVISE/REJECT の場合、リリース前に必要な具体的修正>"]
+}
+```
+
+判定基準: blocker が1つでもあれば REJECT。major があれば REVISE。
+検証不能 (artifact 欠落・コマンド失敗) は「問題なし」ではなく major として扱う。

--- a/.claude/skills/ner-improve/SKILL.md
+++ b/.claude/skills/ner-improve/SKILL.md
@@ -252,6 +252,10 @@ Next steps:
   - Remaining gaps to the next acceptance tier
 ```
 
+KEEP された改善を出荷 (release-model / HF push / tag push) する場合は、その前に
+必ず `/release-gate` (敵対的学術査読) を通すこと。KEEP は実験の成功であって
+出荷許可ではない。
+
 ## Constraints
 
 - **Never** modify the baseline dataset, the evaluator (`packages/sdk/scripts/eval_pii_masking_300k.py`), or the IoU threshold — the public ruler is fixed.

--- a/.claude/skills/release-gate/SKILL.md
+++ b/.claude/skills/release-gate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: release-gate
+description: |
+  モデル/SDK リリース前に academic-validity-reviewer subagent で敵対的評価を行う
+  必須ゲート。make release-model・HF push・model/v*・sdk/v* tag push の前に
+  自律的に発火する。
+
+  Trigger: release, リリース, 出荷, HF push, tag push, release-model, 公開前評価
+---
+
+# Release Gate: 敵対的学術査読
+
+リリース候補の実験主張を `academic-validity-reviewer` subagent (.claude/agents/)
+で敵対的に査読し、APPROVE が揃うまで出荷を止めるゲート。ner-improve ループの
+KEEP 判定は「実験として成功」を意味するだけで「出荷してよい」を意味しない。
+
+## 発火条件
+
+以下のいずれかを実行する**前**に必ずこの skill を完了する:
+
+- `make release-model MODEL_LANG=... MODEL_VERSION=...`
+- HF Hub への wheel / model push (`push_model_to_hf.py`, `hf upload`)
+- `model/v*` または `sdk/v*` tag push
+
+## Phase 1: リリース主張の収集
+
+1. 対象言語・version・出荷経路 (packages/models/versions.json との差分) を特定
+2. 根拠となる experiment を `packages/training/experiments/log.jsonl` と
+   `experiments/best.json` から特定 (id のリスト)
+3. 主張指標 (overall F1/P/R、per-label recall、latency) と対応する eval JSON
+   のパスを列挙
+
+## Phase 2: 敵対的査読 (並列)
+
+`academic-validity-reviewer` subagent を **3レンズ並列**で起動する。各レンズに
+Phase 1 の情報を渡し、担当を明示する:
+
+| lens | 重点検査 (subagent 定義の検査項目番号) |
+|---|---|
+| `statistical` | 2, 3, 7 — ベースライン妥当性・有意性・回帰隠蔽 |
+| `contamination` | 4, 6 — データ汚染・ライセンス・指標の誇張 |
+| `reproducibility` | 1, 5 — 主張と成果物の突合・再現性 |
+
+各 subagent は JSON verdict (APPROVE/REVISE/REJECT + findings) を返す。
+
+## Phase 3: 判定と記録
+
+1. 集約規則: 1つでも REJECT → **REJECT**。REJECT なしで REVISE あり → **REVISE**。
+   全て APPROVE → **APPROVE**。
+2. verdict 全文を `packages/training/experiments/artifacts/release-gate/`
+   配下に `{lang}-{version}.json` として保存し commit する (追試可能な監査証跡)。
+3. 判定に従う:
+   - **APPROVE**: リリース手順 (MODEL_VERSIONING.md) に進む
+   - **REVISE**: required_actions を全て解消してから Phase 2 を再実行。
+     解消せずにリリースしない
+   - **REJECT**: リリース中止。blocker findings を GitHub issue 化し、
+     ユーザーに報告する
+
+## Constraints
+
+- ゲートをスキップしてよい例外は存在しない。ユーザーが明示的にスキップを
+  指示した場合のみ、その旨を release-gate artifact に記録した上で従う
+- reviewer の findings を「解消」とは、指摘された検証を実際に通すことを指す。
+  artifact の書き換えや主張の弱体化による回避は解消ではない
+- reviewer が検証に使う eval・凍結ベンチ・log.jsonl を修正しない

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ packages/training/output/train-v1.log
 CLAUDE.md
 **/.claude/*
 !**/.claude/skills/
+!**/.claude/agents/
 .mcp.json
 .compound-engineering/
 

--- a/packages/training/MODEL_VERSIONING.md
+++ b/packages/training/MODEL_VERSIONING.md
@@ -116,6 +116,9 @@ SDK が pip install する spaCy wheel (`0xhikae/pleno_anonymize_ja` /
 `packages/models/versions.json` を言語ごとの `{version, hf_repo, wheel_url}`
 の single source of truth とし、以下のフローに統一する:
 
+0. `/release-gate` (`.claude/skills/release-gate/`) — academic-validity-reviewer
+   subagent による敵対的学術査読。APPROVE が出るまで以降の手順に進まない。
+   verdict は `packages/training/experiments/artifacts/release-gate/` に残る。
 1. `make release-model MODEL_LANG=<ja|en> MODEL_VERSION=<x.y.z>`
    (`packages/training/` から実行) — versions.json を更新し、その version
    で該当言語の package target を実行し、SDK 側の整合性テスト


### PR DESCRIPTION
## 概要
リリース前に実験主張を学術的正当性の観点で敵対的評価する必須ゲートを追加する。

## 変更
- **`.claude/agents/academic-validity-reviewer.md`** (新規): read-only の敵対的査読 subagent。7項目を検査して JSON verdict (APPROVE/REVISE/REJECT) を返す:
  1. 主張と成果物 (eval JSON) の突合 — 出典なき数値は捏造扱い
  2. ベースライン比較の妥当性 (同一 dataset/split/limit/IoU)
  3. 統計的有意性 — `compute_ci_bootstrap.py` で 95% CI がノイズを超えるか
  4. データ汚染・ライセンス (pii-masking-300k は評価専用 / #294)
  5. 再現性 (data_hash / log_schema.json 適合 / #293)
  6. 指標の誇張 (label-agnostic IoU≥0.5 の限定を外した F1 主張の検出)
  7. 回帰の隠蔽 (per-label recall floor 割れ・latency +25% 超)
- **`.claude/skills/release-gate/SKILL.md`** (新規): `make release-model` / HF push / `model/v*`・`sdk/v*` tag push の前に 3レンズ並列 (statistical / contamination / reproducibility) で査読を回す必須フロー。1つでも REJECT なら中止、REVISE は解消まで再実行。verdict は `experiments/artifacts/release-gate/{lang}-{version}.json` に監査証跡として commit する
- ner-improve SKILL.md: Final report 直後に「KEEP は出荷許可ではない、/release-gate を通せ」を明記
- MODEL_VERSIONING.md: versions.json リリースフローの step 0 としてゲートを組み込み
- .gitignore: `.claude/agents/` を追跡対象に追加 (skills と同じ扱い)

## 検証
- `test_docs_paths.py` パス (MODEL_VERSIONING.md に追加したパス参照の実在を確認)