### PR TITLE
ci(training): run packages/training test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,20 @@ jobs:
         working-directory: packages/sdk
         run: uv run pytest -q
 
+  training:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      # datasets/transformers unlock the 3 hf-dependent test modules without
+      # pulling the full `hf` extra (accelerate→torch is ~2GB and needless
+      # for unit tests). The rest of the suite runs on the dev group alone.
+      - name: Test
+        working-directory: packages/training
+        run: uv run --frozen --with datasets --with transformers pytest -q
+
   deploy:
     needs: [check, test, sdk]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,12 @@ ai4privacy/pii-masking-300k は非商用・派生物公開に書面許諾が必�
 ## en-model-030-release-complete ([[en-model-030-release-complete]])
 2026-07-05 ner-improve ループ完了: EN/JA 0.3.0 + SDK 0.2.5 全リリース完了 (HF/PyPI/本番)
 
-## en-model-030-release-pending ([[en-model-030-release-pending]])
-2026-07-05 ner-improve ループ完了: EN/JA 0.3.0 + SDK 0.2.5 全リリース済み (HF/PyPI/本番)
-
 ## face-redaction-feature ([[face-redaction-feature]])
 Face redaction via OpenCV YuNet merged in PR #195; README banner uses presidio OCR redaction
 
 ## readme-redact-banner ([[readme-redact-banner]])
 README before/after presidio OCR redaction banner + reproducible generator script
+
+## release-gate-flow ([[release-gate-flow]])
+リリース前は /release-gate (academic-validity-reviewer による敵対的学術査読) が必須。KEEP は出荷許可ではない
 <!-- agentops:dreaming:end -->

--- a/packages/training/tests/test_mine_external_hardneg.py
+++ b/packages/training/tests/test_mine_external_hardneg.py
@@ -18,6 +18,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+# convert_to_hf_dataset needs the `hf` extra; plain `uv run pytest` (dev group
+# only) must skip cleanly instead of failing collection.
+pytest.importorskip("datasets")
+pytest.importorskip("transformers")
+
 from pleno_ner_training.convert_to_hf_dataset import load_and_convert
 from pleno_ner_training.mine_external_hardneg import (
     MAX_CHARS,

--- a/packages/training/tests/test_pii_filter.py
+++ b/packages/training/tests/test_pii_filter.py
@@ -18,6 +18,11 @@ from __future__ import annotations
 
 import pytest
 
+# convert_to_hf_dataset needs the `hf` extra; plain `uv run pytest` (dev group
+# only) must skip cleanly instead of failing collection.
+pytest.importorskip("datasets")
+pytest.importorskip("transformers")
+
 from pleno_ner_training.convert_to_hf_dataset import PII_HINT_RE
 
 

--- a/packages/training/tests/test_special_care_entities.py
+++ b/packages/training/tests/test_special_care_entities.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+# convert_to_hf_dataset needs the `hf` extra; plain `uv run pytest` (dev group
+# only) must skip cleanly instead of failing collection.
+pytest.importorskip("datasets")
+pytest.importorskip("transformers")
+
 from pleno_ner_training.entity_types import (
     NER_LABELS,
     SPECIAL_CARE_ENTITIES,


### PR DESCRIPTION
## 判断: 運用する価値あり → CI組み込み (削除対象なし)

実測による評価:
- **262テスト全パス・約30秒・ネットワーク/GPU不要** (`--with datasets --with transformers` のみで完走、torch不要)
- 価値の根拠:
  - `test_metrics.py` (42件): 全実験のKEEP/DISCARD判定が依存する char-IoU F1 スコアリングを固定
  - `test_pii_filter.py` (93件のうち大半): 実際に起きたモデル劣化 (#66: hard-negative regexの穴で ADDRESS F1 0.692→0.667) の再発防止ピン
  - #291〜#296 で追加したガード群 (license guard / log schema / runpod dry-run / docs paths) は CI で回って初めて意味を持つ
- 削除候補は無し: 全テストが現存コードを対象に高速でパスしており、削る利得がない

## 変更
- `ci.yml`: `training` job 追加。`hf` extra (accelerate→torch ~2GB) は引かず、collection に必要な datasets/transformers だけ `--with` で注入
- hf依存の3テストモジュールに `pytest.importorskip` を追加 — dev groupのみのローカル/agent実行で collection error (今までの挙動) ではなく clean skip になる

## 検証
- `uv run --frozen pytest -q` → 168 passed, 5 skipped (エラーゼロ)
- `uv run --frozen --with datasets --with transformers pytest -q` → 262 passed
- ruff check パス