### PR TITLE
fix(training): skip test when LFS pointer not resolved

### DIFF
--- a/packages/training/tests/test_pii_filter.py
+++ b/packages/training/tests/test_pii_filter.py
@@ -142,8 +142,10 @@ def test_pii_hint_re_drop_rate_floor_on_ja_v02() -> None:
     if not data_path.exists():
         pytest.skip(f"raw data not available: {data_path}")
 
-    with open(data_path, encoding="utf-8") as f:
-        records = json.load(f)
+    raw = data_path.read_text(encoding="utf-8")
+    if raw.startswith("version https://git-lfs.github.com/spec/v1"):
+        pytest.skip(f"raw data is an LFS pointer (checkout without lfs: true): {data_path}")
+    records = json.loads(raw)
 
     zero = [r for r in records if not r.get("entities") and r.get("text")]
     if not zero:
@@ -155,3 +157,4 @@ def test_pii_hint_re_drop_rate_floor_on_ja_v02() -> None:
         f"PII_HINT_RE drop rate regressed: {rate:.3f} "
         f"(zero={len(zero)}, drop={dropped}); expected >= 0.22"
     )
+


### PR DESCRIPTION
## Summary

- CI checkout does not use `lfs: true`, so `data/raw/ja-v02/generated.json` exists as an LFS pointer file
- The prior skip condition only checked `data_path.exists()` — the pointer file exists, so the skip was never triggered
- `json.load()` then failed with `JSONDecodeError` on the pointer content
- Fix: also skip when the file content starts with the LFS pointer header (`version https://git-lfs.github.com/spec/v1`)

## Root cause

Found via CI log analysis: `test_pii_hint_re_drop_rate_floor_on_ja_v02` was failing consistently on `main` since 2026-07-09.